### PR TITLE
Refactor to support interfaces versus generics

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,16 +1,15 @@
-import * as Operators from './operators';
+import { FunctionOperator, FunctionOperatorOptions } from './operators';
 import { Operator } from './operator';
-import { FunctionOperator } from './operators';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof Operators.FunctionOperator;
+export type BuiltinOperator = typeof FunctionOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = Operators.FunctionOperatorOptions;
+export type BuiltinOptions = FunctionOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -26,7 +26,7 @@ export class OperatorFactory {
    * @param options OperatorOptions used to configure the Operator
    */
   static create(name: string, options: BuiltinOptions): Operator {
-    if (!OperatorFactory.hasOperator) {
+    if (!OperatorFactory.hasOperator(name)) {
       throw new Error(`Operator ${name} is unknown`);
     }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -2,16 +2,31 @@ import * as Operators from './operators';
 import { Operator } from './operator';
 import { FunctionOperator } from './operators';
 
-export type ConfigurableOperator = typeof Operators.FunctionOperator;
+/**
+ * Declares known, built-in Operators.
+ */
+export type BuiltinOperator = typeof Operators.FunctionOperator;
 
-export type ConfigurableOptions = Operators.FunctionOperatorOptions;
+/**
+ * Declares known, built-in OperatorOptions.
+ */
+export type BuiltinOptions = Operators.FunctionOperatorOptions;
 
+/**
+ * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
+ * the factory is responsible for creating a configured Operator for arbitrary DataLayerRule operators.
+ */
 export class OperatorFactory {
-  private static operators: { [key: string]: ConfigurableOperator } = {
+  private static operators: { [key: string]: BuiltinOperator } = {
     function: FunctionOperator,
   };
 
-  static create(name: string, options: ConfigurableOptions): Operator {
+  /**
+   * Creates a configured Operator.
+   * @param name the name of the Operator to create
+   * @param options OperatorOptions used to configure the Operator
+   */
+  static create(name: string, options: BuiltinOptions): Operator {
     if (!OperatorFactory.hasOperator) {
       throw new Error(`Operator ${name} is unknown`);
     }
@@ -19,6 +34,10 @@ export class OperatorFactory {
     return new this.operators[name](options);
   }
 
+  /**
+   * Checks if the factory knows how to create an Operator.
+   * @param name the name to check
+   */
   static hasOperator(name: string) {
     return this.operators[name] !== undefined;
   }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,0 +1,25 @@
+import * as Operators from './operators';
+import { Operator } from './operator';
+import { FunctionOperator } from './operators';
+
+export type ConfigurableOperator = typeof Operators.FunctionOperator;
+
+export type ConfigurableOptions = Operators.FunctionOperatorOptions;
+
+export class OperatorFactory {
+  private static operators: { [key: string]: ConfigurableOperator } = {
+    function: FunctionOperator,
+  };
+
+  static create(name: string, options: ConfigurableOptions): Operator {
+    if (!OperatorFactory.hasOperator) {
+      throw new Error(`Operator ${name} is unknown`);
+    }
+
+    return new this.operators[name](options);
+  }
+
+  static hasOperator(name: string) {
+    return this.operators[name] !== undefined;
+  }
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -90,7 +90,7 @@ export default class DataHandler {
     let handledData = data;
 
     for (let i = 0; i < this.operators.length; i += 1) {
-      const { name } = this.operators[i];
+      const { options: { name } } = this.operators[i];
 
       try {
         // if the data is null, it is a signal to stop processing

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,5 +1,5 @@
 import { Logger } from './utils/logger';
-import { Operator, OperatorOptions } from './operator';
+import { Operator } from './operator';
 import { DataLayerEventType, DataLayerDetail, PropertyDetail } from './event';
 import { select } from './selector';
 
@@ -9,7 +9,7 @@ import { select } from './selector';
  * registered operators.
  */
 export default class DataHandler {
-  private operators: Operator<OperatorOptions>[] = [];
+  private operators: Operator[] = [];
 
   readonly target: any;
 
@@ -124,7 +124,7 @@ export default class DataHandler {
    * Adds an operator to the list. Operators will sequentially pass data to the next operator.
    * @param operators Operator(s) to add
    */
-  push(...operators: Operator<OperatorOptions>[]): void {
+  push(...operators: Operator[]): void {
     operators.forEach((operator) => this.operators.push(operator));
   }
 }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,7 @@
-import { OperatorOptions, Operator } from "./operator";
-import { DataHandler } from "./handler";
-import { FunctionOperator } from "./operators";
-import { Logger } from "./utils/logger";
+import { OperatorOptions, Operator } from './operator';
+import DataHandler from './handler';
+import { FunctionOperator } from './operators';
+import { Logger } from './utils/logger';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -24,7 +24,7 @@ export interface DataLayerConfig {
   rules: DataLayerRule[];
   validateRules?: boolean;
   urlValidator?: (url: string | undefined) => boolean;
-};
+}
 
 /**
  * DataLayerRule configures the behavior for a specific data layer target.
@@ -51,7 +51,6 @@ export interface DataLayerRule {
  * programmatically built on a page.
  */
 export class DataLayerObserver {
-
   private operators: { [key: string]: any } = { // TODO (van) type the class value in the map
     function: FunctionOperator,
   };
@@ -126,7 +125,12 @@ export class DataLayerObserver {
    */
   private isUrlValid(url: string | undefined) {
     const { urlValidator } = this.config;
-    return urlValidator ? urlValidator(url) : url ? RegExp(url).test(window.location.href) : true;
+
+    if (urlValidator) {
+      return urlValidator(url);
+    }
+
+    return url ? RegExp(url).test(window.location.href) : true;
   }
 
   /**
@@ -149,7 +153,7 @@ export class DataLayerObserver {
     } = rule;
 
     // rule properties override global ones
-    const readOnLoad = ruleReadOnLoad ? ruleReadOnLoad : globalReadOnLoad;
+    const readOnLoad = ruleReadOnLoad || globalReadOnLoad;
 
     if (!source || !destination) {
       Logger.getInstance().error(`Rule is missing ${source ? 'destination' : 'source'}`, source);
@@ -166,9 +170,9 @@ export class DataLayerObserver {
 
       try {
         // sequentially add the operators to the handler
-        for (const options of operators) {
+        operators.forEach((options) => {
           this.addOperator(handler, options);
-        }
+        });
 
         // optionally perform a final transformation
         // useful if every rule needs the same operator run before the destination
@@ -180,9 +184,8 @@ export class DataLayerObserver {
         const { previewDestination } = this.config;
         const func = previewMode ? previewDestination : destination;
         this.addOperator(handler, { name: 'function', func });
-
       } catch (err) {
-        Logger.getInstance().error(`Failed to create operators`, source);
+        Logger.getInstance().error('Failed to create operators', source);
         console.error(err.message);
 
         this.removeHandler(handler);
@@ -195,11 +198,11 @@ export class DataLayerObserver {
           // this could error if a function is supplied to readOnLoad
           handler.fireEvent();
         } catch (err) {
-          Logger.getInstance().error(`Failed to read on load`, source);
+          Logger.getInstance().error('Failed to read on load', source);
         }
       }
     } catch (err) {
-      Logger.getInstance().error(`Failed to create data handler`, source);
+      Logger.getInstance().error('Failed to create data handler', source);
     }
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -48,6 +48,13 @@ export class DataLayerObserver {
     return handler;
   }
 
+  /**
+   * Appends an Operator to the existing list for a given DataHandler.
+   * If an error occurs with creating or adding the operator, the DataHandler will be removed
+   * to prevent unexpected data processing.
+   * @param handler the DataHandler to add the operator to
+   * @param options the OperatorOptions used to configure the Operator
+   */
   addOperator<O extends OperatorOptions>(handler: DataHandler, options: O) {
     const { name } = options;
 
@@ -55,12 +62,16 @@ export class DataLayerObserver {
       const operator = new this.operators[name](options);
 
       if (this.config.validateRules) {
-        operator.validate();
+        try {
+          operator.validate();
+        } catch (err) {
+          this.removeHandler(handler);
+          throw new Error(`Data handler removed because operator ${name} not found`);
+        }
       }
 
       handler.push(operator);
     } else {
-      // NOTE to be save, remove the handler so incomplete data processing does not occur
       this.removeHandler(handler);
       throw new Error(`Data handler removed because operator ${name} not found`);
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,5 +1,5 @@
 import { OperatorOptions, Operator } from './operator';
-import { ConfigurableOptions, OperatorFactory } from './factory';
+import { BuiltinOptions, OperatorFactory } from './factory';
 import DataHandler from './handler';
 import { Logger } from './utils/logger';
 import { FunctionOperator } from './operators';
@@ -166,7 +166,7 @@ export class DataLayerObserver {
           // check if this is a generic operator that should be built or a registered one
           const { name } = options;
           const operator = this.customOperators[name] ? this.customOperators[name]
-            : OperatorFactory.create(name, options as ConfigurableOptions);
+            : OperatorFactory.create(name, options as BuiltinOptions);
           this.addOperator(handler, operator);
         });
 
@@ -174,7 +174,7 @@ export class DataLayerObserver {
         // useful if every rule needs the same operator run before the destination
         if (beforeDestination) {
           this.addOperator(handler, OperatorFactory.create(beforeDestination.name,
-            beforeDestination as ConfigurableOptions));
+            beforeDestination as BuiltinOptions));
         }
 
         // end with destination

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,8 @@
 import { OperatorOptions, Operator } from './operator';
+import { ConfigurableOptions, OperatorFactory } from './factory';
 import DataHandler from './handler';
-import { FunctionOperator } from './operators';
 import { Logger } from './utils/logger';
+import { FunctionOperator } from './operators';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -51,9 +52,7 @@ export interface DataLayerRule {
  * programmatically built on a page.
  */
 export class DataLayerObserver {
-  private operators: { [key: string]: any } = { // TODO (van) type the class value in the map
-    function: FunctionOperator,
-  };
+  private customOperators: { [key: string]: Operator } = {};
 
   handlers: DataHandler[] = [];
 
@@ -61,6 +60,7 @@ export class DataLayerObserver {
    * Creates a DataLayerObserver. If no DataLayerConfig is provided, the following settings will be
    * used:
    *  previewMode: false
+   *  previewDestination: console.log
    *  readOnLoad: false
    *  validateRules: true
    * @param config an optional DataLayerConfig
@@ -68,6 +68,7 @@ export class DataLayerObserver {
   constructor(private config: DataLayerConfig = {
     rules: [],
     previewMode: false,
+    previewDestination: 'console.log',
     readOnLoad: false,
     validateRules: true,
   }) {
@@ -96,26 +97,17 @@ export class DataLayerObserver {
    * @param options the OperatorOptions used to configure the Operator
    * @throws an error if ruleValidation is enabled an the OperatorOptions are invalid
    */
-  addOperator<O extends OperatorOptions>(handler: DataHandler, options: O) {
-    const { name } = options;
-
-    if (this.operators[name]) {
-      const operator = new this.operators[name](options);
-
-      if (this.config.validateRules) {
-        try {
-          operator.validate();
-        } catch (err) {
-          this.removeHandler(handler);
-          throw new Error(`Data handler removed because operator ${name} not found`);
-        }
+  addOperator(handler: DataHandler, operator: Operator) {
+    if (this.config.validateRules) {
+      try {
+        operator.validate();
+      } catch (err) {
+        this.removeHandler(handler);
+        throw new Error(`Data handler removed because operator ${operator.options.name} not found`);
       }
-
-      handler.push(operator);
-    } else {
-      this.removeHandler(handler);
-      throw new Error(`Data handler removed because operator ${name} not found`);
     }
+
+    handler.push(operator);
   }
 
   /**
@@ -171,19 +163,24 @@ export class DataLayerObserver {
       try {
         // sequentially add the operators to the handler
         operators.forEach((options) => {
-          this.addOperator(handler, options);
+          // check if this is a generic operator that should be built or a registered one
+          const { name } = options;
+          const operator = this.customOperators[name] ? this.customOperators[name]
+            : OperatorFactory.create(name, options as ConfigurableOptions);
+          this.addOperator(handler, operator);
         });
 
         // optionally perform a final transformation
         // useful if every rule needs the same operator run before the destination
         if (beforeDestination) {
-          this.addOperator(handler, beforeDestination);
+          this.addOperator(handler, OperatorFactory.create(beforeDestination.name,
+            beforeDestination as ConfigurableOptions));
         }
 
         // end with destination
-        const { previewDestination } = this.config;
+        const { previewDestination = 'console.log' } = this.config;
         const func = previewMode ? previewDestination : destination;
-        this.addOperator(handler, { name: 'function', func });
+        this.addOperator(handler, new FunctionOperator({ name: 'function', func }));
       } catch (err) {
         Logger.getInstance().error('Failed to create operators', source);
         console.error(err.message);
@@ -211,11 +208,11 @@ export class DataLayerObserver {
    * @param operator the Operator's class
    * @throws an error if an existing name is used
    */
-  registerOperator(name: string, operator: typeof Operator) {
-    if (this.operators[name]) {
+  registerOperator(name: string, operator: Operator) {
+    if (OperatorFactory.hasOperator(name)) {
       throw new Error(`Operator ${name} already exists`);
     } else {
-      this.operators[name] = operator;
+      this.customOperators[name] = operator;
     }
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,0 +1,154 @@
+import { OperatorOptions, Operator } from "./operator";
+import { DataHandler } from "./handler";
+import { FunctionOperator } from "./operators";
+import { Logger } from "./utils/logger";
+
+export interface DataLayerConfig {
+  previewDestination?: string;
+  previewMode?: boolean;
+  readOnLoad?: boolean;
+  rules: DataLayerRule[];
+  finalize?: OperatorOptions;
+  validateRules?: boolean;
+  urlValidator?: (url: string | undefined) => boolean;
+};
+
+export interface DataLayerRule {
+  source: string | any;
+  operators?: OperatorOptions[];
+  destination: string | Function;
+  readOnLoad?: boolean;
+  url?: string;
+}
+
+export class DataLayerObserver {
+
+  private operators: { [key: string]: any } = { // TODO (van) type the class value in the map
+    function: FunctionOperator,
+  };
+
+  handlers: DataHandler[] = [];
+
+  constructor(private config: DataLayerConfig = {
+    rules: [],
+    previewMode: false,
+    readOnLoad: false,
+    validateRules: true,
+  }) {
+    const { rules } = config;
+    if (rules) {
+      rules.forEach((rule: DataLayerRule) => this.processRule(rule));
+    }
+  }
+
+  addHandler(path: string): DataHandler {
+    const handler = new DataHandler(path);
+    this.handlers.push(handler);
+
+    return handler;
+  }
+
+  addOperator<O extends OperatorOptions>(handler: DataHandler, options: O) {
+    const { name } = options;
+
+    if (this.operators[name]) {
+      const operator = new this.operators[name](options);
+
+      if (this.config.validateRules) {
+        operator.validate();
+      }
+
+      handler.push(operator);
+    } else {
+      // NOTE to be save, remove the handler so incomplete data processing does not occur
+      this.removeHandler(handler);
+      throw new Error(`Data handler removed because operator ${name} not found`);
+    }
+  }
+
+  private isUrlValid(url: string | undefined) {
+    const { urlValidator } = this.config;
+    return urlValidator ? urlValidator(url) : url ? RegExp(url).test(window.location.href) : true;
+  }
+
+  processRule(rule: DataLayerRule) {
+    const { finalize, previewMode, readOnLoad: globalReadOnLoad } = this.config;
+
+    const {
+      source,
+      operators = [],
+      destination,
+      readOnLoad: ruleReadOnLoad,
+      url,
+    } = rule;
+
+    // rule properties override global ones
+    const readOnLoad = ruleReadOnLoad ? ruleReadOnLoad : globalReadOnLoad;
+
+    if (!source || !destination) {
+      Logger.getInstance().error(`Rule is missing ${source ? 'destination' : 'source'}`, source);
+      return;
+    }
+
+    // check the rule is valid for the url
+    if (!this.isUrlValid(url)) {
+      return;
+    }
+
+    try {
+      const handler = this.addHandler(source);
+
+      try {
+        // sequentially add the operators to the handler
+        for (const options of operators) {
+          this.addOperator(handler, options);
+        }
+
+        // optionally finalize all rules, which is useful if all data needs conversion before
+        // being sent to a destination
+        if (finalize) {
+          this.addOperator(handler, finalize);
+        }
+
+        // end with destination
+        const { previewDestination } = this.config;
+        const func = previewMode ? previewDestination : destination;
+        this.addOperator(handler, { name: 'function', func });
+
+      } catch (err) {
+        Logger.getInstance().error(`Failed to create operators`, source);
+        console.error(err.message);
+
+        this.removeHandler(handler);
+      }
+
+      // FIXME (van) this will be delegated to PropertyListeners when available
+      // if the rule creator wants to fire the initial value for a property, do it
+      if (readOnLoad) {
+        try {
+          // this could error if a function is supplied to readOnLoad
+          handler.fireEvent();
+        } catch (err) {
+          Logger.getInstance().error(`Failed to read on load`, source);
+        }
+      }
+    } catch (err) {
+      Logger.getInstance().error(`Failed to create data handler`, source);
+    }
+  }
+
+  registerOperator(name: string, operator: typeof Operator) {
+    if (this.operators[name]) {
+      throw new Error(`Operator ${name} already exists`);
+    } else {
+      this.operators[name] = operator;
+    }
+  }
+
+  removeHandler(handler: DataHandler) {
+    const i = this.handlers.indexOf(handler);
+    if (i > -1) {
+      this.handlers.splice(i, 1);
+    }
+  }
+}

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -54,10 +54,9 @@ export class OperatorValidator {
    * @throws an error if the property has an unsupported type
    */
   checkType(option: string, type: string | string[]) {
-    if (typeof type === 'string' && typeof this.options[option]) {
-      this.throwError(option, `should be type ${type} `);
-    } else if (type.indexOf(typeof this.options[option]) === -1) {
-      this.throwError(option, `should be one of these types ${type.toString()}`);
+    const normalizedType = type.toString().toLowerCase();
+    if (normalizedType.indexOf(typeof this.options[option]) === -1) {
+      this.throwError(option, `is a ${typeof this.options[option]} but should be ${type}`);
     }
   }
 
@@ -70,7 +69,7 @@ export class OperatorValidator {
   checkDependencies(option: string, dependencies: string[]) {
     dependencies.forEach((dependency) => {
       if (!this.options[dependency]) {
-        this.throwError(option, `requires ${dependency}`);
+        this.throwError(option, `requires option ${dependency}`);
       }
     });
   }
@@ -102,27 +101,25 @@ export class OperatorValidator {
   validate(specification: OperatorSpecification) {
     const { name } = this.options;
 
-    if (specification) {
-      Object.getOwnPropertyNames(specification).forEach((key) => {
-        const { required, type, dependencies = [] } = specification[key];
-        if (required) {
-          this.checkRequired(key);
-        }
+    Object.getOwnPropertyNames(specification).forEach((key) => {
+      const { required, type, dependencies = [] } = specification[key];
+      if (required) {
+        this.checkRequired(key);
+      }
 
-        if (this.options[key]) {
-          this.checkType(key, type);
-          this.checkDependencies(key, dependencies);
-        }
-      });
+      if (this.options[key]) {
+        this.checkType(key, type);
+        this.checkDependencies(key, dependencies);
+      }
+    });
 
-      Object.getOwnPropertyNames(this.options).filter(
-        (key) => !OperatorValidator.isReservedProperty(key),
-      ).forEach((key) => {
-        if (!specification[key]) {
-          throw Error(`Operator '${name}' has unknown option ${key}`);
-        }
-      });
-    }
+    Object.getOwnPropertyNames(this.options).filter(
+      (key) => !OperatorValidator.isReservedProperty(key),
+    ).forEach((key) => {
+      if (!specification[key]) {
+        throw Error(`Operator '${name}' has unknown option ${key}`);
+      }
+    });
   }
 }
 

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -1,12 +1,20 @@
 /* eslint-disable max-classes-per-file */
 
+/**
+ * OperatorSpecificationDetail provides additional metadata about the properties in OperatorOptions.
+ * The metadata can be used to verify OperatorOptions match a spec using OperatorValidator.validate().
+ */
 export interface OperatorSpecificationDetail {
-  required: boolean;
-  type: string | string[];
-  dependencies?: string[];
+  required: boolean; // whether or not the property is required
+  type: string | string[]; // the supported types of a property
+  dependencies?: string[]; // any other properties that must be set
 }
 
+/**
+ * OperatorSpecification is a map of each OperatorOptions property with a corresponding OperatorSpecificationDetail.
+ */
 export type OperatorSpecification = { [key: string]: OperatorSpecificationDetail };
+
 /**
  * OperatorOptions define shared properties for all Operators.
  */
@@ -18,43 +26,79 @@ export interface OperatorOptions {
   [key: string]: any; // custom options provided by Operator implementations
 }
 
+/**
+ * OperatorValidator verifies that OperatorOptions have supported values.
+ */
 export class OperatorValidator {
   constructor(private options: OperatorOptions) {
     if (!options.name) {
-      throw new Error(`Operator options ${JSON.stringify(options)} has no name property`);
+      throw new Error(`Operator options ${JSON.stringify(options)} has no name`);
     }
   }
 
-  checkRequired(property: string) {
-    if (!this.options[property]) {
-      this.throwError(property, 'is required');
+  /**
+   * Verifies an option is present.
+   * @param option the property name
+   * @throws an error if the property is missing
+   */
+  checkRequired(option: string) {
+    if (!this.options[option]) {
+      this.throwError(option, 'is required');
     }
   }
 
-  checkType(property: string, type: string | string[]) {
-    if (typeof type === 'string' && typeof this.options[property]) {
-      this.throwError(property, `should be type ${type} `);
-    } else if (type.indexOf(typeof this.options[property]) === -1) {
-      this.throwError(property, `should be one of these types ${type.toString()}`);
+  /**
+   * Verifies an option has a supported type.
+   * @param option the property name
+   * @param type the expected type(s)
+   * @throws an error if the property has an unsupported type
+   */
+  checkType(option: string, type: string | string[]) {
+    if (typeof type === 'string' && typeof this.options[option]) {
+      this.throwError(option, `should be type ${type} `);
+    } else if (type.indexOf(typeof this.options[option]) === -1) {
+      this.throwError(option, `should be one of these types ${type.toString()}`);
     }
   }
 
-  checkDependencies(property: string, dependencies: string[]) {
+  /**
+   * Verifies other options are present for a given property.
+   * @param option the property name
+   * @param dependencies the required other properties
+   * @throws an error if required properties are missing
+   */
+  checkDependencies(option: string, dependencies: string[]) {
     dependencies.forEach((dependency) => {
       if (!this.options[dependency]) {
-        this.throwError(property, `requires ${dependency}`);
+        this.throwError(option, `requires ${dependency}`);
       }
     });
   }
 
-  throwError(property: string, message: string) {
-    throw new Error(`Operator '${this.options.name}' property '${property}' ${message}`);
+  /**
+   * Throws an error with a pre-formatted message.
+   * @param option the property that triggered the error
+   * @param message a more detailed message about the error
+   * @throws an error as expected
+   */
+  throwError(option: string, message: string) {
+    throw new Error(`Operator '${this.options.name}' option '${option}' ${message}`);
   }
 
-  static isReservedProperty(property: string) {
-    return property === 'name' || property === 'index' || property === 'maxDepth';
+  /**
+   * Checks if an option is reserved, which are required options for all OperatorOptions.
+   * @param option the option to check
+   */
+  static isReservedProperty(option: string) {
+    return option === 'name' || option === 'index' || option === 'maxDepth';
   }
 
+  /**
+   * Performs validation that this validator's OperatorOptions matches a specification.
+   * Any unknown properties will result in an error.
+   * @param specification the specification to validate
+   * @throws an error if the OperatorOptions fails validation
+   */
   validate(specification: OperatorSpecification) {
     const { name } = this.options;
 
@@ -75,7 +119,7 @@ export class OperatorValidator {
         (key) => !OperatorValidator.isReservedProperty(key),
       ).forEach((key) => {
         if (!specification[key]) {
-          throw Error(`Operator '${name}' has unknown property ${key}`);
+          throw Error(`Operator '${name}' has unknown option ${key}`);
         }
       });
     }
@@ -85,7 +129,7 @@ export class OperatorValidator {
 /**
  * An Operator takes a list of data objects emitted from a data layer and performs a transformation.
  * Operators should be atomic - performing a specific and succinct transformation. The
- * transformation should return a result that will be passed to the next operator, and it should not
+ * transformation should return a result that will be passed to the next operator. An Operator should not
  * mutate the incoming object.
  *
  * While an Operator will most often transform a single object, the input is always a list of
@@ -93,8 +137,14 @@ export class OperatorValidator {
  * of a function call, which emits a list of arguments.
  *
  * An Operator can choose not to pass information to the next operator by returning null.
+ *
+ * Operators should implement the validate function to ensure the Operator is configured correctly at runtime.
+ * For convenience, Operators can use OperatorValidator and an OperatorSpecification to assist with validation.
  */
 export interface Operator {
+  /**
+   * The OperatorOptions that control the behavior of the Operator's implementation.
+   */
   options: OperatorOptions;
 
   /**

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -29,7 +29,7 @@ export enum OperatorValidationError {
  *
  * An Operator can choose not to pass information to the next operator by returning null.
  */
-export abstract class Operator implements OperatorOptions {
+export abstract class Operator {
   readonly name: string;
 
   // NOTE (van) member for index because it's optional and this confuses the ts compiler in subclass

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -1,3 +1,12 @@
+/* eslint-disable max-classes-per-file */
+
+export interface OperatorSpecificationDetail {
+  required: boolean;
+  type: string | string[];
+  dependencies?: string[];
+}
+
+export type OperatorSpecification = { [key: string]: OperatorSpecificationDetail };
 /**
  * OperatorOptions define shared properties for all Operators.
  */
@@ -5,16 +14,72 @@ export interface OperatorOptions {
   name: string; // the name of the operator
   index?: number; // an index if the operation in on a specific object in a list
   maxDepth?: number; // the maximum depth to traverse nested objects
+  specification?: OperatorSpecification; // specification used for validation
+  [key: string]: any; // custom options provided by Operator implementations
 }
 
-/**
- * Common validation errors, which prevents each Operator from defining their own strings and
- * bloating code.
- */
-export enum OperatorValidationError {
-  MISSING = 'is missing or empty',
-  UNSUPPORTED = 'has unsupported value',
-  MALFORMED = 'is malformed'
+export class OperatorValidator {
+  constructor(private options: OperatorOptions) {
+    if (!options.name) {
+      throw new Error(`Operator options ${JSON.stringify(options)} has no name property`);
+    }
+  }
+
+  checkRequired(property: string) {
+    if (!this.options[property]) {
+      this.throwError(property, 'is required');
+    }
+  }
+
+  checkType(property: string, type: string | string[]) {
+    if (typeof type === 'string' && typeof this.options[property]) {
+      this.throwError(property, `should be type ${type} `);
+    } else if (type.indexOf(typeof this.options[property]) === -1) {
+      this.throwError(property, `should be one of these types ${type.toString()}`);
+    }
+  }
+
+  checkDependencies(property: string, dependencies: string[]) {
+    dependencies.forEach((dependency) => {
+      if (!this.options[dependency]) {
+        this.throwError(property, `requires ${dependency}`);
+      }
+    });
+  }
+
+  throwError(property: string, message: string) {
+    throw new Error(`Operator '${this.options.name}' property '${property}' ${message}`);
+  }
+
+  static isReservedProperty(property: string) {
+    return property === 'name' || property === 'index' || property === 'maxDepth';
+  }
+
+  validate(specification: OperatorSpecification) {
+    const { name } = this.options;
+
+    if (specification) {
+      Object.getOwnPropertyNames(specification).forEach((key) => {
+        const { required, type, dependencies = [] } = specification[key];
+        if (required) {
+          this.checkRequired(key);
+        }
+
+        if (this.options[key]) {
+          this.checkType(key, type);
+          this.checkDependencies(key, dependencies);
+        }
+      });
+
+      Object.getOwnPropertyNames(this.options).filter(
+        (key) => !OperatorValidator.isReservedProperty(key),
+      ).forEach((key) => {
+        if (!specification[key]) {
+          throw Error(`Operator '${name}' has unknown property ${key}`);
+        }
+      });
+    }
+  }
 }
 
 /**
@@ -29,39 +94,19 @@ export enum OperatorValidationError {
  *
  * An Operator can choose not to pass information to the next operator by returning null.
  */
-export abstract class Operator {
-  readonly name: string;
-
-  // NOTE (van) member for index because it's optional and this confuses the ts compiler in subclass
-  readonly index: number;
-
-  constructor(protected options: OperatorOptions) {
-    this.name = options.name;
-    this.index = options.index || 0;
-  }
+export interface Operator {
+  options: OperatorOptions;
 
   /**
    * Transforms data based on Operator implementation. Input data should not be mutated.
    * Returning null signals that data should not be propagated to the next Operator.
    * @param data the list of data object emitted from a data layer
    */
-  abstract handleData(data: any[]): any[] | null;
+  handleData(data: any[]): any[] | null;
 
   /**
-   * Validates OperatorOptions. If an Operator has an invalid configuration, an Error should be
-   * thrown.
+   * Validates OperatorOptions.
+   * @throws if an Operator has an invalid configuration, an Error should be thrown.
    */
-  abstract validate(): void;
-
-  /**
-   * Helper to throw common validation errors.
-   * @param option the option in OperatorOptions that is invalid
-   * @param reason a common reason code
-   * @param details optional detail message
-   */
-  protected throwValidationError(option: string, reason: OperatorValidationError,
-    details?: string) {
-    const message = `${this.name} operator option '${option}' ${reason}`;
-    throw new Error(details ? `${message} (${details})` : message);
-  }
+  validate(): void;
 }

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -29,13 +29,13 @@ export enum OperatorValidationError {
  *
  * An Operator can choose not to pass information to the next operator by returning null.
  */
-export abstract class Operator<O extends OperatorOptions> {
+export abstract class Operator implements OperatorOptions {
   readonly name: string;
 
   // NOTE (van) member for index because it's optional and this confuses the ts compiler in subclass
   readonly index: number;
 
-  constructor(protected options: O) {
+  constructor(protected options: OperatorOptions) {
     this.name = options.name;
     this.index = options.index || 0;
   }

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -1,4 +1,4 @@
-import { Operator, OperatorOptions, OperatorValidationError } from '../operator';
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
 import { select } from '../selector';
 
 export interface FunctionOperatorOptions extends OperatorOptions {
@@ -9,10 +9,14 @@ export interface FunctionOperatorOptions extends OperatorOptions {
 /**
  * FunctionOperator executes a function and returns the result.
  */
-export class FunctionOperator extends Operator {
-  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-  constructor(options: FunctionOperatorOptions) {
-    super(options);
+export class FunctionOperator implements Operator {
+  static specification = {
+    func: { required: true, type: ['string', 'function'] },
+    thisArg: { required: false, type: ['string', 'object'] },
+  };
+
+  constructor(public options: FunctionOperatorOptions) {
+    // sets this.options
   }
 
   handleData(data: any[]): any[] | null {
@@ -29,8 +33,12 @@ export class FunctionOperator extends Operator {
           actualThisArg = select(thisArg);
           break;
         default:
-          super.throwValidationError('thisArg', OperatorValidationError.UNSUPPORTED);
+          throw new Error('FunctionOperator has unsupported this');
       }
+    }
+
+    if (!actualThisArg) {
+      throw new Error('FunctionOperator has no this');
     }
 
     switch (typeof func) {
@@ -45,28 +53,7 @@ export class FunctionOperator extends Operator {
   }
 
   validate() {
-    const { func, thisArg } = this.options as FunctionOperatorOptions;
-    const funcType = typeof func;
-    const thisArgType = typeof thisArg;
-
-    if (!func) {
-      super.throwValidationError('func', OperatorValidationError.MISSING);
-    }
-
-    if (funcType !== 'string' && funcType !== 'function') {
-      super.throwValidationError('func', OperatorValidationError.UNSUPPORTED);
-    }
-
-    if (thisArg && thisArgType !== 'string' && thisArgType !== 'object') {
-      super.throwValidationError('thisArg', OperatorValidationError.UNSUPPORTED);
-    }
-
-    if (thisArg && funcType === 'string' && thisArgType !== 'string') {
-      super.throwValidationError('thisArg', OperatorValidationError.MALFORMED);
-    }
-
-    if (thisArg && funcType === 'function' && thisArgType !== 'object') {
-      super.throwValidationError('thisArg', OperatorValidationError.MALFORMED);
-    }
+    const validator = new OperatorValidator(this.options);
+    validator.validate(FunctionOperator.specification);
   }
 }

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -9,9 +9,14 @@ export interface FunctionOperatorOptions extends OperatorOptions {
 /**
  * FunctionOperator executes a function and returns the result.
  */
-export class FunctionOperator extends Operator<FunctionOperatorOptions> {
+export class FunctionOperator extends Operator {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(options: FunctionOperatorOptions) {
+    super(options);
+  }
+
   handleData(data: any[]): any[] | null {
-    const { func, thisArg } = this.options;
+    const { func, thisArg } = this.options as FunctionOperatorOptions;
 
     let actualThisArg: object = globalThis;
 
@@ -40,7 +45,7 @@ export class FunctionOperator extends Operator<FunctionOperatorOptions> {
   }
 
   validate() {
-    const { func, thisArg } = this.options;
+    const { func, thisArg } = this.options as FunctionOperatorOptions;
     const funcType = typeof func;
     const thisArgType = typeof thisArg;
 

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -1,0 +1,37 @@
+import { Operator, OperatorOptions, OperatorValidationError } from '../operator';
+import { select } from '../selector';
+
+export interface FunctionOperatorOptions extends OperatorOptions {
+  func: string | Function;
+}
+
+/**
+ * FunctionOperator executes a function and returns the result.
+ */
+export class FunctionOperator extends Operator<FunctionOperatorOptions> {
+  handleData(data: any[]): any[] | null {
+    const { func } = this.options;
+
+    switch (typeof func) {
+      case 'function':
+        return [func.apply(globalThis, data)];
+      case 'string':
+        return select(func).apply(globalThis, data);
+      default:
+        // NOTE this will stop the handler
+        return null;
+    }
+  }
+
+  validate() {
+    const { func } = this.options;
+
+    if (!func) {
+      super.throwValidationError('func', OperatorValidationError.MISSING);
+    }
+
+    if (typeof func !== 'string' || typeof func !== 'function') {
+      super.throwValidationError('func', OperatorValidationError.UNSUPPORTED);
+    }
+  }
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,0 +1,1 @@
+export * from './function';

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -5,19 +5,12 @@ import 'mocha';
 import DataHandler from '../src/handler';
 
 import { basicDigitalData, PageInfo, Page } from './mocks/CEDDL';
-import { Operator, OperatorOptions } from '../src/operator';
+import { Operator } from '../src/operator';
 import { DataLayerDetail, PropertyDetail } from '../src/event';
-
-// create a mock operators that store something we can check
-class EchoOperatorOptions implements OperatorOptions {
-  name = 'echo';
-
-  index = 0;
-}
 
 class EchoOperator extends Operator {
   constructor(private seen: any[]) {
-    super(new EchoOperatorOptions());
+    super({ name: 'echo', index: 0 });
   }
 
   handleData(data: any[]): any[] | null {
@@ -30,15 +23,9 @@ class EchoOperator extends Operator {
   }
 }
 
-class GetterOperatorOptions implements OperatorOptions {
-  name = 'getter';
-
-  index = 0;
-}
-
 class GetterOperator extends Operator {
   constructor(private property: string, private seen: any[]) {
-    super(new GetterOperatorOptions());
+    super({ name: 'getter', index: 0 });
   }
 
   handleData(data: any[]): any[] | null {
@@ -51,13 +38,9 @@ class GetterOperator extends Operator {
   }
 }
 
-class NullOperatorOptions implements OperatorOptions {
-  name = 'null';
-}
-
 class NullOperator extends Operator {
   constructor() {
-    super(new NullOperatorOptions());
+    super({ name: 'null' });
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -70,13 +53,9 @@ class NullOperator extends Operator {
   }
 }
 
-class ThrowOperatorOptions implements OperatorOptions {
-  name = 'throw';
-}
-
 class ThrowOperator extends Operator {
   constructor() {
-    super(new ThrowOperatorOptions());
+    super({ name: 'throw' });
   }
 
   handleData(): any[] | null {

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -5,43 +5,61 @@ import 'mocha';
 import DataHandler from '../src/handler';
 
 import { basicDigitalData, PageInfo, Page } from './mocks/CEDDL';
-import { Operator } from '../src/operator';
+import { Operator, OperatorOptions } from '../src/operator';
 import { DataLayerDetail, PropertyDetail } from '../src/event';
 
-class EchoOperator extends Operator {
+class EchoOperator implements Operator {
+  options: OperatorOptions = {
+    name: 'echo',
+    index: 0,
+    specification: {
+      index: { required: true, type: 'number' },
+    },
+  };
+
   constructor(private seen: any[]) {
-    super({ name: 'echo', index: 0 });
+    // sets this.seen
   }
 
   handleData(data: any[]): any[] | null {
-    this.seen.push(data[this.index]);
+    this.seen.push(data[this.options.index!]);
     return data;
   }
 
+  /* eslint-disable class-methods-use-this */
   validate() {
-    throw new Error(`${this.name} validate not implemented`);
+
   }
 }
 
-class GetterOperator extends Operator {
+class GetterOperator implements Operator {
+  options: OperatorOptions = {
+    name: 'getter',
+    index: 0,
+    specification: {
+      index: { required: true, type: 'number' },
+    },
+  };
+
   constructor(private property: string, private seen: any[]) {
-    super({ name: 'getter', index: 0 });
+    // sets this.property and this.seen
   }
 
   handleData(data: any[]): any[] | null {
-    this.seen.push(data[this.index][this.property]);
-    return [data[this.index][this.property]];
+    this.seen.push(data[this.options.index!][this.property]);
+    return [data[this.options.index!][this.property]];
   }
 
+  /* eslint-disable class-methods-use-this */
   validate() {
-    throw new Error(`${this.name} validate not implemented`);
+
   }
 }
 
-class NullOperator extends Operator {
-  constructor() {
-    super({ name: 'null' });
-  }
+class NullOperator implements Operator {
+  options: OperatorOptions = {
+    name: 'null',
+  };
 
   // eslint-disable-next-line class-methods-use-this
   handleData(): any[] | null {
@@ -49,21 +67,22 @@ class NullOperator extends Operator {
   }
 
   validate() {
-    throw new Error(`${this.name} validate not implemented`);
+
   }
 }
 
-class ThrowOperator extends Operator {
-  constructor() {
-    super({ name: 'throw' });
-  }
+class ThrowOperator implements Operator {
+  options: OperatorOptions = {
+    name: 'throw',
+  };
 
   handleData(): any[] | null {
-    throw new Error(`${this.name} data processing error`);
+    throw new Error(`${this.options.name} data processing error`);
   }
 
+  /* eslint-disable class-methods-use-this */
   validate() {
-    throw new Error(`${this.name} validate not implemented`);
+
   }
 }
 

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -15,7 +15,7 @@ class EchoOperatorOptions implements OperatorOptions {
   index = 0;
 }
 
-class EchoOperator extends Operator<EchoOperatorOptions> {
+class EchoOperator extends Operator {
   constructor(private seen: any[]) {
     super(new EchoOperatorOptions());
   }
@@ -36,7 +36,7 @@ class GetterOperatorOptions implements OperatorOptions {
   index = 0;
 }
 
-class GetterOperator extends Operator<GetterOperatorOptions> {
+class GetterOperator extends Operator {
   constructor(private property: string, private seen: any[]) {
     super(new GetterOperatorOptions());
   }
@@ -55,7 +55,7 @@ class NullOperatorOptions implements OperatorOptions {
   name = 'null';
 }
 
-class NullOperator extends Operator<NullOperatorOptions> {
+class NullOperator extends Operator {
   constructor() {
     super(new NullOperatorOptions());
   }
@@ -74,7 +74,7 @@ class ThrowOperatorOptions implements OperatorOptions {
   name = 'throw';
 }
 
-class ThrowOperator extends Operator<ThrowOperatorOptions> {
+class ThrowOperator extends Operator {
   constructor() {
     super(new ThrowOperatorOptions());
   }

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -103,10 +103,6 @@ describe('DataLayerObserver unit tests', () => {
     expectNoCalls(globalMock.console, 'log');
   });
 
-  it('a missing data layer should be retried and fail gracefully', () => {
-
-  });
-
   it('it should allow custom operators to be registered', () => {
     const observer = new DataLayerObserver();
 
@@ -176,10 +172,6 @@ describe('DataLayerObserver unit tests', () => {
     expect(cart).to.eq(globalMock.digitalData.cart);
 
     expectNoCalls(globalMock.console, 'log');
-  });
-
-  it('rule validation can be enabled', () => {
-
   });
 
   it('rules can be previewed before making them live', () => {

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -6,7 +6,7 @@ import { basicDigitalData, CEDDL } from './mocks/CEDDL';
 import Console from './mocks/console';
 import FullStory from './mocks/fullstory-recording';
 import { expectParams, expectNoCalls } from './utils/mocha';
-import { Operator, OperatorOptions } from '../src/operator';
+import { Operator, OperatorOptions, OperatorValidationError } from '../src/operator';
 import { FunctionOperator } from '../src/operators';
 
 class EchoOperatorOptions implements OperatorOptions {
@@ -19,7 +19,7 @@ class EchoOperator extends Operator<EchoOperatorOptions> {
   }
 
   validate() {
-    throw new Error(`${this.name} is not valid`);
+    super.throwValidationError('prop', OperatorValidationError.MISSING, 'this is expected');
   }
 }
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -14,7 +14,7 @@ class EchoOperatorOptions implements OperatorOptions {
   name = 'echo';
 }
 
-class EchoOperator extends Operator<EchoOperatorOptions> {
+class EchoOperator extends Operator {
   // eslint-disable-next-line class-methods-use-this
   handleData(data: any[]): any[] | null {
     return data;
@@ -113,13 +113,12 @@ describe('DataLayerObserver unit tests', () => {
   it('it should allow custom operators to be registered', () => {
     const observer = new DataLayerObserver();
 
-    // @ts-ignore TODO (van) how to typecheck this
     observer.registerOperator('echo', EchoOperator);
   });
 
   it('it should not register operators with the same name', () => {
     const observer = new DataLayerObserver();
-    // @ts-ignore TODO (van) how to typecheck this
+
     expect(() => { observer.registerOperator('function', FunctionOperator); }).to.throw();
   });
 
@@ -147,7 +146,7 @@ describe('DataLayerObserver unit tests', () => {
     });
 
     expect(observer.handlers.length).to.eq(1);
-    // @ts-ignore TODO (van) how to typecheck this
+
     observer.registerOperator('echo', EchoOperator);
 
     expect(() => {

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { expect } from 'chai';
 import 'mocha';
 
@@ -14,6 +15,7 @@ class EchoOperatorOptions implements OperatorOptions {
 }
 
 class EchoOperator extends Operator<EchoOperatorOptions> {
+  // eslint-disable-next-line class-methods-use-this
   handleData(data: any[]): any[] | null {
     return data;
   }
@@ -34,7 +36,6 @@ interface GlobalMock {
 let globalMock: GlobalMock;
 
 describe('DataLayerObserver unit tests', () => {
-
   beforeEach(() => {
     (globalThis as any).digitalData = basicDigitalData;
     (globalThis as any).console = new Console();
@@ -56,7 +57,7 @@ describe('DataLayerObserver unit tests', () => {
 
   it('it should automatically parse config rules', () => {
     const observer = new DataLayerObserver({
-      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }]
+      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }],
     });
     expect(observer.handlers.length).to.eq(1);
   });
@@ -64,7 +65,7 @@ describe('DataLayerObserver unit tests', () => {
   it('rules without a source and destination are invalid', () => {
     const observer = new DataLayerObserver({
       // @ts-ignore
-      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }]
+      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }],
     });
     expect(observer.handlers.length).to.eq(0);
   });
@@ -72,13 +73,15 @@ describe('DataLayerObserver unit tests', () => {
   it('it should read a data layer on-load for all rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       readOnLoad: true,
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
         { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [productInfo] = expectParams(globalMock.console, 'log');
     expect(productInfo).to.eq(globalMock.digitalData.product[0].productInfo);
@@ -90,12 +93,16 @@ describe('DataLayerObserver unit tests', () => {
   it('it should read a data layer on-load for specific rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       rules: [
-        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true },
+        {
+          source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true,
+        },
         { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [pageInfo] = expectParams(globalMock.console, 'log');
     expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
@@ -113,19 +120,19 @@ describe('DataLayerObserver unit tests', () => {
   it('it should not register operators with the same name', () => {
     const observer = new DataLayerObserver();
     // @ts-ignore TODO (van) how to typecheck this
-    expect(() => { observer.registerOperator('function', FunctionOperator) }).to.throw();
+    expect(() => { observer.registerOperator('function', FunctionOperator); }).to.throw();
   });
 
   it('unknown operators should error and remove the handler', () => {
     const observer = new DataLayerObserver({
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
 
     expect(() => {
       observer.addOperator(observer.handlers[0],
-        new EchoOperatorOptions())
+        new EchoOperatorOptions());
     }).to.throw();
 
     expect(observer.handlers.length).to.eq(0);
@@ -136,7 +143,7 @@ describe('DataLayerObserver unit tests', () => {
       validateRules: true,
       rules: [
         { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
-      ]
+      ],
     });
 
     expect(observer.handlers.length).to.eq(1);
@@ -145,7 +152,7 @@ describe('DataLayerObserver unit tests', () => {
 
     expect(() => {
       observer.addOperator(observer.handlers[0],
-        new EchoOperatorOptions())
+        new EchoOperatorOptions());
     }).to.throw();
 
     expect(observer.handlers.length).to.eq(0);
@@ -154,16 +161,19 @@ describe('DataLayerObserver unit tests', () => {
   it('only valid pages should process a rule', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    const urlValidator = (url: string | undefined) =>
-      url ? RegExp(url).test('https://www.fullstory.com/cart') : true;
+    const urlValidator = (url: string | undefined) => (url ? RegExp(url).test('https://www.fullstory.com/cart') : true);
 
     const observer = new DataLayerObserver({
       readOnLoad: true,
       urlValidator,
       rules: [
-        { source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$' },
-        { source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$' },
-      ]
+        {
+          source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$',
+        },
+        {
+          source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$',
+        },
+      ],
     });
 
     expect(observer.handlers.length).to.eq(1);
@@ -178,7 +188,7 @@ describe('DataLayerObserver unit tests', () => {
     expectNoCalls(globalMock.console, 'log');
     expectNoCalls(globalMock.FS, 'setUserVars');
 
-    new DataLayerObserver({
+    const observer = new DataLayerObserver({
       previewMode: true,
       previewDestination: 'console.debug', // NOTE the default is console.log
       readOnLoad: true,
@@ -186,15 +196,16 @@ describe('DataLayerObserver unit tests', () => {
         {
           source: 'digitalData.user.profile[0].profileInfo',
           operators: [],
-          destination: 'FS.setUserVars'
+          destination: 'FS.setUserVars',
         },
-      ]
+      ],
     });
+
+    expect(observer).to.not.be.undefined;
 
     const [profileInfo] = expectParams(globalMock.console, 'debug');
     expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
 
     expectNoCalls(globalMock.FS, 'setUserVars');
   });
-
 });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -143,6 +143,7 @@ describe('DataLayerObserver unit tests', () => {
       ]
     });
 
+    expect(observer.handlers.length).to.eq(1);
     // @ts-ignore TODO (van) how to typecheck this
     observer.registerOperator('echo', EchoOperator);
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -1,0 +1,207 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { DataLayerObserver } from '../src/observer';
+import { basicDigitalData, CEDDL } from './mocks/CEDDL';
+import Console from './mocks/console';
+import FullStory from './mocks/fullstory-recording';
+import { expectParams, expectNoCalls } from './utils/mocha';
+import { Operator, OperatorOptions } from '../src/operator';
+import { FunctionOperator } from '../src/operators';
+
+class EchoOperatorOptions implements OperatorOptions {
+  name = 'echo';
+}
+
+class EchoOperator extends Operator<EchoOperatorOptions> {
+  handleData(data: any[]): any[] | null {
+    return data;
+  }
+
+  validate() {
+    throw new Error(`${this.name} is not valid`);
+  }
+}
+
+const originalConsole = console;
+
+interface GlobalMock {
+  digitalData: CEDDL,
+  FS: FullStory
+  console: Console,
+}
+
+let globalMock: GlobalMock;
+
+describe('DataLayerObserver unit tests', () => {
+
+  beforeEach(() => {
+    (globalThis as any).digitalData = basicDigitalData;
+    (globalThis as any).console = new Console();
+    (globalThis as any).FS = new FullStory();
+    globalMock = globalThis as any;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).digitalData;
+    delete (globalThis as any).FS;
+    (globalThis as any).console = originalConsole;
+  });
+
+  it('it should initialize with defaults', () => {
+    const observer = new DataLayerObserver();
+    expect(observer).to.not.be.undefined;
+    expect(observer).to.not.be.null;
+  });
+
+  it('it should automatically parse config rules', () => {
+    const observer = new DataLayerObserver({
+      rules: [{ source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' }]
+    });
+    expect(observer.handlers.length).to.eq(1);
+  });
+
+  it('rules without a source and destination are invalid', () => {
+    const observer = new DataLayerObserver({
+      // @ts-ignore
+      rules: [{ operators: [], destination: 'console.log' }, { source: 'digitalData.page.pageInfo', operators: [] }]
+    });
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('it should read a data layer on-load for all rules', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    new DataLayerObserver({
+      readOnLoad: true,
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+        { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    const [productInfo] = expectParams(globalMock.console, 'log');
+    expect(productInfo).to.eq(globalMock.digitalData.product[0].productInfo);
+
+    const [pageInfo] = expectParams(globalMock.console, 'log');
+    expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
+  });
+
+  it('it should read a data layer on-load for specific rules', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    new DataLayerObserver({
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', readOnLoad: true },
+        { source: 'digitalData.product[0].productInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    const [pageInfo] = expectParams(globalMock.console, 'log');
+    expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
+
+    expectNoCalls(globalMock.console, 'log');
+  });
+
+  it('a missing data layer should be retried and fail gracefully', () => {
+
+  });
+
+  it('it should allow custom operators to be registered', () => {
+    const observer = new DataLayerObserver();
+
+    // @ts-ignore TODO (van) how to typecheck this
+    observer.registerOperator('echo', EchoOperator);
+  });
+
+  it('it should not register operators with the same name', () => {
+    const observer = new DataLayerObserver();
+    // @ts-ignore TODO (van) how to typecheck this
+    expect(() => { observer.registerOperator('function', FunctionOperator) }).to.throw();
+  });
+
+  it('unknown operators should error and remove the handler', () => {
+    const observer = new DataLayerObserver({
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    expect(() => {
+      observer.addOperator(observer.handlers[0],
+        new EchoOperatorOptions())
+    }).to.throw();
+
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('invalid operators should error and remove the handler', () => {
+    const observer = new DataLayerObserver({
+      validateRules: true,
+      rules: [
+        { source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log' },
+      ]
+    });
+
+    // @ts-ignore TODO (van) how to typecheck this
+    observer.registerOperator('echo', EchoOperator);
+
+    expect(() => {
+      observer.addOperator(observer.handlers[0],
+        new EchoOperatorOptions())
+    }).to.throw();
+
+    expect(observer.handlers.length).to.eq(0);
+  });
+
+  it('only valid pages should process a rule', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    const urlValidator = (url: string | undefined) =>
+      url ? RegExp(url).test('https://www.fullstory.com/cart') : true;
+
+    const observer = new DataLayerObserver({
+      readOnLoad: true,
+      urlValidator,
+      rules: [
+        { source: 'digitalData.transaction', operators: [], destination: 'console.log', url: '/checkout$' },
+        { source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$' },
+      ]
+    });
+
+    expect(observer.handlers.length).to.eq(1);
+
+    const [cart] = expectParams(globalMock.console, 'log');
+    expect(cart).to.eq(globalMock.digitalData.cart);
+
+    expectNoCalls(globalMock.console, 'log');
+  });
+
+  it('rule validation can be enabled', () => {
+
+  });
+
+  it('rules can be previewed before making them live', () => {
+    expectNoCalls(globalMock.console, 'log');
+    expectNoCalls(globalMock.FS, 'setUserVars');
+
+    new DataLayerObserver({
+      previewMode: true,
+      previewDestination: 'console.debug', // NOTE the default is console.log
+      readOnLoad: true,
+      rules: [
+        {
+          source: 'digitalData.user.profile[0].profileInfo',
+          operators: [],
+          destination: 'FS.setUserVars'
+        },
+      ]
+    });
+
+    const [profileInfo] = expectParams(globalMock.console, 'debug');
+    expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
+
+    expectNoCalls(globalMock.FS, 'setUserVars');
+  });
+
+});

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import Console from './mocks/console';
+import { FunctionOperator } from '../src/operators';
+import { expectParams, expectNoCalls } from './utils/mocha';
+
+const originalConsole = globalThis.console;
+const console = new Console();
+
+class ClosureConsole {
+  constructor(private message: string) {
+    // use constructor params
+  }
+
+  log() {
+    console.log(this.message);
+  }
+}
+
+describe('logger unit tests', () => {
+
+  beforeEach(() => {
+    (globalThis as any).console = console;
+    (globalThis as any).testClosure = new ClosureConsole('Hello World')
+  });
+
+  afterEach(() => {
+    (globalThis as any) = originalConsole;
+    delete (globalThis as any).testClosure;
+  });
+
+  it('it should validate options', () => {
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'console.log'
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () =>
+        console.log('Hello World')
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'testClosure.log', thisArg: 'testClosure'
+    }).validate()).to.not.throw();
+
+    // @ts-ignore
+    expect(() => new FunctionOperator({ name: 'function', func: 1234 }).validate()).to.throw();
+    // @ts-ignore
+    expect(() => new FunctionOperator({ name: 'function' }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      // @ts-ignore
+      name: 'function', func: 'testClosure.log', thisArg: 1234
+    }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure'
+    }).validate()).to.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'testClosure.log', thisArg: globalThis
+    }).validate()).to.throw();
+  });
+
+  it('it should call a function using string path', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: 'console.log' });
+    operator.handleData(['Hello World']);
+
+    const [hello] = expectParams(console, 'log');
+    expect(hello).to.eq('Hello World');
+  });
+
+  it('it should call a function (string-path) with proper this context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: 'testClosure.log', thisArg: 'testClosure' });
+    operator.handleData([]);
+
+    const [log] = expectParams(console, 'log');
+    expect(log).to.eq('Hello World');
+  });
+
+  it('it should call a function using native function', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({ name: 'function', func: console.debug });
+    operator.handleData(['Hello World']);
+
+    const [debug] = expectParams(console, 'debug');
+    expect(debug).to.eq('Hello World');
+  });
+
+  it('it should call a function (native) with proper this context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({
+      name: 'function', func: (globalThis as any).testClosure.log,
+      thisArg: (globalThis as any).testClosure
+    });
+    operator.handleData([]);
+
+    const [log] = expectParams(console, 'log');
+    expect(log).to.eq('Hello World');
+  });
+
+  it('it should not call a function (native) with unsupported context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({
+      // @ts-ignore
+      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345
+    });
+    expect(() => operator.handleData([])).to.throw();
+
+    expectNoCalls(console, 'log');
+  });
+
+  it('it should return null for invalid functions', () => {
+    // @ts-ignore
+    const operator = new FunctionOperator({ name: 'function', func: 1234 });
+    const data = operator.handleData(['Hello World']);
+
+    expect(data).to.be.null;
+  });
+
+});

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -47,6 +47,14 @@ describe('logger unit tests', () => {
       name: 'function', func: 'testClosure.log', thisArg: 'testClosure',
     }).validate()).to.not.throw();
 
+    expect(() => new FunctionOperator({
+      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure',
+    }).validate()).to.not.throw();
+
+    expect(() => new FunctionOperator({
+      name: 'function', func: 'testClosure.log', thisArg: globalThis,
+    }).validate()).to.not.throw();
+
     // @ts-ignore
     expect(() => new FunctionOperator({ name: 'function', func: 1234 }).validate()).to.throw();
     // @ts-ignore
@@ -55,14 +63,6 @@ describe('logger unit tests', () => {
     expect(() => new FunctionOperator({
       // @ts-ignore
       name: 'function', func: 'testClosure.log', thisArg: 1234,
-    }).validate()).to.throw();
-
-    expect(() => new FunctionOperator({
-      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure',
-    }).validate()).to.throw();
-
-    expect(() => new FunctionOperator({
-      name: 'function', func: 'testClosure.log', thisArg: globalThis,
     }).validate()).to.throw();
   });
 

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -122,6 +122,17 @@ describe('logger unit tests', () => {
     expectNoCalls(console, 'log');
   });
 
+  it('it should not call a function with missing context', () => {
+    expectNoCalls(console, 'log');
+
+    const operator = new FunctionOperator({
+      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 'unknownThis',
+    });
+    expect(() => operator.handleData([])).to.throw();
+
+    expectNoCalls(console, 'log');
+  });
+
   it('it should return null for invalid functions', () => {
     // @ts-ignore
     const operator = new FunctionOperator({ name: 'function', func: 1234 });

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -19,10 +19,9 @@ class ClosureConsole {
 }
 
 describe('logger unit tests', () => {
-
   beforeEach(() => {
     (globalThis as any).console = console;
-    (globalThis as any).testClosure = new ClosureConsole('Hello World')
+    (globalThis as any).testClosure = new ClosureConsole('Hello World');
   });
 
   afterEach(() => {
@@ -32,20 +31,20 @@ describe('logger unit tests', () => {
 
   it('it should validate options', () => {
     expect(() => new FunctionOperator({
-      name: 'function', func: 'console.log'
+      name: 'function', func: 'console.log',
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () =>
-        console.log('Hello World')
+      name: 'function',
+      func: () => console.log('Hello World'),
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis
+      name: 'function', func: () => console.log('Hello World'), thisArg: globalThis,
     }).validate()).to.not.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: 'testClosure.log', thisArg: 'testClosure'
+      name: 'function', func: 'testClosure.log', thisArg: 'testClosure',
     }).validate()).to.not.throw();
 
     // @ts-ignore
@@ -55,15 +54,15 @@ describe('logger unit tests', () => {
 
     expect(() => new FunctionOperator({
       // @ts-ignore
-      name: 'function', func: 'testClosure.log', thisArg: 1234
+      name: 'function', func: 'testClosure.log', thisArg: 1234,
     }).validate()).to.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure'
+      name: 'function', func: () => console.log('Hello World'), thisArg: 'testClosure',
     }).validate()).to.throw();
 
     expect(() => new FunctionOperator({
-      name: 'function', func: 'testClosure.log', thisArg: globalThis
+      name: 'function', func: 'testClosure.log', thisArg: globalThis,
     }).validate()).to.throw();
   });
 
@@ -101,8 +100,9 @@ describe('logger unit tests', () => {
     expectNoCalls(console, 'log');
 
     const operator = new FunctionOperator({
-      name: 'function', func: (globalThis as any).testClosure.log,
-      thisArg: (globalThis as any).testClosure
+      name: 'function',
+      func: (globalThis as any).testClosure.log,
+      thisArg: (globalThis as any).testClosure,
     });
     operator.handleData([]);
 
@@ -115,7 +115,7 @@ describe('logger unit tests', () => {
 
     const operator = new FunctionOperator({
       // @ts-ignore
-      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345
+      name: 'function', func: (globalThis as any).testClosure.log, thisArg: 12345,
     });
     expect(() => operator.handleData([])).to.throw();
 
@@ -129,5 +129,4 @@ describe('logger unit tests', () => {
 
     expect(data).to.be.null;
   });
-
 });

--- a/test/operator.spec.ts
+++ b/test/operator.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { OperatorFactory } from '../src/factory';
+import { FunctionOperatorOptions } from '../src/operators';
+import {
+  Operator, OperatorOptions, OperatorValidator, OperatorSpecification,
+} from '../src/operator';
+
+class MockOperator implements Operator {
+  options: OperatorOptions = {
+    name: 'mock',
+    requiredString: 'Hello World',
+    requiredNumber: 1,
+    requiredBoolean: true,
+    requiredFunction: () => console.log('Hello World'), // eslint-disable-line
+    requiredObject: {},
+    optionalString: 'Goodbye World',
+  };
+
+  specification: OperatorSpecification = {
+    requiredString: { required: true, type: 'string', dependencies: ['requiredFunction', 'requiredObject'] },
+    requiredNumber: { required: true, type: 'NumBer' },
+    requiredBoolean: { required: true, type: 'boolean' },
+    requiredFunction: { required: true, type: ['string', 'FUNCTION'] },
+    requiredObject: { required: true, type: 'Object' },
+    optionalString: { required: false, type: 'string' },
+  };
+
+  /* eslint-disable-next-line class-methods-use-this */
+  handleData(data: any[]): any[] | null {
+    return data;
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(this.specification);
+  }
+}
+
+describe('operator unit tests', () => {
+  it('operators can be created from the factory', () => {
+    const functionOptions = {
+      name: 'function',
+      func: 'console.log',
+    } as FunctionOperatorOptions;
+
+    const operator = OperatorFactory.create('function', functionOptions);
+    expect(operator).to.not.be.undefined;
+  });
+
+  it('unknown operators should throw an error', () => {
+    // @ts-ignore
+    expect(() => OperatorFactory.create('unknown', {})).to.throw();
+  });
+
+  it('operators should have a name', () => {
+    const operator = new MockOperator();
+    delete operator.options.name;
+    expect(() => operator.validate()).to.throw();
+  });
+
+  it('operators should be validated per specification', () => {
+    const operator = new MockOperator();
+    expect(() => operator.validate()).to.not.throw();
+
+    delete operator.options.requiredObject;
+    expect(() => operator.validate()).to.throw();
+  });
+
+  it('operators should error if additional unknown options are found', () => {
+    const operator = new MockOperator();
+    operator.options.unknown = true;
+    expect(() => operator.validate()).to.throw();
+  });
+});


### PR DESCRIPTION
I took @patrick-fs PR and riffed on it.  I've moved the `Operator` away from an abstract class to a basic interface.

```
export interface Operator {
  options: OperatorOptions;
  handleData(data: any[]): any[] | null;
  validate(): void;
}
```

To make it so that `DataLayerObserver` can deal with arbitrary metadata coming from `DataLayerRule`, an `OperatorFactory` was created.  The factory internalizes the creation of an `Operator` to it versus doing it in the `DataLayerObserver`.  The factory will make for a cleaner separation and way to organize operators we provide.  To support some of the type checking, we'll have to maintain two union typedefs as we build more operators. 

```
export type BuiltinOperator = typeof FunctionOperator | typeof SomeFutureOperator;
export type BuiltinOptions = FunctionOperatorOptions | typeof SomeFutureOperatorOptions;
```

Since a `DataLayerRule` is given to us by users and could contain errors, I've created a more robust `OperatorValidator` for runtime validation. This has a few convenience methods but the main one is `validate`, which accepts an `OperatorSpecification`.  This gives us a JSONy way to declare the expected options at runtime and prevents ugly if/else blocks.  Operator implementors can then just use:

```
const validator = new OperatorValidator(this.options);
validator.validate(FunctionOperator.specification);
```

The `specification` itself is internal to the `Operator`.  I don't think there's a need to externalize it, but we could.  It's also static since it's shared across instances.  The `Operator` interface doesn't force you to supply a specification, but it could.  The main rationale being that validation is possibly more than a specification and `Operator` implementors are free to roll their own `validate` method.

All current tests are passing.  I'll create another spec to cover the validator features to bump up the coverage if we approve this.