### PR TITLE
add FullStory CEDDL Cart spec

### DIFF
--- a/examples/rules/ceddl-cart-fullstory.json
+++ b/examples/rules/ceddl-cart-fullstory.json
@@ -1,0 +1,53 @@
+{
+  "rules": [
+    {
+      "id": "fs-event-ceddl-cart",
+      "description": "send CEDDL cart's cartID and price properties to FS.event as a 'View Cart' event",
+      "source": "digitalData.cart[(cartID,price)]",
+      "operators": [
+        {
+          "name": "insert",
+          "value": "View Cart"
+        }
+      ],
+      "destination": "FS.event"
+    },
+    {
+      "id": "fs-event-ceddl-cart-not-items",
+      "description": "send CEDDL cart properties except items list to FS.event as a 'View Cart' event",
+      "source": "digitalData.cart",
+      "operators": [
+        {
+          "name": "query",
+          "select": "$[!(items)]"
+        },
+        {
+          "name": "insert",
+          "value": "View Cart"
+        }
+      ],
+      "destination": "FS.event"
+    },
+    {
+      "id": "fs-event-ceddl-cart-convert",
+      "description": "converts and sends CEDDL cart properties to FS.event as a 'View Cart' event",
+      "source": "digitalData.cart",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+        {
+          "name": "convert",
+          "properties": "basePrice,priceWithTax,cartTotal",
+          "type": "real"
+        },
+        {
+          "name": "insert",
+          "value": "View Cart"
+        }
+      ],
+      "destination": "FS.event",
+      "debug": true
+    }
+  ]
+}

