### PR TITLE
Add insert operator

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,17 +1,19 @@
 import {
-  FunctionOperator, FunctionOperatorOptions, FlattenOperator, FlattenOperatorOptions,
+  FunctionOperator, FunctionOperatorOptions,
+  FlattenOperator, FlattenOperatorOptions,
+  InsertOperator, InsertOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator;
+export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof InsertOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions;
+export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | InsertOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -21,6 +23,7 @@ export class OperatorFactory {
   private static operators: { [key: string]: BuiltinOperator } = {
     flatten: FlattenOperator,
     function: FunctionOperator,
+    insert: InsertOperator,
   };
 
   /**

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -9,13 +9,14 @@ import { Operator } from './operator';
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof InsertOperator 
-| typeof SuffixOperator;
+export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof InsertOperator
+  | typeof SuffixOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | InsertOperatorOptions | SuffixOperatorOptions;
+export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | InsertOperatorOptions
+  | SuffixOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -42,7 +42,7 @@ export class OperatorValidator {
    * @throws an error if the property is missing
    */
   checkRequired(option: string) {
-    if (!this.options[option]) {
+    if (this.options[option] === undefined) {
       this.throwError(option, 'is required');
     }
   }
@@ -68,7 +68,7 @@ export class OperatorValidator {
    */
   checkDependencies(option: string, dependencies: string[]) {
     dependencies.forEach((dependency) => {
-      if (!this.options[dependency]) {
+      if (this.options[dependency] === undefined) {
         this.throwError(option, `requires option ${dependency}`);
       }
     });

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,2 +1,3 @@
 export * from './flatten';
 export * from './function';
+export * from './insert';

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -1,0 +1,55 @@
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+import { select } from '../selector';
+
+export interface InsertOperatorOptions extends OperatorOptions {
+  select?: string; // a value found using selection syntax
+  value?: boolean | string | number | object; // a given value to insert
+  position?: number; // the location where the value will be inserted
+}
+
+/**
+ * InsertOperator inserts an object into a list at a specified position. This operator is most frequently used
+ * when passing function arguments to a destination. The value inserted can either be explicitly set using the
+ * 'value' option or looked up in an object using the 'select' option. The position of insertion is specified
+ * using the 'position' option. A negative position will insert from the end of the list.
+ */
+export class InsertOperator implements Operator {
+  readonly index: number;
+
+  readonly position: number;
+
+  constructor(public options: InsertOperatorOptions) {
+    const { index = 0, position = 0 } = options;
+
+    this.index = index;
+    this.position = position;
+  }
+
+  static specification = {
+    index: { required: false, type: ['number'] },
+    select: { required: false, type: ['string'] },
+    value: { required: false, type: ['boolean,string,number,object'] },
+    position: { required: false, type: ['number'] },
+  };
+
+  handleData(data: any[]): any[] | null {
+    const { select: selection, value } = this.options;
+    const insertedValue = value || select(selection!, data[this.index]);
+
+    const clone = data.slice();
+    clone.splice(this.position >= 0 ? this.position : clone.length - this.position, 0, insertedValue);
+
+    return clone;
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(InsertOperator.specification);
+
+    // NOTE select and value aren't required, but at least one of them must be specified
+    const { select: selection, value } = this.options;
+    if (!selection && !value) {
+      validator.throwError('selection', ' and \'value\' are missing - at least one is required');
+    }
+  }
+}

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -34,6 +34,11 @@ export class InsertOperator implements Operator {
 
   handleData(data: any[]): any[] | null {
     const { select: selection, value } = this.options;
+
+    if (selection && value !== undefined) {
+      throw new Error('function operator has both \'select\' and \'value\' options set');
+    }
+
     const insertedValue = value || select(selection!, data[this.index]);
 
     const clone = data.slice();
@@ -48,8 +53,12 @@ export class InsertOperator implements Operator {
 
     // NOTE select and value aren't required, but at least one of them must be specified
     const { select: selection, value } = this.options;
-    if (!selection && !value) {
+    if (!selection && value === undefined) {
       validator.throwError('selection', ' and \'value\' are missing - at least one is required');
+    }
+
+    if (selection && value !== undefined) {
+      validator.throwError('selection', ' and \'value\' are both defined - use only one option');
     }
   }
 }

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -18,7 +18,7 @@ class ClosureConsole {
   }
 }
 
-describe('logger unit tests', () => {
+describe('function operator unit tests', () => {
   beforeEach(() => {
     (globalThis as any).console = console;
     (globalThis as any).testClosure = new ClosureConsole('Hello World');

--- a/test/operator-insert.spec.ts
+++ b/test/operator-insert.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { InsertOperator } from '../src/operators';
+
+describe('insert operator unit tests', () => {
+  it('it should validate options', () => {
+    expect(() => new InsertOperator({
+      name: 'insert', select: 'user.profile[0].profileID',
+    }).validate()).to.not.throw();
+
+    expect(() => new InsertOperator({
+      name: 'insert', select: 'user.profile[0].profileID', position: -1, index: 1,
+    }).validate()).to.not.throw();
+
+    expect(() => new InsertOperator({
+      name: 'insert', value: 'Add to Cart', position: 0,
+    }).validate()).to.not.throw();
+
+    // select or value option is required
+    expect(() => new InsertOperator({
+      name: 'insert', position: 0,
+    }).validate()).to.throw();
+  });
+
+  it('it should insert at the beginning by default', () => {
+    const data: any[] = [{ foo: 'foo' }, { bar: 'bar' }];
+    const operator = new InsertOperator({ name: 'insert', value: 'baz' });
+
+    const [baz, foo, bar] = operator.handleData(data)!;
+    expect(baz).to.eq('baz');
+    expect(foo).to.eq(data[0]);
+    expect(bar).to.eq(data[1]);
+  });
+
+  it('it should insert from the end', () => {
+    const data: any[] = [{ foo: 'foo' }, { bar: 'bar' }];
+    const operator = new InsertOperator({ name: 'insert', value: 'baz', position: -1 });
+
+    const [foo, bar, baz]: any[] = operator.handleData(data)!;
+    expect(foo).to.eq(data[0]);
+    expect(bar).to.eq(data[1]);
+    expect(baz).to.eq('baz');
+  });
+
+  it('it should insert in the middle', () => {
+    const data: any[] = [{ foo: 'foo' }, { bar: 'bar' }];
+    const operator = new InsertOperator({ name: 'insert', value: 'baz', position: 1 });
+
+    const [foo, baz, bar]: any[] = operator.handleData(data)!;
+    expect(foo).to.eq(data[0]);
+    expect(bar).to.eq(data[1]);
+    expect(baz).to.eq('baz');
+  });
+
+  it('it should insert using selection syntax', () => {
+    const data: any[] = [{ foo: 'foo', bar: [{ baz: 'baz' }] }];
+    const operator = new InsertOperator({ name: 'insert', select: 'bar[0].baz' });
+
+    const [baz, obj] = operator.handleData(data)!;
+    expect(baz).to.eq('baz');
+    expect(obj).to.eq(data[0]);
+  });
+
+  it('it should insert using selection syntax for an object at a specific index', () => {
+    const data: any[] = ['foobar', { foo: 'foo', bar: [{ baz: 'baz' }] }];
+    const operator = new InsertOperator({ name: 'insert', select: 'bar[0].baz', index: 1 });
+
+    const [baz, foobar, obj] = operator.handleData(data)!;
+    expect(baz).to.eq('baz');
+    expect(foobar).to.eq(data[0]);
+    expect(obj).to.eq(data[1]);
+  });
+});

--- a/test/operator-insert.spec.ts
+++ b/test/operator-insert.spec.ts
@@ -21,6 +21,11 @@ describe('insert operator unit tests', () => {
     expect(() => new InsertOperator({
       name: 'insert', position: 0,
     }).validate()).to.throw();
+
+    // but not both
+    expect(() => new InsertOperator({
+      name: 'insert', select: 'user.profile[0].profileID', value: 'Add to Cart',
+    }).validate()).to.throw();
   });
 
   it('it should insert at the beginning by default', () => {
@@ -70,5 +75,10 @@ describe('insert operator unit tests', () => {
     expect(baz).to.eq('baz');
     expect(foobar).to.eq(data[0]);
     expect(obj).to.eq(data[1]);
+  });
+
+  it('it should error if both select and value options are used together', () => {
+    const operator = new InsertOperator({ name: 'insert', select: 'user.profile[0].profileID', value: 'Add to Cart' });
+    expect(() => operator.handleData([])).to.throw();
   });
 });


### PR DESCRIPTION
This PR introduces the `InsertOperator`.  In the prototype, there was a `prepend` operator that added a value to the beginning of a list.  The use case here is adding information to a list of function arguments that are passed to the `destination` function.  So you might add 'Add to Cart' as a literal to FS.event arguments.  Or you might grab the value of `profileID` to be used with FS.identify.  The design was expanded to be more flexible - supporting arbitrary insertion into the list rather than specifically prepending.  The comments in the `InsertOperator` have detail as well.