### PR TITLE
Add flatten operator

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,4 +1,6 @@
-import { FunctionOperator, FunctionOperatorOptions, FlattenOperator, FlattenOperatorOptions } from './operators';
+import {
+  FunctionOperator, FunctionOperatorOptions, FlattenOperator, FlattenOperatorOptions,
+} from './operators';
 import { Operator } from './operator';
 
 /**

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,15 +1,15 @@
-import { FunctionOperator, FunctionOperatorOptions } from './operators';
+import { FunctionOperator, FunctionOperatorOptions, FlattenOperator, FlattenOperatorOptions } from './operators';
 import { Operator } from './operator';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof FunctionOperator;
+export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = FunctionOperatorOptions;
+export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -17,6 +17,7 @@ export type BuiltinOptions = FunctionOperatorOptions;
  */
 export class OperatorFactory {
   private static operators: { [key: string]: BuiltinOperator } = {
+    flatten: FlattenOperator,
     function: FunctionOperator,
   };
 
@@ -30,7 +31,7 @@ export class OperatorFactory {
       throw new Error(`Operator ${name} is unknown`);
     }
 
-    return new this.operators[name](options);
+    return new (this.operators[name] as any)(options);
   }
 
   /**

--- a/src/operators/flatten.ts
+++ b/src/operators/flatten.ts
@@ -5,13 +5,13 @@ export interface FlattenOperatorOptions extends OperatorOptions {
 }
 
 export class FlattenOperator implements Operator {
-
   static specification = {
     index: { required: false, type: ['number'] },
     maxDepth: { required: false, type: ['number'] },
   };
 
   readonly index: number;
+
   readonly maxDepth: number;
 
   constructor(public options: FlattenOperatorOptions) {
@@ -27,26 +27,32 @@ export class FlattenOperator implements Operator {
    * @param node a child node to flatten
    */
   flattenHelper(root: any, depth = 0, node?: any) {
-    if (!node) {
+    let targetNode = node;
+    let targetRoot = root;
+
+    if (!targetNode) {
       // first time execution
-      node = root;
-      root = {};
+      targetNode = root;
+      targetRoot = {};
     }
 
-    Object.getOwnPropertyNames(node).forEach(prop => {
-      if (typeof node[prop] === 'object' && node[prop] != null && !Array.isArray(node[prop]) && depth < this.maxDepth + 1) {
-        this.flattenHelper(root, depth + 1, node[prop]);
+    Object.getOwnPropertyNames(targetNode).forEach((prop) => {
+      if (typeof targetNode[prop] === 'object' && targetNode[prop] != null
+        && !Array.isArray(targetNode[prop]) && depth < this.maxDepth + 1) {
+        this.flattenHelper(targetRoot, depth + 1, targetNode[prop]);
       } else {
-        root[prop] = node[prop];
+        targetRoot[prop] = targetNode[prop];
       }
     });
 
-    return root;
+    return targetRoot;
   }
 
   handleData(data: any[]): any[] | null {
-    data[this.index] = this.flattenHelper(data[this.index]);
-    return data;
+    const flattenedData = data;
+    flattenedData[this.index] = this.flattenHelper(flattenedData[this.index]);
+
+    return flattenedData;
   }
 
   validate() {

--- a/src/operators/flatten.ts
+++ b/src/operators/flatten.ts
@@ -1,0 +1,56 @@
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+
+export interface FlattenOperatorOptions extends OperatorOptions {
+
+}
+
+export class FlattenOperator implements Operator {
+
+  static specification = {
+    index: { required: false, type: ['number'] },
+    maxDepth: { required: false, type: ['number'] },
+  };
+
+  readonly index: number;
+  readonly maxDepth: number;
+
+  constructor(public options: FlattenOperatorOptions) {
+    const { index = 0, maxDepth = 10 } = options;
+
+    this.index = index;
+    this.maxDepth = maxDepth;
+  }
+
+  /**
+   * Recursively flattens all properties into an object.
+   * @param root the root object to contain all properties
+   * @param node a child node to flatten
+   */
+  flattenHelper(root: any, depth = 0, node?: any) {
+    if (!node) {
+      // first time execution
+      node = root;
+      root = {};
+    }
+
+    Object.getOwnPropertyNames(node).forEach(prop => {
+      if (typeof node[prop] === 'object' && node[prop] != null && !Array.isArray(node[prop]) && depth < this.maxDepth + 1) {
+        this.flattenHelper(root, depth + 1, node[prop]);
+      } else {
+        root[prop] = node[prop];
+      }
+    });
+
+    return root;
+  }
+
+  handleData(data: any[]): any[] | null {
+    data[this.index] = this.flattenHelper(data[this.index]);
+    return data;
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(FlattenOperator.specification);
+  }
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,1 +1,2 @@
+export * from './flatten';
 export * from './function';

--- a/test/operator-flatten.spec.ts
+++ b/test/operator-flatten.spec.ts
@@ -5,10 +5,9 @@ import { FlattenOperator } from '../src/operators';
 import { basicDigitalData } from './mocks/CEDDL';
 
 describe('flatten operator unit tests', () => {
-
   it('it should validate options', () => {
     expect(() => new FlattenOperator({
-      name: 'flatten'
+      name: 'flatten',
     }).validate()).to.not.throw();
 
     expect(() => new FlattenOperator({
@@ -35,7 +34,7 @@ describe('flatten operator unit tests', () => {
   it('it should not flatten array contents', () => {
     const userProfile = {
       nicknames: ['Jon', 'Johny'],
-      ...basicDigitalData.user.profile[0]
+      ...basicDigitalData.user.profile[0],
     };
     const operator = new FlattenOperator({ name: 'flatten' });
     const [flatUser] = operator.handleData([userProfile])!;
@@ -62,13 +61,13 @@ describe('flatten operator unit tests', () => {
       nicknames: ['Jon', 'Johny'],
       children: {
         junior: {
-          name: 'Jon Jr.'
+          name: 'Jon Jr.',
         },
         tripp: {
-          name: 'Jon III'
-        }
+          name: 'Jon III',
+        },
       },
-      ...basicDigitalData.user.profile[0]
+      ...basicDigitalData.user.profile[0],
     };
     const operator = new FlattenOperator({ name: 'flatten', maxDepth: 1 });
     const [flatUser] = operator.handleData([userProfile])!;
@@ -81,5 +80,4 @@ describe('flatten operator unit tests', () => {
     expect(flatUser!.junior).to.be.undefined;
     expect(flatUser!.tripp).to.be.undefined;
   });
-
 });

--- a/test/operator-flatten.spec.ts
+++ b/test/operator-flatten.spec.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { FlattenOperator } from '../src/operators';
+import { basicDigitalData } from './mocks/CEDDL';
+
+describe('flatten operator unit tests', () => {
+
+  it('it should validate options', () => {
+    expect(() => new FlattenOperator({
+      name: 'flatten'
+    }).validate()).to.not.throw();
+
+    expect(() => new FlattenOperator({
+      name: 'flatten', index: 1,
+    }).validate()).to.not.throw();
+
+    expect(() => new FlattenOperator({
+      name: 'flatten', maxDepth: 3,
+    }).validate()).to.not.throw();
+  });
+
+  it('it should flatten an object', () => {
+    const userProfile = basicDigitalData.user.profile[0];
+    const operator = new FlattenOperator({ name: 'flatten' });
+    const [flatUser] = operator.handleData([userProfile])!;
+
+    expect(flatUser).to.not.be.null;
+    expect(flatUser!.profileID).to.eq(userProfile.profileInfo.profileID);
+    expect(flatUser!.userName).to.eq(userProfile.profileInfo.userName);
+    expect(flatUser!.city).to.eq(userProfile.address.city);
+    expect(flatUser!.stateProvince).to.eq(userProfile.address.stateProvince);
+  });
+
+  it('it should not flatten array contents', () => {
+    const userProfile = {
+      nicknames: ['Jon', 'Johny'],
+      ...basicDigitalData.user.profile[0]
+    };
+    const operator = new FlattenOperator({ name: 'flatten' });
+    const [flatUser] = operator.handleData([userProfile])!;
+
+    expect(flatUser).to.not.be.null;
+    expect(flatUser!.nicknames).to.eq(userProfile.nicknames);
+  });
+
+  it('it should flatten an object at a specific index', () => {
+    const userProfile = basicDigitalData.user.profile[0];
+    const operator = new FlattenOperator({ name: 'flatten', index: 1 });
+    const [profileID, flatUser] = operator.handleData([userProfile.profileInfo.profileID, userProfile])!;
+
+    expect(flatUser).to.not.be.null;
+    expect(profileID).to.not.be.null;
+    expect(flatUser!.profileID).to.eq(userProfile.profileInfo.profileID);
+    expect(flatUser!.userName).to.eq(userProfile.profileInfo.userName);
+    expect(flatUser!.city).to.eq(userProfile.address.city);
+    expect(flatUser!.stateProvince).to.eq(userProfile.address.stateProvince);
+  });
+
+  it('it should flatten an object to a specific depth', () => {
+    const userProfile = {
+      nicknames: ['Jon', 'Johny'],
+      children: {
+        junior: {
+          name: 'Jon Jr.'
+        },
+        tripp: {
+          name: 'Jon III'
+        }
+      },
+      ...basicDigitalData.user.profile[0]
+    };
+    const operator = new FlattenOperator({ name: 'flatten', maxDepth: 1 });
+    const [flatUser] = operator.handleData([userProfile])!;
+
+    expect(flatUser).to.not.be.null;
+    expect(flatUser!.profileID).to.eq(userProfile.profileInfo.profileID);
+    expect(flatUser!.userName).to.eq(userProfile.profileInfo.userName);
+    expect(flatUser!.city).to.eq(userProfile.address.city);
+    expect(flatUser!.stateProvince).to.eq(userProfile.address.stateProvince);
+    expect(flatUser!.junior).to.be.undefined;
+    expect(flatUser!.tripp).to.be.undefined;
+  });
+
+});


### PR DESCRIPTION
The `FlattenOperator` copies nested properties into a top level object.  This is a required step prior to using APIs such as `FS.setUserVars` or `FS.event`.