### PR TITLE
Add convert operator

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -3,20 +3,21 @@ import {
   FlattenOperator, FlattenOperatorOptions,
   InsertOperator, InsertOperatorOptions,
   SuffixOperator, SuffixOperatorOptions,
+  ConvertOperator, ConvertOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof FlattenOperator | typeof FunctionOperator | typeof InsertOperator
-  | typeof SuffixOperator;
+export type BuiltinOperator = typeof ConvertOperator | typeof FlattenOperator | typeof FunctionOperator
+  | typeof InsertOperator | typeof SuffixOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | InsertOperatorOptions
-  | SuffixOperatorOptions;
+export type BuiltinOptions = ConvertOperatorOptions | FlattenOperatorOptions | FunctionOperatorOptions
+  | InsertOperatorOptions | SuffixOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -24,6 +25,7 @@ export type BuiltinOptions = FlattenOperatorOptions | FunctionOperatorOptions | 
  */
 export class OperatorFactory {
   private static operators: { [key: string]: BuiltinOperator } = {
+    convert: ConvertOperator,
     flatten: FlattenOperator,
     function: FunctionOperator,
     insert: InsertOperator,

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -1,4 +1,5 @@
 import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+import { Logger } from '../utils/logger';
 
 type ConvertibleType = 'bool' | 'int' | 'real' | 'string';
 
@@ -56,7 +57,13 @@ export class ConvertOperator implements Operator {
 
     const converted: { [key: string]: any } = { ...data[this.index] };
     list.forEach((property) => {
-      converted[property] = ConvertOperator.convert(type, data[this.index][property]);
+      const original = data[this.index][property];
+      converted[property] = ConvertOperator.convert(type, original);
+
+      if ((type === 'int' || type === 'real') && Number.isNaN(converted[property])) {
+        Logger.getInstance().error(`Unable to convert ${properties.toString()} to ${type} for value ${original}`);
+        converted[property] = original; // NOTE that we will reset the value back to something other than NaN
+      }
     });
 
     const clone = data.slice();

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -1,0 +1,77 @@
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+
+type ConvertibleType = 'bool' | 'int' | 'real' | 'string';
+
+export interface ConvertOperatorOptions extends OperatorOptions {
+  properties: string | string[];
+  type: ConvertibleType;
+}
+
+/**
+ * ConvertOperator formats a value from one `type` to a bool, int, real, or string.
+ * The `properties` to be converted can either be a single string property, a list of string properties separated by
+ * a comma, or a native array of strings. The string `*` can also be used to denote that all properties in an object
+ * should be converted to the desired `type`.
+ */
+export class ConvertOperator implements Operator {
+  static specification = {
+    index: { required: false, type: ['number'] },
+    properties: { required: true, type: ['string,object'] }, // NOTE an typeof array is object
+    type: { required: true, type: ['string'] },
+  };
+
+  readonly index: number;
+
+  constructor(public options: ConvertOperatorOptions) {
+    const { index = 0 } = options;
+
+    this.index = index;
+  }
+
+  static convert(type: ConvertibleType, value: any) {
+    switch (type) {
+      case 'bool': return Boolean(value).valueOf();
+      case 'int': return parseInt(value, 10);
+      case 'real': return parseFloat(value);
+      case 'string':
+        switch (typeof value) {
+          case 'boolean': return Boolean(value).toString();
+          case 'number': return (value as number).toString();
+          default: return value;
+        }
+      default: return value;
+    }
+  }
+
+  handleData(data: any[]): any[] | null {
+    let { properties } = this.options;
+    const { type } = this.options;
+
+    if (typeof properties === 'string') {
+      properties = properties.split(',');
+    }
+
+    // NOTE if * is supplied, convert all properties
+    const list = properties[0] === '*' ? Object.getOwnPropertyNames(data[this.index]) : properties;
+
+    const converted: { [key: string]: any } = { ...data[this.index] };
+    list.forEach((property) => {
+      converted[property] = ConvertOperator.convert(type, data[this.index][property]);
+    });
+
+    const clone = data.slice();
+    clone.splice(this.index, 0, converted);
+
+    return clone;
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(ConvertOperator.specification);
+
+    const { type } = this.options;
+    if (type !== 'bool' && type !== 'int' && type !== 'real' && type !== 'string') {
+      throw validator.throwError('type', `unknown type '${type}' used`);
+    }
+  }
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,3 +1,4 @@
+export * from './convert';
 export * from './flatten';
 export * from './function';
 export * from './insert';

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { OperatorFactory } from '../src/factory';
+import { ConvertOperator } from '../src/operators';
+
+const item = {
+  quantity: '10',
+  stock: '10',
+  price: '29.99',
+  tax: '1.99',
+  available: 'true',
+  size: 5,
+  type: true,
+};
+
+describe('convert operator unit tests', () => {
+  it('it should validate options', () => {
+    expect(() => new ConvertOperator({ name: 'convert', properties: 'quantity', type: 'int' }).validate())
+      .to.not.throw();
+    expect(() => new ConvertOperator({
+      name: 'convert', properties: 'quantity', type: 'int', index: 1,
+    }).validate())
+      .to.not.throw();
+    expect(() => new ConvertOperator({ name: 'convert', properties: 'price,tax', type: 'real' }).validate())
+      .to.not.throw();
+    expect(() => new ConvertOperator({ name: 'convert', properties: ['price', 'tax'], type: 'real' }).validate())
+      .to.not.throw();
+    // @ts-ignore
+    expect(() => new ConvertOperator({ name: 'convert', properties: ['price', 'tax'], type: 'array' }).validate())
+      .to.throw();
+    // @ts-ignore
+    expect(() => new ConvertOperator({ name: 'convert', type: 'array' }).validate())
+      .to.throw();
+    // @ts-ignore
+    expect(() => new ConvertOperator({ name: 'convert', properties: 'quantity' }).validate())
+      .to.throw();
+  });
+
+  it('it should convert to int', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'int' });
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(int.size).to.eq(5); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to real', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: ['price', 'tax'], type: 'real' });
+    const [reals] = operator.handleData([item])!;
+
+    expect(reals).to.not.be.null;
+    expect(reals!.price).to.eq(29.99);
+    expect(reals!.tax).to.eq(1.99);
+    expect(reals.type).to.eq(true); // non-converted properties remain
+    expect(item.price).to.eq('29.99'); // don't mutate the actual data layer
+    expect(item.tax).to.eq('1.99'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to bool', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'available', type: 'bool' });
+    const [bool] = operator.handleData([item])!;
+
+    expect(bool).to.not.be.null;
+    expect(bool!.available).to.eq(true);
+    expect(bool.stock).to.eq('10'); // non-converted properties remain
+    expect(item.available).to.eq('true'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to string', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'size', type: 'string' });
+    const [stringInt] = operator.handleData([item])!;
+
+    expect(stringInt).to.not.be.null;
+    expect(stringInt.size).to.eq('5');
+    expect(item.size).to.eq(5); // don't mutate the actual data layer
+
+    operator = OperatorFactory.create('convert', { name: 'convert', properties: 'type', type: 'string' });
+    const [stringBool] = operator.handleData([item])!;
+
+    expect(stringBool).to.not.be.null;
+    expect(stringBool.type).to.eq('true');
+    expect(stringBool.tax).to.eq('1.99'); // non-converted properties remain
+    expect(item.type).to.eq(true); // don't mutate the actual data layer
+  });
+
+  it('it should convert CSV input', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity,stock', type: 'int' });
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(int.type).to.eq(true); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+    expect(item.stock).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert all properties using *', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: '*', type: 'int' });
+    const { quantity, stock } = item;
+    const [int] = operator.handleData([{ quantity, stock }])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(quantity).to.eq('10'); // don't mutate the actual data layer
+    expect(stock).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should not convert unsupported types', () => {
+    // @ts-ignore
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'array' });
+    const [unsupported] = operator.handleData([item])!;
+
+    expect(unsupported).to.not.be.null;
+    expect(unsupported!.quantity).to.eq(item.quantity); // no format occurs
+  });
+
+  it('it should convert an object at a specific index', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'quantity', type: 'int', index: 1,
+    });
+    const [event, int] = operator.handleData(['Product View', item])!;
+
+    expect(event).to.not.be.null;
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+  });
+});

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -12,6 +12,7 @@ const item = {
   available: 'true',
   size: 5,
   type: true,
+  empty: '',
 };
 
 describe('convert operator unit tests', () => {
@@ -128,5 +129,25 @@ describe('convert operator unit tests', () => {
     expect(event).to.not.be.null;
     expect(int).to.not.be.null;
     expect(int.quantity).to.eq(10);
+  });
+
+  it('it should not fail if NaN is the result of conversion', () => {
+    let operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'empty', type: 'int',
+    });
+
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int.empty).to.eq(item.empty);
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'empty', type: 'real',
+    });
+
+    const [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real.empty).to.eq(item.empty);
   });
 });


### PR DESCRIPTION
This PR adds a `ConvertOperator` to convert from one type to another.  The use case is that some data layers have string values like `1.99` when this would be better represented as numeric in a destination.  It supports the `cart` object better for CEDDL work.

One design point is that I've taken some precaution to not mutate the underlying object, but this is a sharp edge for operator implementors.  I'll create a story that moves deep copying so it's not the responsibility of the operator.