### PR TITLE
Remaining selection syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "scripts": {
-    "test": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/**/*.spec.ts"
+    "test": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/*.spec.ts test/**/*.spec.ts"
   },
   "repository": {
     "type": "git",

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -5,11 +5,11 @@ let parsedPaths: { [path: string]: Path | false } = {};
 enum ElementKind {
   Pluck = "pluck",    // color
   Index = "index",    // colors[-2]
-  Pick = "pick",      // colors[(favorite, hated)]
-  Omit = "omit",      // colors[!(hated)]
-  Prefix = "prefix",  // colors[^(fav)]
-  Suffix = "suffix",  // colors[$(orite)]
-  Filter = "filter"   // colors[?(favorite=red, hated)]
+  Pick = "pick",      // colors[(favorite, hated, ...)]
+  Omit = "omit",      // colors[!(hated, loved, ...)]
+  Prefix = "prefix",  // colors[^(fav, lov, ...)]
+  Suffix = "suffix",  // colors[$(orite, ove, ...)]
+  Filter = "filter"   // colors[?(favorite=red, hated, ...)]
 }
 
 const kindSniffers: { [key: string]: any } = {
@@ -44,7 +44,7 @@ class OpProp {
     const tokens = raw.split('=');
     if (tokens.length > 2) throw new Error('Invalid OpProp: ' + raw);
     if (raw.includes('=')) {
-      let keyValTokens = raw.split('=');
+      const keyValTokens = raw.split('=');
       if (keyValTokens.length != 2) throw new Error('Invalid OpProp: ' + raw);
       this.name = keyValTokens[0];
       this.value = keyValTokens[1];
@@ -62,6 +62,7 @@ class Op {
   kind: OpKind;
   index: number = 0;
   props: OpProp[] = [];
+  propNames: string[]; // Used often when iterating during selection
 
   constructor(public raw: string) {
     raw = raw.trim();
@@ -101,13 +102,14 @@ class Op {
         this.kind = OpKind.Index;
         this.index = index;
     }
+    this.propNames = this.props.map(op => { return op.name; });
   }
 
   parseProps(rawProps: string) {
     rawProps = rawProps.trim();
     if (rawProps.length === 0) throw new Error('Could not parse operation properties: ' + rawProps);
     const tokens = rawProps.split(',');
-    for (let token of tokens) {
+    for (const token of tokens) {
       this.props.push(new OpProp(token));
     }
   }
@@ -123,7 +125,7 @@ class Brackets {
     raw = raw.trim();
     if (raw.includes('[') === false) throw new Error('Could not parse brackets: ' + raw);
     if (raw.endsWith(']') === false) throw new Error('Could not parse brackets: ' + raw);
-    let tokens = raw.split('[');
+    const tokens = raw.split('[');
     if (tokens.length != 2) throw new Error('Could not parse brackets: ' + raw);
     this.prop = tokens[0];
     this.op = new Op(tokens[1].substring(0, tokens[1].length - 1));
@@ -133,12 +135,11 @@ class Brackets {
 class PathElement {
   kind: ElementKind;
   brackets?: Brackets;
-  parsedInfo: { [key: string]: any }; // per-kind info populated in `parse` calls
+  parsedInfo: { [key: string]: any } = {}; // per-kind info populated in `parse` calls
 
   // This throws an exception if `raw` can not be parsed
   constructor(public raw: string) {
     this.kind = PathElement.sniffKind(raw);
-    this.parsedInfo = {};
     this.parse();
   }
 
@@ -152,16 +153,16 @@ class PathElement {
         return this.selectPick(target);
         break;
       case ElementKind.Omit:
-        throw new Error('TBD');
+        return this.selectOmit(target);
         break;
       case ElementKind.Prefix:
-        throw new Error('TBD');
+        return this.selectPrefix(target);
         break;
       case ElementKind.Suffix:
-        throw new Error('TBD');
+        return this.selectSuffix(target);
         break;
       case ElementKind.Filter:
-        throw new Error('TBD');
+        return this.selectFilter(target);
         break;
        default:
          throw new Error('Unknown PathElement.kind: ' + this.kind);
@@ -191,11 +192,10 @@ class PathElement {
   }
 
   selectIndex(target: any): any | undefined {
-    if (!this.brackets) throw Error('Invalid brackets state!' + this);
+    if (!this.brackets || this.brackets.op.kind != OpKind.Index) throw new Error('Invalid brackets state!' + this);
 
-    let prop = target[this.brackets.prop];
+    const prop = target[this.brackets.prop];
     if (typeof prop === 'undefined') return undefined;
-    if (typeof prop.length === 'undefined') return undefined;
 
     let index = this.brackets.op.index;
     if (index >= prop.length) return undefined;
@@ -213,12 +213,72 @@ class PathElement {
   }
 
   selectPick(target: any): any | undefined {
+    if (!this.brackets || this.brackets.op.kind != OpKind.Pick) throw new Error('Invalid brackets state!' + this);
+
+    const prop: any = target[this.brackets.prop];
+    if (typeof prop === 'undefined') return undefined;
+
+    let results: { [key: string]: any } = {};
+    let atLeastOne = false;
+    for (const opProp of this.brackets.op.props) {
+      if (typeof prop[opProp.name] !== 'undefined') {
+        results[opProp.name] = prop[opProp.name];
+        atLeastOne = true;
+      }
+    }
+    if (atLeastOne === false) return undefined;
+    return results;
+  }
+
+  selectOmit(target: any): any | undefined {
+    if (!this.brackets || this.brackets.op.kind != OpKind.Omit) throw new Error('Invalid brackets state!' + this);
+
+    const prop: any = target[this.brackets.prop];
+    if (typeof prop === 'undefined') return undefined;
+
+    let results: { [key: string]: any } = {};
+    let atLeastOne = false;
+    for (const key of Object.getOwnPropertyNames(prop)) {
+      if (this.brackets.op.propNames.includes(key)) continue;
+      results[key] = prop[key];
+      atLeastOne = true;
+    }
+    if (atLeastOne === false) return undefined;
+    return results;
+  }
+
+  selectPrefix(target: any): any | undefined {
+    if (!this.brackets || this.brackets.op.kind != OpKind.Prefix) throw new Error('Invalid brackets state!' + this);
+
+    const prop: any = target[this.brackets.prop];
+    if (typeof prop === 'undefined') return undefined;
+
+    let results: { [key: string]: any } = {};
+    let atLeastOne = false;
+    for (const key of Object.getOwnPropertyNames(prop)) {
+      for (const propPrefix of this.brackets.op.propNames) {
+        if (key.startsWith(propPrefix)) {
+          results[key] = prop[key];
+          atLeastOne = true;
+          break;
+        }
+      }
+    }
+    if (atLeastOne === false) return undefined;
+    return results;
+  }
+
+  selectSuffix(target: any): any | undefined {
+    throw new Error('TBD');
+  }
+
+  selectFilter(target: any): any | undefined {
     throw new Error('TBD');
   }
 
   static sniffKind(raw: string): ElementKind {
     if (raw.length == 0) throw new Error(`Invalid path element: ${ raw }`);
-    for (let kind of Object.keys(kindSniffers)) {
+    for (const kind of Object.keys(kindSniffers)) {
       if (kindSniffers[kind](raw)) return kind as ElementKind;
     }
     throw new Error(`Could not sniff kind of ${ raw }`);
@@ -232,14 +292,14 @@ export class Path {
   constructor(public path: string) {
     path = path.trim();
     this.tokens = path.split('.');
-    for (let token of this.tokens) {
+    for (const token of this.tokens) {
       this.elements.push(new PathElement(token)) // Will throw an exception if it can't parse
     }
   }
 
   select(target: object): any | undefined {
     let selection = target;
-    for (let element of this.elements) {
+    for (const element of this.elements) {
       selection = element.select(selection);
       if (typeof selection === 'undefined') return undefined
     }

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -5,8 +5,8 @@ import { Logger, LogLevel, LogEvent } from '../src/utils/logger';
 import { Console, FullStory } from './mocks';
 import { expectParams, expectNoCalls } from './utils/mocha';
 
+const originalConsole = globalThis.console;
 const console = new Console();
-const originalConsole = console;
 
 describe('logger unit tests', () => {
 

--- a/test/operator-pick.spec.ts
+++ b/test/operator-pick.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import * as CEDDL from './data/CEDDL';
+import * as CEDDL from './mocks/CEDDL';
 import { PickOperator } from '../src/operators';
 
 const data = {

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -91,7 +91,7 @@ describe('test selection paths', () => {
   it('should respect dot notation', () => {
     expect(select('favorites', testData)).to.eq(testData.favorites);
     expect(select('favorites.color', testData)).to.eq('red');
-    expect(select('favorites.films.action', testData)).to.eq('Armageddon');
+    expect(select('favorites.films.action', testData)).to.eq('Rogue One');
   });
 
   it('should respect index notation', () => {
@@ -126,12 +126,40 @@ describe('test selection paths', () => {
   });
 
   it('should respect prefix notation', () => {
-    expect(select('favorites[!(color)]', testData).color).to.be.undefined;
-    expect(select('favorites[!(color)]', testData).number).to.eq(25);
-    expect(select('favorites[!(color)]', testData).pickle).to.eq('dill');
-    expect(select('favorites[!(color, number)]', testData).color).to.be.undefined;
-    expect(select('favorites[!(color, number)]', testData).number).to.be.undefined;
-    expect(select('favorites[!(color, number)]', testData).pickle).to.eq('dill');
+    expect(select('favorites[^(color)]', testData).color).to.eq('red');
+    expect(select('favorites[^(co)]', testData).color).to.eq('red');
+    expect(select('favorites[^(colr)]', testData)).to.be.undefined;
+    expect(select('favorites[^(bogus)]', testData)).to.be.undefined;
+    expect(select('favorites[^(bogus, col)]', testData).color).to.eq('red');
+    expect(select('favorites[^(bogus, col)]', testData).bogus).to.be.undefined;
+    expect(select('favorites[^(col, bogus)]', testData).color).to.eq('red');
+    expect(select('favorites[^(col, bogus)]', testData).bogus).to.be.undefined;
   });
 
+  it('should respect suffix notation', () => {
+    expect(select('favorites[$(color)]', testData).color).to.eq('red');
+    expect(select('favorites[$(olor)]', testData).color).to.eq('red');
+    expect(select('favorites[$(clor)]', testData)).to.be.undefined;
+    expect(select('favorites[$(bogus)]', testData)).to.be.undefined;
+    expect(select('favorites[$(bogus, olor)]', testData).color).to.eq('red');
+    expect(select('favorites[$(bogus, olor)]', testData).bogus).to.be.undefined;
+    expect(select('favorites[$(olor, bogus)]', testData).color).to.eq('red');
+    expect(select('favorites[$(olor, bogus)]', testData).bogus).to.be.undefined;
+  });
+
+  it('should respect filter notation', () => {
+    expect(select('favorites[?(color)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color=red)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus=totally)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color, number)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus, number)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color=red, number)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus=totally, number)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color, number=25)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus, number=25)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color=red, number=25)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(bogus=totally, number=25)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color=red, number=pi)]', testData)).to.be.undefined;
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "lib": ["es6", "dom", "es2017"]
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR adds the remaining selection syntax: pick, omit, prefix, suffix, filter

In a previous PR we omitted the tests in /test/ when adding tests in /test/mocks/ so I re-added that.

Also fixes the globalThis.console which was being overwritten in other tests.