### PR TITLE
Add  suffix operator

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,17 +1,19 @@
 import {
-  FunctionOperator, FunctionOperatorOptions, FlattenOperator, FlattenOperatorOptions,
+  FunctionOperator, FunctionOperatorOptions,
+  FlattenOperator, FlattenOperatorOptions,
+  SuffixOperator, SuffixOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator;
+export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof SuffixOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions;
+export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | SuffixOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -21,6 +23,7 @@ export class OperatorFactory {
   private static operators: { [key: string]: BuiltinOperator } = {
     flatten: FlattenOperator,
     function: FunctionOperator,
+    suffix: SuffixOperator,
   };
 
   /**

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,2 +1,3 @@
 export * from './flatten';
 export * from './function';
+export * from './suffix';

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -1,0 +1,172 @@
+import { OperatorValidator, OperatorOptions, Operator } from '../operator';
+
+/**
+ * A SuffixedObject is an object that has had FS types appended to properties.
+ */
+export type SuffixedObject = { [key: string]: SuffixableValue | SuffixedObject };
+
+/**
+ * A SuffixableValue is an allowed value for a suffix type.
+ */
+export type SuffixableValue = boolean | number | string | boolean[] | number[] | string[] | object | object[];
+
+/**
+ * Enum of allowed FullStory object suffixes.
+ */
+export enum Suffixes {
+  Bool = '_bool',
+  Bools = '_bools',
+  Date = '_date',
+  Dates = '_dates',
+  Int = '_int',
+  Ints = '_ints',
+  Obj = '_obj',
+  Objs = '_objs',
+  String = '_str',
+  Strings = '_strs',
+  Real = '_real',
+  Reals = '_reals',
+}
+
+export interface SuffixOperatorOptions extends OperatorOptions {
+
+}
+
+/**
+ * SuffixOperator appends FullStory types to an object's properties.
+ */
+export class SuffixOperator implements Operator {
+  static specification = {
+    index: { required: false, type: ['number'] },
+    maxDepth: { required: false, type: ['number'] },
+  };
+
+  readonly index: number;
+
+  readonly maxDepth: number;
+
+  constructor(public options: SuffixOperatorOptions) {
+    const { index = 0, maxDepth = 10 } = options;
+
+    this.index = index;
+    this.maxDepth = maxDepth;
+  }
+
+  /**
+   * Infers the type suffix for a numeric value (i.e. Int or Real).
+   * @param value value property value used to infer type and return suffix
+   */
+  static coerceNumSuffix(value: number): string {
+    // NOTE 1.00 will return _int but you might expect 1.00 as a _real suffix
+    return value % 1 === 0 ? Suffixes.Int : Suffixes.Real;
+  }
+
+  /**
+   * Infers the type suffix needed for FS API objects.
+   * There are 10 valid type suffixes:
+   * _bool, _date, _int, _real, _str, _bools, _dates, _ints, _reals, and _strs.
+   * @param value the object to inspect and return suffix
+   */
+  static coerceSuffix(value: SuffixableValue): string {
+    // arrays are pluralized
+    if (Array.isArray(value)) {
+      if (value.every((v: any) => typeof v === 'string')) {
+        return Suffixes.Strings;
+      }
+
+      if (value.every((v: any) => typeof v === 'boolean')) {
+        return Suffixes.Bools;
+      }
+
+      if (value.every((v: any) => typeof v === 'number')) {
+        // NOTE [1.00, 1.99] is actually _int, _real types respectively
+        // so favor _reals over _ints if the list is mixed
+        return (value as number[]).filter((v: number) => SuffixOperator.coerceNumSuffix(v) === '_real').length === 0
+          ? Suffixes.Ints : Suffixes.Reals;
+      }
+
+      if (value.every((v: any) => v instanceof Date)) {
+        return Suffixes.Dates;
+      }
+
+      if (value.every((v: any) => typeof v === 'object')) {
+        return Suffixes.Objs;
+      }
+
+      // it's an array but doesn't have values that we can support or has multiple types
+      return '';
+    }
+
+    if (value instanceof Date) {
+      return Suffixes.Date;
+    }
+
+    // NOTE this needs to go here because the object check must occur after the Arrays check
+    switch (typeof value) {
+      case 'string':
+        return Suffixes.String;
+      case 'boolean':
+        return Suffixes.Bool;
+      case 'number':
+        return SuffixOperator.coerceNumSuffix(value);
+      case 'object':
+        return Suffixes.Obj;
+      default:
+        // unable to coerce the type, which is expected for function types for example
+        return '';
+    }
+  }
+
+  /**
+   * Maps a given object to an object with FS type suffixes on properties.
+   * If a value can not be suffixed, it will not be included in the resulting object.
+   * @param obj the Object to map
+   * @param maxDepth the maximum number of levels to recursive suffix child objects
+   * @param currentDepth the current depth if recursively suffixing object (this is not intended to be used externally)
+   */
+  mapToSuffix(obj: { [key: string]: any }, currentDepth = 0): SuffixedObject {
+    const suffixedObj: SuffixedObject = {};
+
+    // guard against error condition 'Cannot convert undefined or null to object'
+    if (obj === undefined || obj === null) {
+      return suffixedObj;
+    }
+
+    Object.getOwnPropertyNames(obj).forEach((prop: string) => {
+      const value = obj[prop];
+      const suffix = SuffixOperator.coerceSuffix(value);
+      const suffixedProp = `${prop}${suffix}`;
+
+      // if a suffix exists, it means we support the value
+      if (suffix) {
+        switch (suffix) {
+          case Suffixes.Obj:
+            if (currentDepth < this.maxDepth) {
+              suffixedObj[suffixedProp] = this.mapToSuffix(value, currentDepth + 1);
+            }
+            break;
+          case Suffixes.Objs:
+            if (currentDepth < this.maxDepth) {
+              suffixedObj[suffixedProp] = value.map((item: any) => this.mapToSuffix(item, currentDepth + 1));
+            }
+            break;
+          default:
+            suffixedObj[suffixedProp] = value;
+        }
+      }
+    });
+    return suffixedObj;
+  }
+
+  handleData(data: any[]): any[] | null {
+    const suffixedData = data;
+    suffixedData[this.index] = this.mapToSuffix(suffixedData[this.index]);
+
+    return suffixedData;
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(SuffixOperator.specification);
+  }
+}

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -1,0 +1,238 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import {
+  Suffixes, SuffixedObject, SuffixableValue, SuffixOperator,
+} from '../src/operators/suffix';
+
+const date = new Date();
+
+const testData: any = {
+  id: '130983678493',
+  first_name: 'Daniel',
+  last_name: 'Falco',
+  price: 49.99,
+  quantity: 1,
+  isFeatured: true,
+  listedPages: [true, false, false],
+  created: date,
+  shippingDates: [date, date, date],
+  discountTiers: [1, 2, 3],
+  discountPrices: [45.00, 40.50, 29.99],
+  variants: ['red', 'blue', 'green'],
+  child: {
+    first_name: 'Danny',
+    last_name: 'Falco Jr.',
+    fn: () => { console.log('child object'); }, // eslint-disable-line no-console
+  },
+  grandchildren: [
+    {
+      first_name: 'Danny',
+      last_name: 'Falco III',
+      fn: () => { console.log('grandchild object'); }, // eslint-disable-line no-console
+    },
+    {
+      first_name: 'Danny',
+      last_name: 'Falco IV',
+      fn: () => { console.log('grandchild object'); }, // eslint-disable-line no-console
+    },
+  ],
+};
+
+describe('suffix operator unit test', () => {
+  it('it should validate options', () => {
+    expect(() => new SuffixOperator({
+      name: 'suffix',
+    }).validate()).to.not.throw();
+
+    expect(() => new SuffixOperator({
+      name: 'suffix', index: 1,
+    }).validate()).to.not.throw();
+
+    expect(() => new SuffixOperator({
+      name: 'suffix', maxDepth: 3,
+    }).validate()).to.not.throw();
+  });
+
+  it('it should not suffix undefineds', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([undefined])!;
+
+    expect(suffixedObject).to.not.be.undefined;
+    expect(Object.getOwnPropertyNames(suffixedObject).length).to.eq(0);
+  });
+
+  it('it should suffix all properties in object', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+
+    Object.getOwnPropertyNames(suffixedObject).forEach((prop) => {
+      if (prop !== 'child_obj') {
+        expect(prop).to.contain('_');
+      }
+    });
+
+    Object.getOwnPropertyNames(suffixedObject).forEach((prop) => {
+      expect(prop).to.not.contain('fn');
+    });
+  });
+
+  it('it should suffix child properties in object', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+
+    expect(suffixedObject.child_obj).to.not.be.undefined;
+    Object.getOwnPropertyNames(suffixedObject.child_obj).forEach((prop) => {
+      expect(prop).to.contain('_');
+    });
+  });
+
+  it('it should suffix each obj within an array', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+
+    expect(suffixedObject.grandchildren_objs).to.not.be.undefined;
+    const array: SuffixedObject[] = suffixedObject.grandchildren_objs as SuffixedObject[];
+
+    array.forEach((item) => {
+      Object.getOwnPropertyNames(item).forEach((prop) => {
+        expect(prop).to.contain('_');
+      });
+    });
+  });
+
+  it('it should not copy functions', () => {
+    const fnObj: any = {
+      fn: () => { console.log('root object'); }, // eslint-disable-line no-console
+    };
+
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([fnObj])!;
+    expect(Object.getOwnPropertyNames(suffixedObject).length).to.eq(0);
+  });
+
+  it('it should not copy mixed arrays', () => {
+    const mixed: any = {
+      mixedArray: ['red', 1, 'blue', '2'],
+    };
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const suffixedObject = operator.handleData([mixed])!;
+    expect(Object.getOwnPropertyNames(suffixedObject[0]).length).to.eq(0);
+  });
+
+  it('it should suffix all possible FS types', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+    const suffixedObjectProps = Object.getOwnPropertyNames(suffixedObject);
+
+    Object.keys(Suffixes).forEach((key) => {
+      const suffix = (Suffixes as any)[key];
+      const hasSuffix = suffixedObjectProps.filter((p) => p.indexOf(suffix) > -1) !== undefined;
+      expect(hasSuffix, `Suffix ${suffix} not found`).to.be.true;
+    });
+  });
+
+  it('it should suffix types correctly', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+
+    expect(suffixedObject).to.haveOwnProperty('id_str');
+    expect(suffixedObject).to.haveOwnProperty('price_real');
+    expect(suffixedObject).to.haveOwnProperty('quantity_int');
+    expect(suffixedObject).to.haveOwnProperty('isFeatured_bool');
+    expect(suffixedObject).to.haveOwnProperty('listedPages_bools');
+    expect(suffixedObject).to.haveOwnProperty('created_date');
+    expect(suffixedObject).to.haveOwnProperty('shippingDates_dates');
+    expect(suffixedObject).to.haveOwnProperty('discountTiers_ints');
+    expect(suffixedObject).to.haveOwnProperty('discountPrices_reals');
+    expect(suffixedObject).to.haveOwnProperty('variants_strs');
+  });
+
+  it('it should re-assign values correctly', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([testData])!;
+
+    Object.getOwnPropertyNames(suffixedObject).forEach((prop) => {
+      if (prop !== 'child_obj' && prop !== 'grandchildren_objs') {
+        expect(suffixedObject[prop], `${prop} does not have the same value`).to.eq(
+          testData[prop.substring(0, prop.lastIndexOf('_'))],
+        );
+      }
+    });
+
+    const child = suffixedObject.child_obj as SuffixedObject;
+    Object.getOwnPropertyNames(child).forEach((prop) => {
+      expect(child[prop], `${prop} does not have the same value`).to.eq(
+        testData.child[prop.substring(0, prop.lastIndexOf('_'))],
+      );
+    });
+
+    expect((suffixedObject.grandchildren_objs as SuffixableValue[]).length).to.eq(testData.grandchildren.length);
+  });
+
+  it('it should not suffix objects beyond a desired depth', () => {
+    const nestedObj: any = {
+      1: {
+        level: '1',
+        2: {
+          level: '2',
+          3: {
+            level: '3',
+            4: {
+              level: '4',
+              5: {
+                level: '5',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const operator = new SuffixOperator({ name: 'suffix', maxDepth: 3 });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([nestedObj])!;
+
+    // @ts-ignore
+    expect(suffixedObject['1_obj']['2_obj']['3_obj']).to.not.be.undefined;
+
+    // @ts-ignore
+    expect(suffixedObject['1_obj']['2_obj']['3_obj']['4_obj']).to.be.undefined;
+  });
+
+  it('it should not infinitely suffix', () => {
+    const a: any = {};
+    const b: any = { a };
+    a.b = b;
+
+    // results in Converting circular structure to JSON
+    // console.log(JSON.stringify(a));
+
+    const operator = new SuffixOperator({ name: 'suffix', maxDepth: 3 });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([a])!;
+
+    // @ts-ignore
+    expect(suffixedObject.b_obj.a_obj.b_obj.a_obj).to.be.undefined;
+  });
+});


### PR DESCRIPTION
This PR adds the `SuffixOperator`, which is needed for suffixing objects with type information before sending to FullStory.  This will place vendor-specific behavior into core, but suffixing is complex enough that it requires a large amount of code to do so and bolting it on from the outside would be a chore.

Since suffixing is required if using FullStory, the `beforeDestination` option will be used to specify that the `suffix` operator run every time rather than requiring specific reference to suffix in the operator chain.