### PR TITLE
refactor to support select

### DIFF
--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -7,9 +7,6 @@ import { basicDigitalData, PageInfo, Page } from './data/CEDDL';
 import { Operator, OperatorOptions } from '../src/operator';
 import { DataLayerDetail, PropertyDetail } from '../src/event';
 
-// inject the data layer into global scope
-(globalThis as any).digitalData = basicDigitalData;
-
 // create a mock operators that store something we can check
 class EchoOperatorOptions implements OperatorOptions {
   name = 'echo';
@@ -81,8 +78,16 @@ class ThrowOperator extends Operator<ThrowOperatorOptions> {
 
 describe('DataHandler unit tests', () => {
 
+  before(() => {
+    (globalThis as any).digitalData = basicDigitalData;
+  });
+
+  after(() => {
+    delete (globalThis as any).digitalData;
+  });
+
   it('data handlers should find a data layer for a given target and property', () => {
-    const handler = new DataHandler('digitalData', globalThis, 'digitalData');
+    const handler = new DataHandler('digitalData');
     expect(handler).to.not.be.undefined;
   });
 
@@ -92,7 +97,7 @@ describe('DataHandler unit tests', () => {
   });
 
   it('non-existent data layers should throw an Error', () => {
-    expect(() => new DataHandler('notFound', undefined)).to.throw();
+    expect(() => new DataHandler('notFound')).to.throw();
     expect(() => new DataHandler('notFound')).to.throw();
   });
 


### PR DESCRIPTION
This PR refactors `DataHandler` to use the new selection syntax.  The test was also updated to have a `before` and `after` to add and remove mock data from global scope.

One point on looking ahead.  The `DataHandler` class currently has to find `target` to support `fireEvent`.  When we add `PropertyListener`s that need should go away.  The handler then only needs to know the `path` and decide if it should kick off handling the data via operators.  It shouldn't need the target object itself.  Firing an event makes more sense in the listener as well.