### PR TITLE
Add debug flag in observer

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,8 +13,6 @@ export default class DataHandler {
 
   readonly target: any;
 
-  debug = false; // NOTE debugging is done at a rule level, which is why Logger is not used
-
   // external tooling can override the console debugger
   debugger = (message: string, data?: any, indent?: string) => console.debug(
     data ? `${indent}${message}\n${indent}${JSON.stringify(data)}` : `${indent}${message}`,
@@ -23,9 +21,10 @@ export default class DataHandler {
   /**
    * Creates a DataHandler.
    * @param path the string path to the data layer (used to identify which data layer emitted data)
+   * @param debug true optionally enables debugging data transformation (defaults to console.debug)
    * @throws will throw an error if the data layer is not found (i.e. undefined or null)
    */
-  constructor(private readonly path: string) {
+  constructor(private readonly path: string, public debug = false) {
     this.target = select(path);
 
     // guards against trying to register an observer on a non-existent datalayer

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -34,11 +34,13 @@ export interface DataLayerConfig {
  *  source: data layer target using selector syntax
  *  destination: destination function using selector syntax
  * Optional
+ *  debug: true if the rule should print debug for each Operator transformation
  *  operators: list of OperatorOptions to transform data before a destination
  *  readOnLoad: rule-specific readOnLoad (see DataLayerConfig readOnLoad)
  *  url: regular expression used to enable the rule when the page URL matches
  */
 export interface DataLayerRule {
+  debug?: boolean;
   source: string;
   operators?: OperatorOptions[];
   destination: string;
@@ -147,6 +149,7 @@ export class DataLayerObserver {
     const { beforeDestination, previewMode, readOnLoad: globalReadOnLoad } = this.config;
 
     const {
+      debug,
       source,
       operators = [],
       destination,
@@ -169,6 +172,7 @@ export class DataLayerObserver {
 
     try {
       const handler = this.addHandler(source);
+      handler.debug = !!debug;
 
       try {
         // sequentially add the operators to the handler

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -4,9 +4,14 @@ import 'mocha';
 
 import DataHandler from '../src/handler';
 
+import Console from './mocks/console';
 import { basicDigitalData, PageInfo, Page } from './mocks/CEDDL';
 import { Operator, OperatorOptions } from '../src/operator';
 import { DataLayerDetail, PropertyDetail } from '../src/event';
+import { expectNoCalls, expectParams } from './utils/mocha';
+
+const originalConsole = globalThis.console;
+const console = new Console();
 
 class EchoOperator implements Operator {
   options: OperatorOptions = {
@@ -87,12 +92,15 @@ class ThrowOperator implements Operator {
 }
 
 describe('DataHandler unit tests', () => {
-  before(() => {
+  beforeEach(() => {
     (globalThis as any).digitalData = basicDigitalData;
+    (globalThis as any).console = console;
+
   });
 
-  after(() => {
+  afterEach(() => {
     delete (globalThis as any).digitalData;
+    (globalThis as any).console = originalConsole;
   });
 
   it('data handlers should find a data layer for a given target and property', () => {
@@ -137,7 +145,9 @@ describe('DataHandler unit tests', () => {
     expect((seen[1] as PageInfo).pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
   });
 
-  it('debug should print operator transformations', () => {
+  it('debug should print operator transformations to console.debug', () => {
+    expectNoCalls(console, 'debug');
+
     const handler = new DataHandler('digitalData.page');
     handler.debug = true;
 
@@ -149,8 +159,36 @@ describe('DataHandler unit tests', () => {
     handler.push(echo, getter);
     handler.fireEvent();
 
+    // NOTE the call queues will be expected in reverse order
+    const [exit] = expectParams(console, 'debug');
+    expect(exit).to.contain(`digitalData.page handleData exit\n[${JSON.stringify(basicDigitalData.page.pageInfo)}]`);
+
+    const [getterOutput] = expectParams(console, 'debug');
+    expect(getterOutput).to.contain(`  [1] getter output\n  [${JSON.stringify(basicDigitalData.page.pageInfo)}]`);
+
+    const [echoOutput] = expectParams(console, 'debug');
+    expect(echoOutput).to.contain(`  [0] echo output\n  [${JSON.stringify(basicDigitalData.page)}]`);
+
+    const [entry] = expectParams(console, 'debug');
+    expect(entry).to.contain(`digitalData.page handleData entry\n[${JSON.stringify(basicDigitalData.page)}]`);
+
     expect((seen[0] as Page).pageInfo.pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
     expect((seen[1] as PageInfo).pageID).to.eq(basicDigitalData.page.pageInfo.pageID);
+  });
+
+  it('debug output function can be configured', () => {
+    const debugMessages: string[] = [];
+
+    const handler = new DataHandler('digitalData.page');
+    handler.debug = true;
+    handler.debugger = (message: string, data?: any, indent?: string) => debugMessages.push(message);
+
+    const getter = new GetterOperator('pageInfo', []);
+
+    handler.push(getter);
+    handler.fireEvent();
+
+    expect(debugMessages.length).to.eq(3);
   });
 
   it('returning null in an operator should halt data handling', () => {

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -95,7 +95,6 @@ describe('DataHandler unit tests', () => {
   beforeEach(() => {
     (globalThis as any).digitalData = basicDigitalData;
     (globalThis as any).console = console;
-
   });
 
   afterEach(() => {
@@ -181,7 +180,7 @@ describe('DataHandler unit tests', () => {
 
     const handler = new DataHandler('digitalData.page');
     handler.debug = true;
-    handler.debugger = (message: string, data?: any, indent?: string) => debugMessages.push(message);
+    handler.debugger = (message: string) => debugMessages.push(message);
 
     const getter = new GetterOperator('pageInfo', []);
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -250,8 +250,19 @@ describe('DataLayerObserver unit tests', () => {
     expect(observer).to.not.be.undefined;
 
     observer.registerOperator('toUpper', new UppercaseOperator());
-    observer.processRule({ source: 'digitalData.page.pageInfo', operators: [{ name: 'toUpper' }], destination: 'console.log', debug: true });
-    observer.processRule({ source: 'digitalData.product[0].productInfo', operators: [{ name: 'toUpper' }], destination: 'console.log' });
+    observer.processRule({
+      source: 'digitalData.page.pageInfo',
+      operators: [
+        { name: 'toUpper' }],
+      destination: 'console.log',
+      debug: true,
+    });
+    observer.processRule({
+      source: 'digitalData.product[0].productInfo',
+      operators: [
+        { name: 'toUpper' }],
+      destination: 'console.log',
+    });
 
     expect(observer.handlers.length).to.eq(2);
     observer.handlers[0].fireEvent();


### PR DESCRIPTION
This PR allows end users to configure debug for specific rules.  It also adds more robust testing that rules are printed to console.debug using the mock console.  This supports acceptance criteria in CH119003.