### PR TITLE
Path selection utility methods.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
           name: Audit
-          command: npm audit --audit-level=low
+          command: npm audit --audit-level=low --production
       - run:
           name: Test
           command: npm test

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -60,7 +60,7 @@ For example: `!(foo=bar, blatz)` where `!` is the kind and `foo=bar` and `blatz`
 */
 class Op {
   kind: OpKind;
-  index?: Number;
+  index: number = 0;
   props: OpProp[] = [];
 
   constructor(public raw: string) {
@@ -191,7 +191,25 @@ class PathElement {
   }
 
   selectIndex(target: any): any | undefined {
-    throw new Error('TBD');
+    if (!this.brackets) throw Error('Invalid brackets state!' + this);
+
+    let prop = target[this.brackets.prop];
+    if (typeof prop === 'undefined') return undefined;
+    if (typeof prop.length === 'undefined') return undefined;
+
+    let index = this.brackets.op.index;
+    if (index >= prop.length) return undefined;
+    if (index < 0) {
+      index = prop.length + index
+    }
+    if (index < 0) return undefined;
+
+    try {
+      return prop[index];
+    } catch (e) {
+      console.log('Index fail', this.brackets, e);
+      return undefined;
+    }
   }
 
   selectPick(target: any): any | undefined {

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -13,13 +13,127 @@ enum ElementKind {
 }
 
 const kindSniffers: { [key: string]: any } = {
-  Pluck: (raw: string): boolean => { return raw.includes('[') === false && raw.includes('(') === false },
-  Index: (raw: string): boolean => { return /.+\[-?\d+\]$/.test(raw) }
+  pluck: (raw: string): boolean =>  { return raw.includes('[') === false && raw.includes('(') === false },
+  index: (raw: string): boolean =>  { return /.+\[-?\d+\]$/.test(raw) },
+  pick: (raw: string): boolean =>   { return /.+\[\(.*\)\]$/.test(raw) },
+  omit: (raw: string): boolean =>   { return /.+\[\!\(.*\)\]$/.test(raw) },
+  prefix: (raw: string): boolean => { return /.+\[\^\(.*\)\]$/.test(raw) },
+  suffix: (raw: string): boolean => { return /.+\[\$\(.*\)\]$/.test(raw) },
+  filter: (raw: string): boolean => { return /.+\[\?\(.*\)\]$/.test(raw) },
+}
+
+enum OpKind {
+  Pick = "",
+  Omit = "!",
+  Prefix = "^",
+  Suffix = "$",
+  Filter = "?",
+  Index = "index"
+}
+
+/**
+OpProp is a property name and optional value like `foo=bar` or 'blatz'
+For now we assume equality ('=') but in the future we could add prop ops types like `<=`
+*/
+class OpProp {
+  name: string;
+  value?: string;
+
+  constructor(public raw: string) {
+    raw = raw.trim();
+    const tokens = raw.split('=');
+    if (tokens.length > 2) throw new Error('Invalid OpProp: ' + raw);
+    if (raw.includes('=')) {
+      let keyValTokens = raw.split('=');
+      if (keyValTokens.length != 2) throw new Error('Invalid OpProp: ' + raw);
+      this.name = keyValTokens[0];
+      this.value = keyValTokens[1];
+    } else {
+      this.name = raw;
+    }
+  }
+}
+
+/**
+Op is an operator inside brackets with a list of properies
+For example: `!(foo=bar, blatz)` where `!` is the kind and `foo=bar` and `blatz` are parsed into OpProps
+*/
+class Op {
+  kind: OpKind;
+  index?: Number;
+  props: OpProp[] = [];
+
+  constructor(public raw: string) {
+    raw = raw.trim();
+    switch(raw[0]) {
+      case '(':
+        if (raw[raw.length - 1] !== ')') throw new Error('Could not parse Op: ' + raw);
+        this.kind = OpKind.Pick;
+        this.parseProps(raw.substring(1, raw.length - 1));
+        break;
+      case '!':
+        if (raw[1] !== '(') throw new Error('Could not parse Op: ' + raw);
+        if (raw[raw.length - 1] !== ')') throw new Error('Could not parse Op: ' + raw);
+        this.kind = OpKind.Omit;
+        this.parseProps(raw.substring(2, raw.length - 1));
+        break;
+      case '^':
+        if (raw[1] !== '(') throw new Error('Could not parse Op: ' + raw);
+        if (raw[raw.length - 1] !== ')') throw new Error('Could not parse Op: ' + raw);
+        this.kind = OpKind.Prefix;
+        this.parseProps(raw.substring(2, raw.length - 1));
+        break;
+      case '$':
+        if (raw[1] !== '(') throw new Error('Could not parse Op: ' + raw);
+        if (raw[raw.length - 1] !== ')') throw new Error('Could not parse Op: ' + raw);
+        this.kind = OpKind.Suffix;
+        this.parseProps(raw.substring(2, raw.length - 1));
+        break;
+      case '?':
+        if (raw[1] !== '(') throw new Error('Could not parse Op: ' + raw);
+        if (raw[raw.length - 1] !== ')') throw new Error('Could not parse Op: ' + raw);
+        this.kind = OpKind.Filter;
+        this.parseProps(raw.substring(2, raw.length - 1));
+        break;
+      default:
+        const index = Number.parseInt(raw);
+        if (Number.isNaN(index)) throw new Error('Could not parse the Op: ' + raw);
+        this.kind = OpKind.Index;
+        this.index = index;
+    }
+  }
+
+  parseProps(rawProps: string) {
+    rawProps = rawProps.trim();
+    if (rawProps.length === 0) throw new Error('Could not parse operation properties: ' + rawProps);
+    const tokens = rawProps.split(',');
+    for (let token of tokens) {
+      this.props.push(new OpProp(token));
+    }
+  }
+}
+
+/**
+Brackets holds parsed info for selections like `foo[(prop1=23, prop2)]`
+*/
+class Brackets {
+  op: Op; // the operation from `foo[!(operation)]`
+  prop: string; // `foo` from `foo[...]`
+  constructor(public raw: string) {
+    raw = raw.trim();
+    if (raw.includes('[') === false) throw new Error('Could not parse brackets: ' + raw);
+    if (raw.endsWith(']') === false) throw new Error('Could not parse brackets: ' + raw);
+    let tokens = raw.split('[');
+    if (tokens.length != 2) throw new Error('Could not parse brackets: ' + raw);
+    this.prop = tokens[0];
+    this.op = new Op(tokens[1].substring(0, tokens[1].length - 1));
+  }
 }
 
 class PathElement {
   kind: ElementKind;
-  parsedInfo: { [key: string]: any }; // per-kind info populated in `parse` call
+  brackets?: Brackets;
+  parsedInfo: { [key: string]: any }; // per-kind info populated in `parse` calls
 
   // This throws an exception if `raw` can not be parsed
   constructor(public raw: string) {
@@ -35,7 +149,7 @@ class PathElement {
       case ElementKind.Index:
         return this.selectIndex(target);
       case ElementKind.Pick:
-        throw new Error('TBD');
+        return this.selectPick(target);
         break;
       case ElementKind.Omit:
         throw new Error('TBD');
@@ -49,6 +163,8 @@ class PathElement {
       case ElementKind.Filter:
         throw new Error('TBD');
         break;
+       default:
+         throw new Error('Unknown PathElement.kind: ' + this.kind);
     }
   }
 
@@ -58,35 +174,27 @@ class PathElement {
       /* No-op, we just use `raw` */
         break;
       case ElementKind.Index:
-        this.parseIndex();
-        break;
       case ElementKind.Pick:
-        throw new Error('TBD');
-        break;
       case ElementKind.Omit:
-        throw new Error('TBD');
-        break;
       case ElementKind.Prefix:
-        throw new Error('TBD');
-        break;
       case ElementKind.Suffix:
-        throw new Error('TBD');
-        break;
       case ElementKind.Filter:
-        throw new Error('TBD');
+        this.brackets = new Brackets(this.raw);
         break;
+       default:
+         throw new Error('Invalid PathElement kind: ' + this.kind);
     }
   }
 
-  parseIndex(){
-    throw new Error('TBD');
-  }
-
   selectPluck(target: any): any | undefined {
-
+    return target[this.raw]
   }
 
   selectIndex(target: any): any | undefined {
+    throw new Error('TBD');
+  }
+
+  selectPick(target: any): any | undefined {
     throw new Error('TBD');
   }
 
@@ -99,11 +207,12 @@ class PathElement {
   }
 }
 
-class Path {
+export class Path {
   tokens: string[];
   elements: PathElement[] = [];
 
   constructor(public path: string) {
+    path = path.trim();
     this.tokens = path.split('.');
     for (let token of this.tokens) {
       this.elements.push(new PathElement(token)) // Will throw an exception if it can't parse
@@ -111,10 +220,12 @@ class Path {
   }
 
   select(target: object): any | undefined {
-
-    // THIS IS WHERE I STOPPED. Walk the elements and select if possible
-
-    throw new Error('TBD');
+    let selection = target;
+    for (let element of this.elements) {
+      selection = element.select(selection);
+      if (typeof selection === 'undefined') return undefined
+    }
+    return selection
   }
 }
 

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,0 +1,68 @@
+
+// Memoized Paths or false if the path cannot be parsed
+let parsedPaths: { [path: string]: Path | false } = {};
+
+class PathElement {}
+
+class Path {
+  tokens: string[];
+  elements: PathElement[];
+
+  constructor(public path: string) {
+    throw new Error('TBD');
+  }
+
+  select(target: object): any {
+    throw new Error('TBD');
+  }
+}
+
+// Parses and then memoizes a path for future calls
+function parsePath(path: string): Path | false {
+  if (typeof parsedPaths[path] === 'undefined') {
+    try {
+      parsedPaths[path] = new Path(path);
+    } catch {
+      parsedPaths[path] = false;
+    }
+  }
+  return parsedPaths[path];
+}
+
+/**
+
+Selection path notations:
+
+- Pluck:  parent.child.grandchild        -> grandchild
+- Index:  object[index]                  -> object[index] (a negative index steps back from the end, so -1 is the last item in the array)
+- Pick:   object[(property, ...)]        -> object with properties
+- Omit:   object[!(property, ...)]       -> [object] with properties removed
+- Prefix: object[^(property, ...)]       -> [object] with only properties whose names begin with `property`
+- Suffix: object[$(property, ...)]       -> [object] with only properties whose names end with `property`
+- Exists: object[?(property, ...)]       -> object or null if object does not have property
+- Filter: object[=(property=value, ...)] -> object or null if the object's `property` does not equal `value` 
+
+Notations can be chained:
+
+- parent.child.grandchild[3] -> fourth item in the grandchild array
+- parent.child[-1].grandchild[(property)] -> last child's grandchild with only `property` set
+
+@param path - a selection path
+@param target - the object from which to select
+@return an array of selected
+*/
+export function select(path: string, target: object): any | undefined {
+  const parsedPath: Path | false = parsePath(path);
+  if (parsedPath === false) {
+    return undefined;
+  }
+  return parsedPath.select(target);
+}
+
+/**
+@param path - a selection path
+@return true if the `path` can be used as a `path` parameter to `select`
+*/
+export function validate(path: string): boolean {
+  return parsePath(path) !== false;
+}

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -2,17 +2,118 @@
 // Memoized Paths or false if the path cannot be parsed
 let parsedPaths: { [path: string]: Path | false } = {};
 
-class PathElement {}
+enum ElementKind {
+  Pluck = "pluck",    // color
+  Index = "index",    // colors[-2]
+  Pick = "pick",      // colors[(favorite, hated)]
+  Omit = "omit",      // colors[!(hated)]
+  Prefix = "prefix",  // colors[^(fav)]
+  Suffix = "suffix",  // colors[$(orite)]
+  Filter = "filter"   // colors[?(favorite=red, hated)]
+}
 
-class Path {
-  tokens: string[];
-  elements: PathElement[];
+const kindSniffers: { [key: string]: any } = {
+  Pluck: (raw: string): boolean => { return raw.includes('[') === false && raw.includes('(') === false },
+  Index: (raw: string): boolean => { return /.+\[-?\d+\]$/.test(raw) }
+}
 
-  constructor(public path: string) {
+class PathElement {
+  kind: ElementKind;
+  parsedInfo: { [key: string]: any }; // per-kind info populated in `parse` call
+
+  // This throws an exception if `raw` can not be parsed
+  constructor(public raw: string) {
+    this.kind = PathElement.sniffKind(raw);
+    this.parsedInfo = {};
+    this.parse();
+  }
+
+  select(target: any): any | undefined {
+    switch (this.kind) {
+      case ElementKind.Pluck:
+        return this.selectPluck(target);
+      case ElementKind.Index:
+        return this.selectIndex(target);
+      case ElementKind.Pick:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Omit:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Prefix:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Suffix:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Filter:
+        throw new Error('TBD');
+        break;
+    }
+  }
+
+  parse() {
+    switch (this.kind) {
+      case ElementKind.Pluck:
+      /* No-op, we just use `raw` */
+        break;
+      case ElementKind.Index:
+        this.parseIndex();
+        break;
+      case ElementKind.Pick:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Omit:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Prefix:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Suffix:
+        throw new Error('TBD');
+        break;
+      case ElementKind.Filter:
+        throw new Error('TBD');
+        break;
+    }
+  }
+
+  parseIndex(){
     throw new Error('TBD');
   }
 
-  select(target: object): any {
+  selectPluck(target: any): any | undefined {
+
+  }
+
+  selectIndex(target: any): any | undefined {
+    throw new Error('TBD');
+  }
+
+  static sniffKind(raw: string): ElementKind {
+    if (raw.length == 0) throw new Error(`Invalid path element: ${ raw }`);
+    for (let kind of Object.keys(kindSniffers)) {
+      if (kindSniffers[kind](raw)) return kind as ElementKind;
+    }
+    throw new Error(`Could not sniff kind of ${ raw }`);
+  }
+}
+
+class Path {
+  tokens: string[];
+  elements: PathElement[] = [];
+
+  constructor(public path: string) {
+    this.tokens = path.split('.');
+    for (let token of this.tokens) {
+      this.elements.push(new PathElement(token)) // Will throw an exception if it can't parse
+    }
+  }
+
+  select(target: object): any | undefined {
+
+    // THIS IS WHERE I STOPPED. Walk the elements and select if possible
+
     throw new Error('TBD');
   }
 }
@@ -39,8 +140,8 @@ Selection path notations:
 - Omit:   object[!(property, ...)]       -> [object] with properties removed
 - Prefix: object[^(property, ...)]       -> [object] with only properties whose names begin with `property`
 - Suffix: object[$(property, ...)]       -> [object] with only properties whose names end with `property`
-- Exists: object[?(property, ...)]       -> object or null if object does not have property
-- Filter: object[=(property=value, ...)] -> object or null if the object's `property` does not equal `value` 
+- Filter: object[?(property, ...)]       -> object or null if object does not have property
+- Filter: object[?(property=value, ...)] -> object or null if the object's `property` does not equal `value` 
 
 Notations can be chained:
 
@@ -51,12 +152,12 @@ Notations can be chained:
 @param target - the object from which to select
 @return an array of selected
 */
-export function select(path: string, target: object): any | undefined {
+export function select(path: string, target?: object): any | undefined {
   const parsedPath: Path | false = parsePath(path);
   if (parsedPath === false) {
     return undefined;
   }
-  return parsedPath.select(target);
+  return parsedPath.select(target ? target : globalThis);
 }
 
 /**

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -15,6 +15,8 @@ class MockConsole extends MockClass {
   debug(message: string): void { }
 }
 
+const originalConsole = console;
+
 describe('logger unit tests', () => {
 
   it('it should create a console logger with warn and error levels by default', () => {
@@ -40,6 +42,7 @@ describe('logger unit tests', () => {
     logger.debug('Operator output', mockDatalayer);
     expectNoCalls(console, 'debug');
 
+    globalThis.console = originalConsole;
   });
 
   it('it should allow setting higher log levels', () => {
@@ -57,6 +60,8 @@ describe('logger unit tests', () => {
     logger.debug('Operator output');
     const [ debug ] = expectParams(console, 'debug');
     expect(debug).to.eq(`Operator output`);
+
+    globalThis.console = originalConsole;
   });
 
   it('it should allow setting a custom appender', () => {

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { select, validate } from '../src/selector';
+import { select, validate, Path } from '../src/selector';
 
 const testData = {
   favorites: {
@@ -17,8 +17,41 @@ const testData = {
 
 describe('test selection paths', () => {
 
-  it('it should respect dot notation', () => {
+  it('should parse valid paths and throw exceptions for invalid paths', () => {
+    // Empty
+    expect(() => { new Path('') }).to.throw(Error);
+    expect(() => { new Path('   ') }).to.throw(Error);
+
+    // Pluck
+    expect(() => { new Path('favorites') }).to.not.throw();
+    expect(() => { new Path('favorites.color') }).to.not.throw();
+    expect(() => { new Path('favorites.color.films') }).to.not.throw();
+    expect(() => { new Path('.') }).to.throw(Error);
+    expect(() => { new Path('..') }).to.throw(Error);
+    expect(() => { new Path('favorites..films') }).to.throw(Error);
+    expect(() => { new Path('favorites.') }).to.throw(Error);
+    expect(() => { new Path('.favorites.films') }).to.throw(Error);
+
+    // Index
+    expect(() => { new Path('cities[0]') }).to.not.throw();
+    expect(() => { new Path('cities[1]') }).to.not.throw();
+    expect(() => { new Path('cities[-2]') }).to.not.throw();
+    expect(() => { new Path('favorites.cities[-2]') }).to.not.throw();
+    expect(() => { new Path('favorites.cities[-2].neighborhoods') }).to.not.throw();
+    expect(() => { new Path('[0]') }).to.throw(Error);
+    expect(() => { new Path('[]') }).to.throw(Error);
+    expect(() => { new Path('cities[]') }).to.throw(Error);
+    expect(() => { new Path('favorites.cities[].neighborhoods') }).to.throw(Error);
+
+    // Pick
+    expect(() => { new Path('films[(action)]') }).to.not.throw();
+    expect(() => { new Path('films[()]') }).to.throw(Error);
+
     expect(validate('favorites.films.action')).to.be.true;
+    expect(validate('.')).to.be.false;
+  });
+
+  it('should respect dot notation', () => {
     expect(select('favorites.films.action', testData)).to.eq('Armageddon');
   });
 

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -52,7 +52,18 @@ describe('test selection paths', () => {
   });
 
   it('should respect dot notation', () => {
+    expect(select('favorites', testData)).to.eq(testData.favorites);
+    expect(select('favorites.color', testData)).to.eq('red');
     expect(select('favorites.films.action', testData)).to.eq('Armageddon');
+  });
+
+  it('should respect index notation', () => {
+    expect(select('cities[0]', testData)).to.eq('Seattle');
+    expect(select('cities[1]', testData)).to.eq('Atlanta');
+    expect(select('cities[-1]', testData)).to.eq('New York City');
+    expect(select('cities[-2]', testData)).to.eq('San Francisco');
+    expect(select('cities[20]', testData)).to.eq(undefined);
+    expect(select('cities[-20]', testData)).to.eq(undefined);
   });
 
 });

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { select, validate } from '../src/selector';
+
+const testData = {
+  favorites: {
+    color: 'red',
+    number: 25,
+    films: {
+      action: 'Armageddon',
+      'rom com': "Isn't it romantic"
+    }
+  },
+  cities: ['Seattle', 'Atlanta', 'San Francisco', 'New York City']
+}
+
+describe('test selection paths', () => {
+
+  it('it should respect dot notation', () => {
+    expect(validate('favorites.films.action')).to.be.true;
+    expect(select('favorites.films.action', testData)).to.eq('Armageddon');
+  });
+
+});


### PR DESCRIPTION
This will eventually provide the path selection utility methods used to find rule sources and within operators. The goal is to use path selection strings like `digitalData.page.pageInfo.author` or `digitalData.cart.item[-1].quantity` to traverse the Javascript namespace and find specific information.