--- a/examples/rules/ceddl-user-fullstory.json
+++ b/examples/rules/ceddl-user-fullstory.json
@@ -1,47 +1,49 @@
-[
-  {
-    "id": "fs-uservars-ceddl-user-all",
-    "description": "send all CEDDL user properties to FS.setUserVars",
-    "source": "digitalData.user.profile[0]",
-    "operators": [
-      {
-        "name": "flatten"
-      }
-    ],
-    "destination": "FS.setUserVars"
-  },
-  {
-    "id": "fs-identify-ceddl-user-all",
-    "description": "send all CEDDL user properties to FS.identify using the profileID as the FullStory uid",
-    "source": "digitalData.user.profile[0]",
-    "operators": [
-      {
-        "name": "flatten"
-      },
-      {
-        "name": "insert",
-        "select": "profileID"
-      }
-    ],
-    "destination": "FS.identify"
-  },
-  {
-    "id": "fs-identify-ceddl-user-allowed",
-    "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
-    "source": "digitalData.user.profile[0]",
-    "operators": [
-      {
-        "name": "flatten"
-      },
-      {
-        "name": "query",
-        "select": "$[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]"
-      },
-      {
-        "name": "insert",
-        "select": "profileID"
-      }
-    ],
-    "destination": "FS.identify"
-  }
-]
+{
+  "rules": [
+    {
+      "id": "fs-uservars-ceddl-user-all",
+      "description": "send all CEDDL user properties to FS.setUserVars",
+      "source": "digitalData.user.profile[0]",
+      "operators": [
+        {
+          "name": "flatten"
+        }
+      ],
+      "destination": "FS.setUserVars"
+    },
+    {
+      "id": "fs-identify-ceddl-user-all",
+      "description": "send all CEDDL user properties to FS.identify using the profileID as the FullStory uid",
+      "source": "digitalData.user.profile[0]",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+        {
+          "name": "insert",
+          "select": "profileID"
+        }
+      ],
+      "destination": "FS.identify"
+    },
+    {
+      "id": "fs-identify-ceddl-user-allowed",
+      "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
+      "source": "digitalData.user.profile[0]",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+        {
+          "name": "query",
+          "select": "$[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]"
+        },
+        {
+          "name": "insert",
+          "select": "profileID"
+        }
+      ],
+      "destination": "FS.identify"
+    }
+  ]
+}

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -61,7 +61,7 @@ describe('FullStory example rules unit tests', () => {
     expect(payload.attributes).to.be.undefined;
     expect(payload.job).to.eq('developer'); // verify custom property
 
-    (globalThis as any).digitalData.user.profile[0].job; // remove custom property
+    delete (globalThis as any).digitalData.user.profile[0].job; // remove custom property
   });
 
   it('it should send any CEDDL user property to FS.identify', () => {
@@ -108,7 +108,7 @@ describe('FullStory example rules unit tests', () => {
     expect(payload.price).to.eq(price);
     expect(payload.promotion).to.be.undefined;
 
-    (globalThis as any).digitalData.cart.promotion; // remove custom property
+    delete (globalThis as any).digitalData.cart.promotion; // remove custom property
   });
 
   it('it should send all CEDDL cart properties except items to FS.event', () => {
@@ -128,7 +128,7 @@ describe('FullStory example rules unit tests', () => {
     expect(payload.promotion).to.eq('LaborDay2020');
     expect(payload.items).to.be.undefined;
 
-    (globalThis as any).digitalData.cart.promotion; // remove custom property
+    delete (globalThis as any).digitalData.cart.promotion; // remove custom property
   });
 
   it('it should convert strings to reals and send CEDDL cart properties to FS.event', () => {

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { DataLayerObserver } from '../src/observer';
-import * as rules from '../examples/rules/ceddl-user-fullstory.json';
+import { DataLayerObserver, DataLayerRule } from '../src/observer';
+import * as userRules from '../examples/rules/ceddl-user-fullstory.json';
+import * as cartRules from '../examples/rules/ceddl-cart-fullstory.json';
 
 import { CEDDL, basicDigitalData } from './mocks/CEDDL';
 import Console from './mocks/console';
@@ -16,6 +17,15 @@ interface GlobalMock {
 }
 
 let globalMock: GlobalMock;
+
+const rules = [...cartRules.rules, ...userRules.rules];
+
+function getRule(id: string) {
+  const rule = rules.find((r: DataLayerRule) => r.id === id);
+  expect(rule).to.not.be.undefined;
+
+  return rule!;
+}
 
 describe('FullStory example rules unit tests', () => {
   beforeEach(() => {
@@ -34,7 +44,7 @@ describe('FullStory example rules unit tests', () => {
 
     (globalThis as any).digitalData.user.profile[0].job = 'developer'; // inject custom property
 
-    const observer = new DataLayerObserver({ rules: [rules[0]], readOnLoad: true });
+    const observer = new DataLayerObserver({ rules: [getRule('fs-uservars-ceddl-user-all')], readOnLoad: true });
     expect(observer).to.not.be.undefined;
 
     const [payload] = expectParams(globalMock.FS, 'setUserVars');
@@ -57,7 +67,7 @@ describe('FullStory example rules unit tests', () => {
   it('it should send any CEDDL user property to FS.identify', () => {
     const { profileInfo, address } = basicDigitalData.user.profile[0];
 
-    const observer = new DataLayerObserver({ rules: [rules[1]], readOnLoad: true });
+    const observer = new DataLayerObserver({ rules: [getRule('fs-identify-ceddl-user-all')], readOnLoad: true });
     expect(observer).to.not.be.undefined;
 
     const [uid, payload] = expectParams(globalMock.FS, 'identify');
@@ -72,7 +82,7 @@ describe('FullStory example rules unit tests', () => {
 
     const { profileInfo, address } = basicDigitalData.user.profile[0];
 
-    const observer = new DataLayerObserver({ rules: [rules[2]], readOnLoad: true });
+    const observer = new DataLayerObserver({ rules: [getRule('fs-identify-ceddl-user-allowed')], readOnLoad: true });
     expect(observer).to.not.be.undefined;
 
     const [uid, payload] = expectParams(globalMock.FS, 'identify');
@@ -82,5 +92,71 @@ describe('FullStory example rules unit tests', () => {
     expect(payload.password).to.be.undefined;
 
     delete (globalThis as any).digitalData.user.profile[0].password; // remove sensitive property
+  });
+
+  it('it should send CEDDL cart cartID and price properties to FS.event', () => {
+    const { cartID, price } = basicDigitalData.cart;
+
+    (globalThis as any).digitalData.cart.promotion = 'LaborDay2020'; // inject custom property
+
+    const observer = new DataLayerObserver({ rules: [getRule('fs-event-ceddl-cart')], readOnLoad: true });
+    expect(observer).to.not.be.undefined;
+
+    const [eventName, payload] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('View Cart');
+    expect(payload.cartID).to.eq(cartID);
+    expect(payload.price).to.eq(price);
+    expect(payload.promotion).to.be.undefined;
+
+    (globalThis as any).digitalData.cart.promotion; // remove custom property
+  });
+
+  it('it should send all CEDDL cart properties except items to FS.event', () => {
+    // NOTE that items is a list of complex objects that requires special transformations (see FS.event limitations)
+    const { cartID, price, attributes } = basicDigitalData.cart;
+
+    (globalThis as any).digitalData.cart.promotion = 'LaborDay2020'; // inject custom property
+
+    const observer = new DataLayerObserver({ rules: [getRule('fs-event-ceddl-cart-not-items')], readOnLoad: true });
+    expect(observer).to.not.be.undefined;
+
+    const [eventName, payload] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('View Cart');
+    expect(payload.cartID).to.eq(cartID);
+    expect(payload.price).to.eq(price);
+    expect(payload.attributes).to.eq(attributes);
+    expect(payload.promotion).to.eq('LaborDay2020');
+    expect(payload.items).to.be.undefined;
+
+    (globalThis as any).digitalData.cart.promotion; // remove custom property
+  });
+
+  it('it should convert strings to reals and send CEDDL cart properties to FS.event', () => {
+    const { price: { basePrice, priceWithTax, cartTotal } } = basicDigitalData.cart;
+
+    // convert to strings for testing
+    (globalThis as any).digitalData.cart.price.basePrice = basePrice.toString();
+    (globalThis as any).digitalData.cart.price.priceWithTax = priceWithTax.toString();
+    (globalThis as any).digitalData.cart.price.cartTotal = cartTotal.toString();
+
+    expect(typeof (globalThis as any).digitalData.cart.price.basePrice).to.eq('string');
+    expect(typeof (globalThis as any).digitalData.cart.price.priceWithTax).to.eq('string');
+    expect(typeof (globalThis as any).digitalData.cart.price.cartTotal).to.eq('string');
+
+    const observer = new DataLayerObserver({ rules: [getRule('fs-event-ceddl-cart-convert')], readOnLoad: true });
+    expect(observer).to.not.be.undefined;
+
+    const [eventName, payload] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('View Cart');
+
+    // NOTE these are flattened but you could also simply send digitalData.cart.price
+    expect(payload.basePrice).to.eq(basePrice);
+    expect(payload.priceWithTax).to.eq(priceWithTax);
+    expect(payload.cartTotal).to.eq(cartTotal);
+
+    // reset to original values
+    (globalThis as any).digitalData.cart.price.basePrice = basePrice;
+    (globalThis as any).digitalData.cart.price.priceWithTax = priceWithTax;
+    (globalThis as any).digitalData.cart.price.cartTotal = cartTotal;
   });
 });


### PR DESCRIPTION
This PR adds examples for FullStory and CEDDL Cart.  The example JSONs were converted to objects with a `rules` property.  I saw some odd behavior when trying to iterate over the pure list.  Making the examples objects with a `rules` property and a value of an array solved this.  Also added a `getRule` function to make it clearer which rule to test rather than relying on the order in the list.