### PR TITLE
Adding DataLayerObserver core

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,7 @@
-import { OperatorOptions, Operator } from "./operator";
-import { DataHandler } from "./handler";
-import { FunctionOperator } from "./operators";
-import { Logger } from "./utils/logger";
+import { OperatorOptions, Operator } from './operator';
+import DataHandler from './handler';
+import { FunctionOperator } from './operators';
+import { Logger } from './utils/logger';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -24,7 +24,7 @@ export interface DataLayerConfig {
   rules: DataLayerRule[];
   validateRules?: boolean;
   urlValidator?: (url: string | undefined) => boolean;
-};
+}
 
 /**
  * DataLayerRule configures the behavior for a specific data layer target.
@@ -51,7 +51,6 @@ export interface DataLayerRule {
  * programmatically built on a page.
  */
 export class DataLayerObserver {
-
   private operators: { [key: string]: any } = { // TODO (van) type the class value in the map
     function: FunctionOperator,
   };
@@ -126,7 +125,12 @@ export class DataLayerObserver {
    */
   private isUrlValid(url: string | undefined) {
     const { urlValidator } = this.config;
-    return urlValidator ? urlValidator(url) : url ? RegExp(url).test(window.location.href) : true;
+
+    if (urlValidator) {
+      return urlValidator(url);
+    }
+
+    return url ? RegExp(url).test(window.location.href) : true;
   }
 
   /**
@@ -149,7 +153,7 @@ export class DataLayerObserver {
     } = rule;
 
     // rule properties override global ones
-    const readOnLoad = ruleReadOnLoad ? ruleReadOnLoad : globalReadOnLoad;
+    const readOnLoad = ruleReadOnLoad || globalReadOnLoad;
 
     if (!source || !destination) {
       Logger.getInstance().error(`Rule is missing ${source ? 'destination' : 'source'}`, source);
@@ -166,9 +170,9 @@ export class DataLayerObserver {
 
       try {
         // sequentially add the operators to the handler
-        for (const options of operators) {
+        operators.forEach((options) => {
           this.addOperator(handler, options);
-        }
+        });
 
         // optionally perform a final transformation
         // useful if every rule needs the same operator run before the destination
@@ -180,9 +184,8 @@ export class DataLayerObserver {
         const { previewDestination } = this.config;
         const func = previewMode ? previewDestination : destination;
         this.addOperator(handler, { name: 'function', func });
-
       } catch (err) {
-        Logger.getInstance().error(`Failed to create operators`, source);
+        Logger.getInstance().error('Failed to create operators', source);
         console.error(err.message);
 
         this.removeHandler(handler);
@@ -195,11 +198,11 @@ export class DataLayerObserver {
           // this could error if a function is supplied to readOnLoad
           handler.fireEvent();
         } catch (err) {
-          Logger.getInstance().error(`Failed to read on load`, source);
+          Logger.getInstance().error('Failed to read on load', source);
         }
       }
     } catch (err) {
-      Logger.getInstance().error(`Failed to create data handler`, source);
+      Logger.getInstance().error('Failed to create data handler', source);
     }
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -48,6 +48,13 @@ export class DataLayerObserver {
     return handler;
   }
 
+  /**
+   * Appends an Operator to the existing list for a given DataHandler.
+   * If an error occurs with creating or adding the operator, the DataHandler will be removed
+   * to prevent unexpected data processing.
+   * @param handler the DataHandler to add the operator to
+   * @param options the OperatorOptions used to configure the Operator
+   */
   addOperator<O extends OperatorOptions>(handler: DataHandler, options: O) {
     const { name } = options;
 
@@ -55,12 +62,16 @@ export class DataLayerObserver {
       const operator = new this.operators[name](options);
 
       if (this.config.validateRules) {
-        operator.validate();
+        try {
+          operator.validate();
+        } catch (err) {
+          this.removeHandler(handler);
+          throw new Error(`Data handler removed because operator ${name} not found`);
+        }
       }
 
       handler.push(operator);
     } else {
-      // NOTE to be save, remove the handler so incomplete data processing does not occur
       this.removeHandler(handler);
       throw new Error(`Data handler removed because operator ${name} not found`);
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,0 +1,154 @@
+import { OperatorOptions, Operator } from "./operator";
+import { DataHandler } from "./handler";
+import { FunctionOperator } from "./operators";
+import { Logger } from "./utils/logger";
+
+export interface DataLayerConfig {
+  previewDestination?: string;
+  previewMode?: boolean;
+  readOnLoad?: boolean;
+  rules: DataLayerRule[];
+  finalize?: OperatorOptions;
+  validateRules?: boolean;
+  urlValidator?: (url: string | undefined) => boolean;
+};
+
+export interface DataLayerRule {
+  source: string | any;
+  operators?: OperatorOptions[];
+  destination: string | Function;
+  readOnLoad?: boolean;
+  url?: string;
+}
+
+export class DataLayerObserver {
+
+  private operators: { [key: string]: any } = { // TODO (van) type the class value in the map
+    function: FunctionOperator,
+  };
+
+  handlers: DataHandler[] = [];
+
+  constructor(private config: DataLayerConfig = {
+    rules: [],
+    previewMode: false,
+    readOnLoad: false,
+    validateRules: true,
+  }) {
+    const { rules } = config;
+    if (rules) {
+      rules.forEach((rule: DataLayerRule) => this.processRule(rule));
+    }
+  }
+
+  addHandler(path: string): DataHandler {
+    const handler = new DataHandler(path);
+    this.handlers.push(handler);
+
+    return handler;
+  }
+
+  addOperator<O extends OperatorOptions>(handler: DataHandler, options: O) {
+    const { name } = options;
+
+    if (this.operators[name]) {
+      const operator = new this.operators[name](options);
+
+      if (this.config.validateRules) {
+        operator.validate();
+      }
+
+      handler.push(operator);
+    } else {
+      // NOTE to be save, remove the handler so incomplete data processing does not occur
+      this.removeHandler(handler);
+      throw new Error(`Data handler removed because operator ${name} not found`);
+    }
+  }
+
+  private isUrlValid(url: string | undefined) {
+    const { urlValidator } = this.config;
+    return urlValidator ? urlValidator(url) : url ? RegExp(url).test(window.location.href) : true;
+  }
+
+  processRule(rule: DataLayerRule) {
+    const { finalize, previewMode, readOnLoad: globalReadOnLoad } = this.config;
+
+    const {
+      source,
+      operators = [],
+      destination,
+      readOnLoad: ruleReadOnLoad,
+      url,
+    } = rule;
+
+    // rule properties override global ones
+    const readOnLoad = ruleReadOnLoad ? ruleReadOnLoad : globalReadOnLoad;
+
+    if (!source || !destination) {
+      Logger.getInstance().error(`Rule is missing ${source ? 'destination' : 'source'}`, source);
+      return;
+    }
+
+    // check the rule is valid for the url
+    if (!this.isUrlValid(url)) {
+      return;
+    }
+
+    try {
+      const handler = this.addHandler(source);
+
+      try {
+        // sequentially add the operators to the handler
+        for (const options of operators) {
+          this.addOperator(handler, options);
+        }
+
+        // optionally finalize all rules, which is useful if all data needs conversion before
+        // being sent to a destination
+        if (finalize) {
+          this.addOperator(handler, finalize);
+        }
+
+        // end with destination
+        const { previewDestination } = this.config;
+        const func = previewMode ? previewDestination : destination;
+        this.addOperator(handler, { name: 'function', func });
+
+      } catch (err) {
+        Logger.getInstance().error(`Failed to create operators`, source);
+        console.error(err.message);
+
+        this.removeHandler(handler);
+      }
+
+      // FIXME (van) this will be delegated to PropertyListeners when available
+      // if the rule creator wants to fire the initial value for a property, do it
+      if (readOnLoad) {
+        try {
+          // this could error if a function is supplied to readOnLoad
+          handler.fireEvent();
+        } catch (err) {
+          Logger.getInstance().error(`Failed to read on load`, source);
+        }
+      }
+    } catch (err) {
+      Logger.getInstance().error(`Failed to create data handler`, source);
+    }
+  }
+
+  registerOperator(name: string, operator: typeof Operator) {
+    if (this.operators[name]) {
+      throw new Error(`Operator ${name} already exists`);
+    } else {
+      this.operators[name] = operator;
+    }
+  }
+
+  removeHandler(handler: DataHandler) {
+    const i = this.handlers.indexOf(handler);
+    if (i > -1) {
+      this.handlers.splice(i, 1);
+    }
+  }
+}

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -1,0 +1,37 @@
+import { Operator, OperatorOptions, OperatorValidationError } from '../operator';
+import { select } from '../selector';
+
+export interface FunctionOperatorOptions extends OperatorOptions {
+  func: string | Function;
+}
+
+/**
+ * FunctionOperator executes a function and returns the result.
+ */
+export class FunctionOperator extends Operator<FunctionOperatorOptions> {
+  handleData(data: any[]): any[] | null {
+    const { func } = this.options;
+
+    switch (typeof func) {
+      case 'function':
+        return [func.apply(globalThis, data)];
+      case 'string':
+        return select(func).apply(globalThis, data);
+      default:
+        // NOTE this will stop the handler
+        return null;
+    }
+  }
+
+  validate() {
+    const { func } = this.options;
+
+    if (!func) {
+      super.throwValidationError('func', OperatorValidationError.MISSING);
+    }
+
+    if (typeof func !== 'string' || typeof func !== 'function') {
+      super.throwValidationError('func', OperatorValidationError.UNSUPPORTED);
+    }
+  }
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,0 +1,1 @@
+export * from './function';

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -103,10 +103,6 @@ describe('DataLayerObserver unit tests', () => {
     expectNoCalls(globalMock.console, 'log');
   });
 
-  it('a missing data layer should be retried and fail gracefully', () => {
-
-  });
-
   it('it should allow custom operators to be registered', () => {
     const observer = new DataLayerObserver();
 
@@ -176,10 +172,6 @@ describe('DataLayerObserver unit tests', () => {
     expect(cart).to.eq(globalMock.digitalData.cart);
 
     expectNoCalls(globalMock.console, 'log');
-  });
-
-  it('rule validation can be enabled', () => {
-
   });
 
   it('rules can be previewed before making them live', () => {

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -6,7 +6,7 @@ import { basicDigitalData, CEDDL } from './mocks/CEDDL';
 import Console from './mocks/console';
 import FullStory from './mocks/fullstory-recording';
 import { expectParams, expectNoCalls } from './utils/mocha';
-import { Operator, OperatorOptions } from '../src/operator';
+import { Operator, OperatorOptions, OperatorValidationError } from '../src/operator';
 import { FunctionOperator } from '../src/operators';
 
 class EchoOperatorOptions implements OperatorOptions {
@@ -19,7 +19,7 @@ class EchoOperator extends Operator<EchoOperatorOptions> {
   }
 
   validate() {
-    throw new Error(`${this.name} is not valid`);
+    super.throwValidationError('prop', OperatorValidationError.MISSING, 'this is expected');
   }
 }
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { expect } from 'chai';
 import 'mocha';
 
@@ -14,6 +15,7 @@ class EchoOperatorOptions implements OperatorOptions {
 }
 
 class EchoOperator extends Operator<EchoOperatorOptions> {
+  // eslint-disable-next-line class-methods-use-this
   handleData(data: any[]): any[] | null {
     return data;
   }
@@ -34,7 +36,6 @@ interface GlobalMock {
 let globalMock: GlobalMock;
 
 describe('DataLayerObserver unit tests', () => {
-
   beforeEach(() => {
     (globalThis as any).digitalData = basicDigitalData;
     (globalThis as any).console = new Console();
@@ -56,7 +57,7 @@ describe('DataLayerObserver unit tests', () => {
 
   it('it should automatically parse config rules', () => {
     const observer = new DataLayerObserver({
-      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }]
+      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }],
     });
     expect(observer.handlers.length).to.eq(1);
   });
@@ -64,7 +65,7 @@ describe('DataLayerObserver unit tests', () => {
   it('rules without a source and destination are invalid', () => {
     const observer = new DataLayerObserver({
       // @ts-ignore
-      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }]
+      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }],
     });
     expect(observer.handlers.length).to.eq(0);
   });
@@ -72,13 +73,15 @@ describe('DataLayerObserver unit tests', () => {
   it('it should read a data layer on-load for all rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       readOnLoad: true,
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
         { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [productInfo] = expectParams(globalMock.console, 'log');
     expect(productInfo).to.eq(globalMock.digitalData.product[0].productInfo);
@@ -90,12 +93,16 @@ describe('DataLayerObserver unit tests', () => {
   it('it should read a data layer on-load for specific rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       rules: [
-        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true },
+        {
+          source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true,
+        },
         { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [pageInfo] = expectParams(globalMock.console, 'log');
     expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
@@ -113,19 +120,19 @@ describe('DataLayerObserver unit tests', () => {
   it('it should not register operators with the same name', () => {
     const observer = new DataLayerObserver();
     // @ts-ignore TODO (van) how to typecheck this
-    expect(() => { observer.registerOperator('function', FunctionOperator) }).to.throw();
+    expect(() => { observer.registerOperator('function', FunctionOperator); }).to.throw();
   });
 
   it('unknown operators should error and remove the handler', () => {
     const observer = new DataLayerObserver({
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
 
     expect(() => {
       observer.addOperator(observer.handlers[0],
-        new EchoOperatorOptions())
+        new EchoOperatorOptions());
     }).to.throw();
 
     expect(observer.handlers.length).to.eq(0);
@@ -136,7 +143,7 @@ describe('DataLayerObserver unit tests', () => {
       validateRules: true,
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
 
     expect(observer.handlers.length).to.eq(1);
@@ -145,7 +152,7 @@ describe('DataLayerObserver unit tests', () => {
 
     expect(() => {
       observer.addOperator(observer.handlers[0],
-        new EchoOperatorOptions())
+        new EchoOperatorOptions());
     }).to.throw();
 
     expect(observer.handlers.length).to.eq(0);
@@ -154,16 +161,19 @@ describe('DataLayerObserver unit tests', () => {
   it('only valid pages should process a rule', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    const urlValidator = (url: string | undefined) =>
-      url ? RegExp(url).test('https://www.fullstory.com/cart') : true;
+    const urlValidator = (url: string | undefined) => (url ? RegExp(url).test('https://www.fullstory.com/cart') : true);
 
     const observer = new DataLayerObserver({
       readOnLoad: true,
       urlValidator,
       rules: [
-        { source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$' },
-        { source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$' },
-      ]
+        {
+          source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$',
+        },
+        {
+          source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$',
+        },
+      ],
     });
 
     expect(observer.handlers.length).to.eq(1);
@@ -178,7 +188,7 @@ describe('DataLayerObserver unit tests', () => {
     expectNoCalls(globalMock.console, 'log');
     expectNoCalls(globalMock.FS, 'setUserVars');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       previewMode: true,
       previewDestination: 'console.debug', // NOTE the default is console.log
       readOnLoad: true,
@@ -186,15 +196,16 @@ describe('DataLayerObserver unit tests', () => {
         {
           source: 'digitalData.user.profile[0].profileInfo',
           operators: [],
-          destination: 'FS.setUserVars'
+          destination: 'FS.setUserVars',
         },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [profileInfo] = expectParams(globalMock.console, 'debug');
     expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
 
     expectNoCalls(globalMock.FS, 'setUserVars');
   });
-
 });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -143,6 +143,7 @@ describe('DataLayerObserver unit tests', () => {
       ]
     });
 
+    expect(observer.handlers.length).to.eq(1);
     // @ts-ignore TODO (van) how to typecheck this
     observer.registerOperator('echo', EchoOperator);
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -1,0 +1,207 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { DataLayerObserver } from '../src/observer';
+import { basicDigitalData, CEDDL } from './mocks/CEDDL';
+import Console from './mocks/console';
+import FullStory from './mocks/fullstory-recording';
+import { expectParams, expectNoCalls } from './utils/mocha';
+import { Operator, OperatorOptions } from '../src/operator';
+import { FunctionOperator } from '../src/operators';
+
+class EchoOperatorOptions implements OperatorOptions {
+  name = 'echo';
+}
+
+class EchoOperator extends Operator<EchoOperatorOptions> {
+  handleData(data: any[]): any[] | null {
+    return data;
+  }
+
+  validate() {
+    throw new Error(`${this.name} is not valid`);
+  }
+}
+
+const originalConsole = console;
+
+interface GlobalMock {
+  digitalData: CEDDL,
+  FS: FullStory
+  console: Console,
+}
+
+let globalMock: GlobalMock;
+
+describe('DataLayerObserver unit tests', () => {
+
+  beforeEach(() => {
+    (globalThis as any).digitalData = basicDigitalData;
+    (globalThis as any).console = new Console();
+    (globalThis as any).FS = new FullStory();
+    globalMock = globalThis as any;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).digitalData;
+    delete (globalThis as any).FS;
+    (globalThis as any).console = originalConsole;
+  });
+
+  it('it should initialize with defaults', () => {
+    const observer = new DataLayerObserver();
+    expect(observer).to.not.be.undefined;
+    expect(observer).to.not.be.null;
+  });
+
+  it('it should automatically parse config rules', () => {
+    const observer = new DataLayerObserver({
+      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }]
+    });
+    expect(observer.handlers.length).to.eq(1);
+  });
+
+  it('rules without a source and destination are invalid', () => {
+    const observer = new DataLayerObserver({
+      // @ts-ignore
+      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }]
+    });
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('it should read a data layer on-load for all rules', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    new DataLayerObserver({
+      readOnLoad: true,
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+        { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    const [productInfo] = expectParams(globalMock.console, 'log');
+    expect(productInfo).to.eq(globalMock.digitalData.product[0].productInfo);
+
+    const [pageInfo] = expectParams(globalMock.console, 'log');
+    expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
+  });
+
+  it('it should read a data layer on-load for specific rules', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    new DataLayerObserver({
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true },
+        { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    const [pageInfo] = expectParams(globalMock.console, 'log');
+    expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
+
+    expectNoCalls(globalMock.console, 'log');
+  });
+
+  it('a missing data layer should be retried and fail gracefully', () => {
+
+  });
+
+  it('it should allow custom operators to be registered', () => {
+    const observer = new DataLayerObserver();
+
+    // @ts-ignore TODO (van) how to typecheck this
+    observer.registerOperator('echo', EchoOperator);
+  });
+
+  it('it should not register operators with the same name', () => {
+    const observer = new DataLayerObserver();
+    // @ts-ignore TODO (van) how to typecheck this
+    expect(() => { observer.registerOperator('function', FunctionOperator) }).to.throw();
+  });
+
+  it('unknown operators should error and remove the handler', () => {
+    const observer = new DataLayerObserver({
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    expect(() => {
+      observer.addOperator(observer.handlers[0],
+        new EchoOperatorOptions())
+    }).to.throw();
+
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('invalid operators should error and remove the handler', () => {
+    const observer = new DataLayerObserver({
+      validateRules: true,
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    // @ts-ignore TODO (van) how to typecheck this
+    observer.registerOperator('echo', EchoOperator);
+
+    expect(() => {
+      observer.addOperator(observer.handlers[0],
+        new EchoOperatorOptions())
+    }).to.throw();
+
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('only valid pages should process a rule', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    const urlValidator = (url: string | undefined) =>
+      url ? RegExp(url).test('https://www.fullstory.com/cart') : true;
+
+    const observer = new DataLayerObserver({
+      readOnLoad: true,
+      urlValidator,
+      rules: [
+        { source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$' },
+        { source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$' },
+      ]
+    });
+
+    expect(observer.handlers.length).to.eq(1);
+
+    const [cart] = expectParams(globalMock.console, 'log');
+    expect(cart).to.eq(globalMock.digitalData.cart);
+
+    expectNoCalls(globalMock.console, 'log');
+  });
+
+  it('rule validation can be enabled', () => {
+
+  });
+
+  it('rules can be previewed before making them live', () => {
+    expectNoCalls(globalMock.console, 'log');
+    expectNoCalls(globalMock.FS, 'setUserVars');
+
+    new DataLayerObserver({
+      previewMode: true,
+      previewDestination: 'console.debug', // NOTE the default is console.log
+      readOnLoad: true,
+      rules: [
+        {
+          source: 'digitalData.user.profile[0].profileInfo',
+          operators: [],
+          destination: 'FS.setUserVars'
+        },
+      ]
+    });
+
+    const [profileInfo] = expectParams(globalMock.console, 'debug');
+    expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
+
+    expectNoCalls(globalMock.FS, 'setUserVars');
+  });
+
+});

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import Console from './mocks/console';
+import { FunctionOperator } from '../src/operators';
+import { expectParams, expectNoCalls } from './utils/mocha';
+
+const originalConsole = globalThis.console;
+const console = new Console();
+
+class ClosureConsole {
+  constructor(private message: string) {
+    // use constructor params
+  }
+
+  log() {
+    console.log(this.message);
+  }
+}
+
+describe('logger unit tests', () => {
+
+  beforeEach(() => {
+    (globalThis as any).console = console;
+    (globalThis as any).testClosure = new ClosureConsole('Hello World')
+  });
+
+  afterEach(() => {
+    (globalThis as any) = originalConsole;
+    delete (globalThis as any).testClosure;
+  });
+
+  it('it should validate options', () => {
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'console.log'
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () =>
+        console.log('Hello World')
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'testClosure.log', thisArg: 'testClosure'
+    }).validate()).to.not.throw();
+
+    // @ts-ignore
+    expect(() => new FunctionOperator({ name: 'function', func: 1234 }).validate()).to.throw();
+    // @ts-ignore
+    expect(() => new FunctionOperator({ name: 'function' }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      // @ts-ignore
+      name: 'function', func: 'testClosure.log', thisArg: 1234
+    }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure'
+    }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'testClosure.log', thisArg: globalThis
+    }).validate()).to.throw();
+  });
+
+  it('it should call a function using string path', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: 'console.log' });
+    operator.handleData(['Hello World']);
+
+    const [hello] = expectParams(console, 'log');
+    expect(hello).to.eq('Hello World');
+  });
+
+  it('it should call a function (string-path) with proper this context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: 'testClosure.log', thisArg: 'testClosure' });
+    operator.handleData([]);
+
+    const [log] = expectParams(console, 'log');
+    expect(log).to.eq('Hello World');
+  });
+
+  it('it should call a function using native function', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: console.debug });
+    operator.handleData(['Hello World']);
+
+    const [debug] = expectParams(console, 'debug');
+    expect(debug).to.eq('Hello World');
+  });
+
+  it('it should call a function (native) with proper this context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({
+      name: 'function', func: (globalThis as any).testClosure.log,
+      thisArg: (globalThis as any).testClosure
+    });
+    operator.handleData([]);
+
+    const [log] = expectParams(console, 'log');
+    expect(log).to.eq('Hello World');
+  });
+
+  it('it should not call a function (native) with unsupported context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({
+      // @ts-ignore
+      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345
+    });
+    expect(() => operator.handleData([])).to.throw();
+
+    expectNoCalls(console, 'log');
+  });
+
+  it('it should return null for invalid functions', () => {
+    // @ts-ignore
+    const operator = new FunctionOperator({ name: 'function', func: 1234 });
+    const data = operator.handleData(['Hello World']);
+
+    expect(data).to.be.null;
+  });
+
+});

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -19,10 +19,9 @@ class ClosureConsole {
 }
 
 describe('logger unit tests', () => {
-
   beforeEach(() => {
     (globalThis as any).console = console;
-    (globalThis as any).testClosure = new ClosureConsole('Hello World')
+    (globalThis as any).testClosure = new ClosureConsole('Hello World');
   });
 
   afterEach(() => {
@@ -32,20 +31,20 @@ describe('logger unit tests', () => {
 
   it('it should validate options', () => {
     expect(() => new FunctionOperator({
-      name: 'function', func: 'console.log'
+      name: 'function', func: 'console.log',
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () =>
-        console.log('Hello World')
+      name: 'function',
+      func: () => console.log('Hello World'),
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis
+      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis,
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: 'testClosure.log', thisArg: 'testClosure'
+      name: 'function', func: 'testClosure.log', thisArg: 'testClosure',
     }).validate()).to.not.throw();
 
     // @ts-ignore
@@ -55,15 +54,15 @@ describe('logger unit tests', () => {
 
     expect(() => new FunctionOperator({
       // @ts-ignore
-      name: 'function', func: 'testClosure.log', thisArg: 1234
+      name: 'function', func: 'testClosure.log', thisArg: 1234,
     }).validate()).to.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure'
+      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure',
     }).validate()).to.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: 'testClosure.log', thisArg: globalThis
+      name: 'function', func: 'testClosure.log', thisArg: globalThis,
     }).validate()).to.throw();
   });
 
@@ -101,8 +100,9 @@ describe('logger unit tests', () => {
     expectNoCalls(console, 'log');
 
     const operator = new FunctionOperator({
-      name: 'function', func: (globalThis as any).testClosure.log,
-      thisArg: (globalThis as any).testClosure
+      name: 'function',
+      func: (globalThis as any).testClosure.log,
+      thisArg: (globalThis as any).testClosure,
     });
     operator.handleData([]);
 
@@ -115,7 +115,7 @@ describe('logger unit tests', () => {
 
     const operator = new FunctionOperator({
       // @ts-ignore
-      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345
+      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345,
     });
     expect(() => operator.handleData([])).to.throw();
 
@@ -129,5 +129,4 @@ describe('logger unit tests', () => {
 
     expect(data).to.be.null;
   });
-
 });


### PR DESCRIPTION
This PR adds the main functionality of DataLayerObserver for static data layers.  The `readOnLoad` property is heavily used in this iteration.  The `FunctionOperator` is a key component since it is used with the `destination` in rules.