### PR TITLE
Added interfaces for the full CEDDL spec

### DIFF
--- a/test/ceddl.spec.ts
+++ b/test/ceddl.spec.ts
@@ -2,14 +2,40 @@ import { expect } from 'chai';
 import 'mocha';
 
 import * as CEDDL from './data/CEDDL';
+import { PickOperator } from '../src/operators';
 
 describe('mock CEDDL unit tests', () => {
 
-  it('it should have JSO subobjects ', () => {
-    const { minimalDigitalData } = CEDDL;
-    const { pageInstanceID, page, product, cart, transaction, event, component, user, privacy, version } = minimalDigitalData;
+  it('empty digitalData should have JSO subobjects ', () => {
+    const { emptyDigitalData } = CEDDL;
+    const {
+        pageInstanceID, page, product, cart, transaction,
+        event, component, user, privacy, version
+    } = emptyDigitalData;
 
-    expect(minimalDigitalData).not.be.undefined;
+    expect(emptyDigitalData).not.be.undefined;
+    expect(pageInstanceID).not.be.undefined;
+    expect(pageInstanceID).be.empty;
+    expect(page).not.be.undefined;
+    expect(product).not.be.undefined;
+    expect(cart).not.be.undefined;
+    expect(transaction).not.be.undefined;
+    expect(event).not.be.undefined;
+    expect(component).not.be.undefined;
+    expect(user).not.be.undefined;
+    expect(privacy).not.be.undefined;
+    expect(version).not.be.undefined;
+    expect(version).not.be.empty;
+  });
+
+  it('basic digitalData should have JSO subobjects ', () => {
+    const { basicDigitalData } = CEDDL;
+    const {
+        pageInstanceID, page, product, cart, transaction,
+        event, component, user, privacy, version
+    } = basicDigitalData;
+
+    expect(basicDigitalData).not.be.undefined;
     expect(pageInstanceID).not.be.undefined;
     expect(pageInstanceID).not.be.empty;
     expect(page).not.be.undefined;
@@ -22,6 +48,23 @@ describe('mock CEDDL unit tests', () => {
     expect(privacy).not.be.undefined;
     expect(version).not.be.undefined;
     expect(version).not.be.empty;
+  });
+
+
+  it('it should pick data from CEDDL', () => {
+    const { basicDigitalData, ceddlVersion } = CEDDL;
+    expect(basicDigitalData.version).to.not.be.undefined;
+    expect(basicDigitalData.page.pageInfo.pageID).to.not.be.undefined;
+
+    const pick = new PickOperator({
+      name: 'pick',
+      properties: 'version,pageID'
+    })
+    const output = pick.handleData([basicDigitalData]);
+    console.log('output', output);
+    expect(output).to.not.be.null;
+    expect(output![0].version).to.eq(ceddlVersion);
+    expect(output![0].pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
   });
 
 });

--- a/test/ceddl.spec.ts
+++ b/test/ceddl.spec.ts
@@ -6,10 +6,10 @@ import * as CEDDL from './data/CEDDL';
 describe('mock CEDDL unit tests', () => {
 
   it('it should have JSO subobjects ', () => {
-    const { digitalData } = CEDDL;
-    const { pageInstanceID, page, product, cart, transaction, event, component, user, privacy, version } = digitalData;
+    const { minimalDigitalData } = CEDDL;
+    const { pageInstanceID, page, product, cart, transaction, event, component, user, privacy, version } = minimalDigitalData;
 
-    expect(digitalData).not.be.undefined;
+    expect(minimalDigitalData).not.be.undefined;
     expect(pageInstanceID).not.be.undefined;
     expect(pageInstanceID).not.be.empty;
     expect(page).not.be.undefined;

--- a/test/ceddl.spec.ts
+++ b/test/ceddl.spec.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import 'mocha';
 
 import * as CEDDL from './data/CEDDL';
-import { PickOperator } from '../src/operators';
 
 describe('mock CEDDL unit tests', () => {
 
@@ -49,22 +48,4 @@ describe('mock CEDDL unit tests', () => {
     expect(version).not.be.undefined;
     expect(version).not.be.empty;
   });
-
-
-  it('it should pick data from CEDDL', () => {
-    const { basicDigitalData, ceddlVersion } = CEDDL;
-    expect(basicDigitalData.version).to.not.be.undefined;
-    expect(basicDigitalData.page.pageInfo.pageID).to.not.be.undefined;
-
-    const pick = new PickOperator({
-      name: 'pick',
-      properties: 'version,pageID'
-    })
-    const output = pick.handleData([basicDigitalData]);
-    console.log('output', output);
-    expect(output).to.not.be.null;
-    expect(output![0].version).to.eq(ceddlVersion);
-    expect(output![0].pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
-  });
-
 });

--- a/test/data/CEDDL.ts
+++ b/test/data/CEDDL.ts
@@ -69,7 +69,7 @@ export interface Product {
   productInfo: ProductInfo;
   category: ProductCategory;
   linkedProduct: LinkedProduct[];
-  attributes: { [key: string]: any };
+  attributes?: { [key: string]: any };
 }
 
 export interface ProductInfo {
@@ -169,7 +169,7 @@ export interface EventInfo {
   eventAction: string;
   eventPoints: number;
   type: string;
-  timeStamp: Date;
+  timeStamp: string | Date;
   effect: string;
 }
 
@@ -254,9 +254,8 @@ export interface AccessCategory {
   domains: string[];
 }
 
-/*
 
-export const digitalData: CEDDL = {
+export const minimalDigitalData: CEDDL = {
   pageInstanceID: '755ebb86-60b5-451e-92d3-044157d29965',
   page: {
     pageInfo: {
@@ -280,18 +279,182 @@ export const digitalData: CEDDL = {
       primaryCategory: 'homepage'
     }
   },
-  product: [],
+  product: [{
+    productInfo: {
+      productID: '668ebb86-60b5-451e-92d3-044157d27823',
+      productName: 'Cosmic Crisp Apple',
+      description: 'A crisp and cosmic apple',
+      productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+      productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+      productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+      manufacturer: 'Washington State Apple Farm',
+      sku: 'cca-1234',
+      color: 'red and white',
+      size: 'medium'
+    },
+    category: {
+      primaryCategory: 'fruit'
+    },
+    linkedProduct: []
+  }],
   cart: {
     cartID: 'cart-1234',
-    price: 23.04,
-    attributes: {},
-    item: {}
+    price: {
+      basePrice: 15.55,
+      voucherCode: '',
+      voucherDiscount: 0,
+      currency: 'USD',
+      taxRate: 0.09,
+      shipping: 5.0,
+      shippingMethod: 'UPS-Ground',
+      priceWithTax: 16.95,
+      cartTotal: 21.95
+    },
+    item: [{
+      productInfo: {
+        productID: '668ebb86-60b5-451e-92d3-044157d27823',
+        productName: 'Cosmic Crisp Apple',
+        description: 'A crisp and cosmic apple',
+        productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+        productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+        productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+        manufacturer: 'Washington State Apple Farm',
+        sku: 'cca-1234',
+        color: 'red and white',
+        size: 'medium',
+      },
+      category: { primaryCategory: 'fruit' },
+      price: {
+        basePrice: 15.55,
+        voucherCode: '',
+        voucherDiscount: 0,
+        currency: 'USD',
+        taxRate: 0.09,
+        shipping: 5.0,
+        shippingMethod: 'UPS-Ground',
+        priceWithTax: 16.95
+      },
+      quantity: 1,
+      linkedProduct: [],
+      attributes: {}
+    }],
+    attributes: {}
   },
-  transaction: {},
-  event: [],
-  component: [],
-  user: {},
-  privacy: {},
+  transaction: {
+    transactionID: 'tr-235098236',
+    profile: {
+      profileInfo: {
+        profileID: 'pr-12333211',
+        userName: 'JohnyAppleseed'
+      },
+      address: {
+        line1: '123 Easy St.',
+        line2: '',
+        city: 'Athens',
+        stateProvince: 'GA',
+        postalCode: '30606',
+        country: 'USA'
+      },
+      shippingAddress: {
+        line1: '123 Easy St.',
+        line2: '',
+        city: 'Athens',
+        stateProvince: 'GA',
+        postalCode: '30606',
+        country: 'USA'
+      }
+    },
+    total: {
+      basePrice: 15.55,
+      voucherCode: '',
+      voucherDiscount: 0,
+      currency: 'USD',
+      taxRate: 0.09,
+      shipping: 5.0,
+      shippingMethod: 'UPS-Ground',
+      priceWithTax: 16.95,
+      transactionTotal: 16.95
+    },
+    attributes: {},
+    item: [{
+      productInfo: {
+        productID: '668ebb86-60b5-451e-92d3-044157d27823',
+        productName: 'Cosmic Crisp Apple',
+        description: 'A crisp and cosmic apple',
+        productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+        productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+        productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+        manufacturer: 'Washington State Apple Farm',
+        sku: 'cca-1234',
+        color: 'red and white',
+        size: 'medium',
+      },
+      category: { primaryCategory: 'fruit' },
+      price: {
+        basePrice: 15.55,
+        voucherCode: '',
+        voucherDiscount: 0,
+        currency: 'USD',
+        taxRate: 0.09,
+        shipping: 5.0,
+        shippingMethod: 'UPS-Ground',
+        priceWithTax: 16.95
+      },
+      quantity: 1,
+      linkedProduct: [],
+      attributes: {}
+    }]
+  },
+  event: [{
+    eventInfo: {
+      eventName: 'Cart Item Added',
+      eventAction: 'cart-item-added',
+      eventPoints: 11,
+      type: 'cart-modifier',
+      timeStamp: new Date(),
+      effect: 'cart has a new item'
+    },
+    category: {
+      primaryCategory: 'cart',
+      attributes: {}
+    }
+  }],
+  component: [{
+    componentInfo: {
+      componentID: 'c-54123',
+      componentName: 'Cosmic Crisp Promo Video',
+      description: 'A video showing you just how cosmic and just how crisp is this apple.'
+    },
+    category: {
+      primaryCategory: 'promo-video',
+      componentType: 'video',
+      attributes: {}
+    }
+  }],
+  user: {
+    segment: {},
+    profile: [{
+      profileInfo: {
+        profileID: 'pr-12333211',
+        userName: 'JohnyAppleseed'
+      },
+      address: {
+        line1: '123 Easy St.',
+        line2: '',
+        city: 'Athens',
+        stateProvince: 'GA',
+        postalCode: '30606',
+        country: 'USA'
+      },
+      social: {},
+      attributes: {}
+    }]
+  },
+  privacy: {
+    accessCategories: [{
+      categoryName: 'analytics',
+      domains: ['fruitshoppe.firebaseapp.com',]
+    }]
+  },
   version: '1.0.0'
 }
-*/

--- a/test/data/CEDDL.ts
+++ b/test/data/CEDDL.ts
@@ -3,6 +3,8 @@
  * See https://www.w3.org/2013/12/ceddl-201312.pdf
  */
 
+export const ceddlVersion = '1.0'
+
 /**
  * The root JavaScript Object (JSO) MUST be window.digitalData.
  * All data properties within this specification MUST fall within the hierarchy of the digitalData object.
@@ -254,8 +256,98 @@ export interface AccessCategory {
   domains: string[];
 }
 
+export const emptyDigitalData = {
+  pageInstanceID: '',
+  page: {
+    pageInfo: {
+      pageID: '',
+      pageName: '',
+      destinationURL: '',
+      referringURL: '',
+      sysEnv: '',
+      variant: '',
+      version: '',
+      breadcrumbs: [],
+      author: '',
+      issueDate: '',
+      effectiveDate: '',
+      expiryDate: '',
+      language: '',
+      industryCodes: '',
+      publisher: ''
+    },
+    category: {
+      primaryCategory: ''
+    }
+  },
+  product: [],
+  cart: {
+    cartID: '',
+    price: {
+      basePrice: 0,
+      voucherCode: '',
+      voucherDiscount: 0,
+      currency: '',
+      taxRate: 0.0,
+      shipping: 0,
+      shippingMethod: '',
+      priceWithTax: 0,
+      cartTotal: 0
+    },
+    item: [],
+    attributes: {}
+  },
+  transaction: {
+    transactionID: '',
+    profile: {
+      profileInfo: {
+        profileID: '',
+        userName: ''
+      },
+      address: {
+        line1: '',
+        line2: '',
+        city: '',
+        stateProvince: '',
+        postalCode: '',
+        country: ''
+      },
+      shippingAddress: {
+        line1: '',
+        line2: '',
+        city: '',
+        stateProvince: '',
+        postalCode: '',
+        country: ''
+      }
+    },
+    total: {
+      basePrice: 0,
+      voucherCode: '',
+      voucherDiscount: 0,
+      currency: '',
+      taxRate: 0,
+      shipping: 0,
+      shippingMethod: '',
+      priceWithTax: 0,
+      transactionTotal: 0
+    },
+    attributes: {},
+    item: []
+  },
+  event: [],
+  component: [],
+  user: {
+    segment: {},
+    profile: []
+  },
+  privacy: {
+    accessCategories: []
+  },
+  version: ceddlVersion
+}
 
-export const minimalDigitalData: CEDDL = {
+export const basicDigitalData: CEDDL = {
   pageInstanceID: '755ebb86-60b5-451e-92d3-044157d29965',
   page: {
     pageInfo: {
@@ -456,5 +548,5 @@ export const minimalDigitalData: CEDDL = {
       domains: ['fruitshoppe.firebaseapp.com',]
     }]
   },
-  version: '1.0.0'
+  version: ceddlVersion
 }

--- a/test/data/CEDDL.ts
+++ b/test/data/CEDDL.ts
@@ -4,8 +4,8 @@
  */
 
 /**
- * The root JavaScript Object (JSO) MUST be digitalData, and all data properties within this specification MUST fall
- * within the hierarchy of the digitalData object.
+ * The root JavaScript Object (JSO) MUST be window.digitalData.
+ * All data properties within this specification MUST fall within the hierarchy of the digitalData object.
  */
 export interface CEDDL {
   pageInstanceID: string;
@@ -23,8 +23,10 @@ export interface CEDDL {
 /**
  * Because of the wide range of methods for categorization, an object literal is provided for categories.
  */
-export interface Category {
+export interface PageCategory {
   primaryCategory: string;
+  subCategory1?: string;
+  pageType?: string;
 }
 
 /**
@@ -33,7 +35,7 @@ export interface Category {
  */
 export interface Page {
   pageInfo: PageInfo;
-  category: Category;
+  category: PageCategory;
   attributes?: { [key: string]: any };
 }
 
@@ -64,7 +66,33 @@ export interface PageInfo {
  * ordered in a transaction, see the Cart and Transaction objects below.
  */
 export interface Product {
+  productInfo: ProductInfo;
+  category: ProductCategory;
+  linkedProduct: LinkedProduct[];
+  attributes: { [key: string]: any };
+}
 
+export interface ProductInfo {
+  productID: string;
+  productName: string;
+  description: string;
+  productURL: string;
+  productImage: string;
+  productThumbnail: string;
+  manufacturer: string;
+  sku: string;
+  color: string;
+  size: string;
+}
+
+export interface ProductCategory {
+  primaryCategory: string;
+  subCategory1?: string;
+  productType?: string;
+}
+
+export interface LinkedProduct {
+  productInfo: ProductInfo
 }
 
 /**
@@ -73,7 +101,34 @@ export interface Product {
  * orders.
  */
 export interface Cart {
+  cartID: string;
+  price: TotalCartPrice;
+  attributes: { [key: string]: any };
+  item: ProductItem[];
+}
 
+export interface Price {
+  basePrice: number;
+  voucherCode: string;
+  voucherDiscount: number;
+  currency: string; // ISO 4217 is RECOMMENDED
+  taxRate: number;
+  shipping: number;
+  shippingMethod: string;
+  priceWithTax: number;
+}
+
+export interface TotalCartPrice extends Price {
+  cartTotal: number;
+}
+
+export interface ProductItem {
+  productInfo: ProductInfo;
+  category: ProductCategory;
+  quantity: number;
+  price: Price;
+  linkedProduct: LinkedProduct[];
+  attributes: { [key: string]: any };
 }
 
 /**
@@ -81,8 +136,23 @@ export interface Cart {
  * contains analogous sub-objects to the Cart object as well as additional subobjects specific to completed orders.
  */
 export interface Transaction {
-
+  transactionID: string;
+  profile: TransactionProfile;
+  total: TotalTransactionPrice;
+  attributes: { [key: string]: any };
+  item: ProductItem[];
 }
+
+export interface TransactionProfile {
+  profileInfo: ProfileInfo;
+  address: Address;
+  shippingAddress: Address;
+}
+
+export interface TotalTransactionPrice extends Price {
+  transactionTotal: number;
+}
+
 
 /**
  * The Event object collects information about an interaction event by the user. An event might be a button click,
@@ -90,7 +160,23 @@ export interface Transaction {
  * could be captured by an Event object.
  */
 export interface Event {
+  eventInfo: EventInfo;
+  category: EventCategory;
+}
 
+export interface EventInfo {
+  eventName: string;
+  eventAction: string;
+  eventPoints: number;
+  type: string;
+  timeStamp: Date;
+  effect: string;
+}
+
+export interface EventCategory {
+  primaryCategory: string;
+  subCategory1?: string;
+  attributes: { [key: string]: any };
 }
 
 /**
@@ -99,15 +185,59 @@ export interface Event {
  * object above.
  */
 export interface Component {
+  componentInfo: ComponentInfo;
+  category: ComponentCategory;
+}
 
+export interface ComponentInfo {
+  componentID: string;
+  componentName?: string;
+  description?: string;
+}
+
+export interface ComponentCategory {
+  primaryCategory: string;
+  subCategory1?: string;
+  componentType: string;
+  attributes: { [key: string]: any };
 }
 
 /**
  * The User object captures the profile of a user who is interacting with the website.
  */
 export interface User {
-
+  segment: UserSegment;
+  profile: UserProfile[];
 }
+
+export interface UserSegment {}
+
+export interface UserProfile {
+  profileInfo: ProfileInfo;
+  address: Address;
+  social: UserSocial;
+  attributes: { [key: string]: any };
+}
+
+export interface ProfileInfo {
+  profileID: string;
+  userName: string;
+  email?: string;
+  language?: string;
+  returningStatus?: string;
+  type?: string;
+}
+
+export interface Address {
+  line1: string;
+  line2: string;
+  city: string;
+  stateProvince: string;
+  postalCode: string;
+  country: string;
+}
+
+export interface UserSocial {}
 
 /**
  * The Privacy object holds the privacy policy settings that could be used to:
@@ -116,8 +246,15 @@ export interface User {
  * of tracking technologies.
  */
 export interface Privacy {
-
+  accessCategories: AccessCategory[];
 }
+
+export interface AccessCategory {
+  categoryName: string;
+  domains: string[];
+}
+
+/*
 
 export const digitalData: CEDDL = {
   pageInstanceID: '755ebb86-60b5-451e-92d3-044157d29965',
@@ -144,7 +281,12 @@ export const digitalData: CEDDL = {
     }
   },
   product: [],
-  cart: {},
+  cart: {
+    cartID: 'cart-1234',
+    price: 23.04,
+    attributes: {},
+    item: {}
+  },
   transaction: {},
   event: [],
   component: [],
@@ -152,3 +294,4 @@ export const digitalData: CEDDL = {
   privacy: {},
   version: '1.0.0'
 }
+*/

--- a/test/operator-pick.spec.ts
+++ b/test/operator-pick.spec.ts
@@ -87,6 +87,15 @@ describe('pick operator unit tests', () => {
     expect(output![0].contact.email).to.eq(data.contact.email);
   });
 
+  it('it should find properties at different depths', () => {
+    const pick = new PickOperator({ name: 'pick', properties: 'id,color' })
+    const output = pick.handleData([data]);
+
+    expect(output).to.not.be.null;
+    expect(output![0].id).to.eq(data.id);
+    expect(output![0].color).to.eq(data.favorites.color);
+  });
+
   it('it should not go below a certain depth', () => {
     const pick = new PickOperator({ name: 'pick', properties: 'id,contact,email', maxDepth: 0 })
     const output = pick.handleData([data]);

--- a/test/operator-pick.spec.ts
+++ b/test/operator-pick.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
+import * as CEDDL from './data/CEDDL';
 import { PickOperator } from '../src/operators';
 
 const data = {
@@ -122,6 +123,21 @@ describe('pick operator unit tests', () => {
 
     output![0].id = 'diff';
     expect(output![0].id).to.not.eq(data.id);
+  });
+
+  it('it should pick data from CEDDL', () => {
+    const { basicDigitalData, ceddlVersion } = CEDDL;
+    expect(basicDigitalData.version).to.not.be.undefined;
+    expect(basicDigitalData.page.pageInfo.pageID).to.not.be.undefined;
+
+    const pick = new PickOperator({
+      name: 'pick',
+      properties: 'version,pageID'
+    })
+    const output = pick.handleData([basicDigitalData]);
+    expect(output).to.not.be.null;
+    expect(output![0].version).to.eq(ceddlVersion);
+    expect(output![0].pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
   });
 
 });


### PR DESCRIPTION
This implements the various interfaces for CEDDL and creates a couple of instances of it for use during testing.

@van-fs One question: I wrote a test for CEDDL using the pick operator and it is failing. So, I've added a pick operator test that (I think) reproduces the failure in the context of the pick tests. Am I missing something about how the properties option is able to specify that a property at any depth can be picked?