### PR TITLE
Add QueryOperator

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -3,6 +3,7 @@ import {
   FlattenOperator, FlattenOperatorOptions,
   InsertOperator, InsertOperatorOptions,
   SuffixOperator, SuffixOperatorOptions,
+  QueryOperator, QueryOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
 
@@ -10,13 +11,13 @@ import { Operator } from './operator';
  * Declares known, built-in Operators.
  */
 export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof InsertOperator
-  | typeof SuffixOperator;
+  | typeof SuffixOperator | typeof QueryOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
 export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | InsertOperatorOptions
-  | SuffixOperatorOptions;
+  | SuffixOperatorOptions | QueryOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -28,6 +29,7 @@ export class OperatorFactory {
     function: FunctionOperator,
     insert: InsertOperator,
     suffix: SuffixOperator,
+    query: QueryOperator,
   };
 
   /**

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -2,3 +2,4 @@ export * from './flatten';
 export * from './function';
 export * from './insert';
 export * from './suffix';
+export * from './query';

--- a/src/operators/query.ts
+++ b/src/operators/query.ts
@@ -36,7 +36,7 @@ export class QueryOperator implements Operator {
 
     const { select: selector } = this.options;
     if (selector.charAt(0) !== '$') {
-      validator.throwError('select', 'does not begin with $');
+      validator.throwError('select', 'must begin with $');
     }
   }
 }

--- a/src/operators/query.ts
+++ b/src/operators/query.ts
@@ -2,7 +2,7 @@ import { Operator, OperatorOptions, OperatorValidator } from '../operator';
 import { select } from '../selector';
 
 export interface QueryOperatorOptions extends OperatorOptions {
-  selector: string; // selection syntax query
+  select: string; // selection syntax query
 }
 
 /**
@@ -12,7 +12,7 @@ export interface QueryOperatorOptions extends OperatorOptions {
 export class QueryOperator implements Operator {
   static specification = {
     index: { required: false, type: ['number'] },
-    selector: { required: true, type: ['string'] },
+    select: { required: true, type: ['string'] },
   };
 
   readonly index: number;
@@ -24,7 +24,7 @@ export class QueryOperator implements Operator {
 
   handleData(data: any[]): any[] | null {
     // NOTE to support selection syntax, we have to start with an object property so use $ as the root
-    const { selector } = this.options;
+    const { select: selector } = this.options;
     const selection = select(selector, { $: data[this.index] });
     return (selection === null || selection === undefined) ? null : [selection];
   }

--- a/src/operators/query.ts
+++ b/src/operators/query.ts
@@ -1,0 +1,36 @@
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+import { select } from '../selector';
+
+export interface QueryOperatorOptions extends OperatorOptions {
+  selector: string; // selection syntax query
+}
+
+/**
+ * QueryOperator executes queries to return specific data within an object. This is most often the result of
+ * using the JSON selector syntax.
+ */
+export class QueryOperator implements Operator {
+  static specification = {
+    index: { required: false, type: ['number'] },
+    selector: { required: true, type: ['string'] },
+  };
+
+  readonly index: number;
+
+  constructor(public options: QueryOperatorOptions) {
+    const { index = 0 } = options;
+    this.index = index;
+  }
+
+  handleData(data: any[]): any[] | null {
+    // NOTE to support selection syntax, we have to start with an object property so use $ as the root
+    const { selector } = this.options;
+    const selection = select(selector, { $: data[this.index] });
+    return (selection === null || selection === undefined) ? null : [selection];
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(QueryOperator.specification);
+  }
+}

--- a/src/operators/query.ts
+++ b/src/operators/query.ts
@@ -25,6 +25,7 @@ export class QueryOperator implements Operator {
   handleData(data: any[]): any[] | null {
     // NOTE to support selection syntax, we have to start with an object property so use $ as the root
     const { select: selector } = this.options;
+
     const selection = select(selector, { $: data[this.index] });
     return (selection === null || selection === undefined) ? null : [selection];
   }
@@ -32,5 +33,10 @@ export class QueryOperator implements Operator {
   validate() {
     const validator = new OperatorValidator(this.options);
     validator.validate(QueryOperator.specification);
+
+    const { select: selector } = this.options;
+    if (selector.charAt(0) !== '$') {
+      validator.throwError('select', 'does not begin with $');
+    }
   }
 }

--- a/test/operator-query.spec.ts
+++ b/test/operator-query.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { QueryOperator } from '../src/operators';
+
+const testData = {
+  favorites: {
+    color: 'red',
+    number: 25,
+    pickle: 'dill',
+    films: {
+      action: 'Rogue One',
+      adventure: 'Atomic Blonde',
+      'rom com': "Isn't it romantic",
+    },
+  },
+  cities: ['Seattle', 'Atlanta', 'San Francisco', 'New York City'],
+};
+
+describe('query operator unit tests', () => {
+  it('it should validate options', () => {
+    expect(() => new QueryOperator({
+      name: 'query', selector: 'profileInfo',
+    }).validate()).to.not.throw();
+
+    expect(() => new QueryOperator({
+      name: 'query', selector: 'profileInfo', index: 1,
+    }).validate()).to.not.throw();
+
+    // @ts-ignore
+    expect(() => new QueryOperator({
+      name: 'query', index: 1,
+    }).validate()).to.throw();
+  });
+
+  it('it should query by selector at the 0 index by default', () => {
+    const operator = new QueryOperator({ name: 'query', selector: '$.cities' });
+    const [selection] = operator.handleData([testData])!;
+
+    expect(selection).to.not.be.null;
+    expect(selection).to.eq(testData.cities);
+  });
+
+  it('it should query by selector at a specific index', () => {
+    const operator = new QueryOperator({ name: 'query', selector: '$.cities', index: 1 });
+    const [selection] = operator.handleData(['Profile Update', testData])!;
+
+    expect(selection).to.not.be.null;
+    expect(selection).to.eq(testData.cities);
+  });
+
+  it('it should pick properties', () => {
+    const operator = new QueryOperator({ name: 'query', selector: '$[(color,number,pickle)]' });
+    const [selection] = operator.handleData([testData.favorites])!;
+
+    expect(selection).to.not.be.null;
+    expect(selection.color).to.eq(testData.favorites.color);
+    expect(selection.number).to.eq(testData.favorites.number);
+    expect(selection.pickle).to.eq(testData.favorites.pickle);
+  });
+
+  it('it should return null for empty query results', () => {
+    const operator = new QueryOperator({ name: 'query', selector: '$.missing' });
+    expect(operator.handleData([testData.favorites])).to.be.null;
+  });
+});

--- a/test/operator-query.spec.ts
+++ b/test/operator-query.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 
 import { QueryOperator } from '../src/operators';
+import { OperatorFactory } from '../src/factory';
 
 const testData = {
   favorites: {
@@ -27,6 +28,10 @@ describe('query operator unit tests', () => {
       name: 'query', select: '$.profileInfo', index: 1,
     }).validate()).to.not.throw();
 
+    expect(() => new QueryOperator({
+      name: 'query', select: '[profileInfo]',
+    }).validate()).to.throw();
+
     // @ts-ignore
     expect(() => new QueryOperator({
       name: 'query', index: 1,
@@ -34,7 +39,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should query by selector at the 0 index by default', () => {
-    const operator = new QueryOperator({ name: 'query', select: '$.cities' });
+    const operator = OperatorFactory.create('query', { name: 'query', select: '$.cities' });
     const [selection] = operator.handleData([testData])!;
 
     expect(selection).to.not.be.null;
@@ -42,7 +47,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should query by selector at a specific index', () => {
-    const operator = new QueryOperator({ name: 'query', select: '$.cities', index: 1 });
+    const operator = OperatorFactory.create('query', { name: 'query', select: '$.cities', index: 1 });
     const [selection] = operator.handleData(['Profile Update', testData])!;
 
     expect(selection).to.not.be.null;
@@ -50,7 +55,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should pick properties', () => {
-    const operator = new QueryOperator({ name: 'query', select: '$[(color,number,pickle)]' });
+    const operator = OperatorFactory.create('query', { name: 'query', select: '$[(color,number,pickle)]' });
     const [selection] = operator.handleData([testData.favorites])!;
 
     expect(selection).to.not.be.null;

--- a/test/operator-query.spec.ts
+++ b/test/operator-query.spec.ts
@@ -20,11 +20,11 @@ const testData = {
 describe('query operator unit tests', () => {
   it('it should validate options', () => {
     expect(() => new QueryOperator({
-      name: 'query', selector: 'profileInfo',
+      name: 'query', select: '$.profileInfo',
     }).validate()).to.not.throw();
 
     expect(() => new QueryOperator({
-      name: 'query', selector: 'profileInfo', index: 1,
+      name: 'query', select: '$.profileInfo', index: 1,
     }).validate()).to.not.throw();
 
     // @ts-ignore
@@ -34,7 +34,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should query by selector at the 0 index by default', () => {
-    const operator = new QueryOperator({ name: 'query', selector: '$.cities' });
+    const operator = new QueryOperator({ name: 'query', select: '$.cities' });
     const [selection] = operator.handleData([testData])!;
 
     expect(selection).to.not.be.null;
@@ -42,7 +42,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should query by selector at a specific index', () => {
-    const operator = new QueryOperator({ name: 'query', selector: '$.cities', index: 1 });
+    const operator = new QueryOperator({ name: 'query', select: '$.cities', index: 1 });
     const [selection] = operator.handleData(['Profile Update', testData])!;
 
     expect(selection).to.not.be.null;
@@ -50,7 +50,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should pick properties', () => {
-    const operator = new QueryOperator({ name: 'query', selector: '$[(color,number,pickle)]' });
+    const operator = new QueryOperator({ name: 'query', select: '$[(color,number,pickle)]' });
     const [selection] = operator.handleData([testData.favorites])!;
 
     expect(selection).to.not.be.null;
@@ -60,7 +60,7 @@ describe('query operator unit tests', () => {
   });
 
   it('it should return null for empty query results', () => {
-    const operator = new QueryOperator({ name: 'query', selector: '$.missing' });
+    const operator = new QueryOperator({ name: 'query', select: '$.missing' });
     expect(operator.handleData([testData.favorites])).to.be.null;
   });
 });


### PR DESCRIPTION
@TrevorFSmith @patrick-fs  While writing the user rules, I had a need to do the following:

```
{
    "id": "fs-identify-ceddl-user-allowed",
    "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
    "source": "digitalData.user.profile[0][(profileInfo.profileID,profileInfo.userName,address.line1,...)]",
    "operators": [
      {
        "name": "flatten"
      },
      {
        "name": "insert",
        "select": "profileID"
      }
    ],
    "destination": "FS.identify"
  }
```

That stretches the ability of the selector syntax.  Do we feel like that is valid syntax?

Alternatively, I was thinking we might have an operator that allows us to perform selection within any step of the operator chain.  It would look something like this:

```
  {
    "id": "fs-identify-ceddl-user-allowed",
    "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
    "source": "digitalData.user.profile[0]",
    "operators": [
      {
        "name": "flatten"
      },
      {
        "name": "query",
        "select": "$[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]"
      },
      {
        "name": "insert",
        "select": "profileID"
      }
    ],
    "destination": "FS.identify"
  }
```

The flatten step yields an intermediate top level object:

```
{
 profileID: ...,
 userName: ...,
...
}
```

The query operator then picks allowlisted properties from the intermediate object.

There's on noticeable character in the selector, the `$`.  What I found is that I can't use `[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]` standalone.  I suspect the selector implementation is expecting some property to precede the picking.  So what I've done under the hood is created an intermediate object `{ $: <object>` to allow the picking to succeed. The `$` was part of the original [JSON Path](https://goessner.net/articles/JsonPath/) project so it's not completely foreign to use.  The question is whether it's needed or if we should revise the selector.

If we do go with `QueryOperator`, I want to sync on naming.  In the `InsertOperator` I used `select` as an option.  It's carried over as an option here - as in "running a select query".  That feels natural, and in the future we might have more executable queries so I went with `QueryOperator` versus `SelectOperator`.
