### PR TITLE
Mock up a FullStory recording API for use in unit testing

### DIFF
--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,0 +1,25 @@
+
+export class MockClass {
+
+  public callQueues: { [methodName: string]: Call[] } = {}
+
+  constructor(){
+    for (const methodName of Object.getOwnPropertyNames(this.constructor.prototype)) {
+      if (methodName === 'constructor') continue;
+      this.callQueues[methodName] = [];
+      const originalMethod = this[methodName].bind(this);
+      this[methodName] = (...params) => {
+        const result = originalMethod(...params);
+        this.callQueues[methodName].push(new Call(
+          params,
+          result
+        ));
+        return result;
+      };
+    }
+  }
+}
+
+export class Call {
+  constructor(public parameters: object, public result: string | null | void){}
+}

--- a/test/vendor.spec.ts
+++ b/test/vendor.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { FullStory } from './vendor/fullstory-recording';
+
+describe('mock FullStory recording tests', () => {
+
+  it('it should add method calls into call queues ', () => {
+    const FS = new FullStory();
+
+    expect(FS.callQueues.consent.length).to.eq(0);
+    FS.consent(true);
+    expect(FS.callQueues.consent.length).to.eq(1);
+    expect(FS.callQueues.consent.pop().parameters[0]).to.be.true;
+
+    expect(FS.callQueues.log.length).to.eq(0);
+    FS.log(0, 'value')
+    expect(FS.callQueues.log.length).to.eq(1);
+    expect(FS.callQueues.log.pop().parameters[1]).to.eq('value');
+  });
+
+});

--- a/test/vendor/fullstory-recording.ts
+++ b/test/vendor/fullstory-recording.ts
@@ -1,0 +1,33 @@
+import { MockClass } from '../mock';
+
+export class FullStory extends MockClass {
+  consent(userConsents?: boolean): void {}
+
+  disableConsole(): void {}
+  
+  enableConsole(): void {}
+  
+  event(eventName: string, eventProperties: object): string | null {
+    return null
+  }
+  
+  identify(uid: string, customVars?: object): void {}
+  
+  anonymize(): void {}
+  
+  log(...msg: any[]): void {}
+  
+  restart(): void {}
+  
+  shutdown(): void {}
+  
+  setUserVars(customVars: object): void {}
+
+  getCurrentSession(): string | null {
+    return null
+  }
+
+  getCurrentSessionURL(now?: boolean): string | null {
+    return null
+  }
+}


### PR DESCRIPTION
Putting this up for comment by @van-fs before going much farther with it. Specifically, it needs a review of the mocking method.

After looking at current mock libs like Sinon (complex) and our needs for mocking FS's recording APIs (simple) I whipped up a basic `MockClass` that (when extended) records calls to any methods on a class for checking during a test.

Take a look at `test/vendor/fullstory-recording.ts` and `test/vendor.spec.ts` to see how we could test that the FS recording API is called (eventually) by the DLO.