### PR TITLE
add FullStory CEDDL Page spec

### DIFF
--- a/examples/rules/ceddl-page-fullstory.json
+++ b/examples/rules/ceddl-page-fullstory.json
@@ -27,8 +27,7 @@
           "value": "digitalData.page"
         }
       ],
-      "destination": "FS.event",
-      "debug": true
+      "destination": "FS.event"
     }
   ]
 }

--- a/examples/rules/ceddl-page-fullstory.json
+++ b/examples/rules/ceddl-page-fullstory.json
@@ -1,0 +1,34 @@
+{
+  "rules": [
+    {
+      "id": "fs-event-ceddl-page-omit-convert",
+      "description": "convert and send CEDDL page properties to FS.event as a 'Page' event",
+      "source": "digitalData.page",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+        {
+          "name": "query",
+          "select": "$[!(destinationURL,referringURL)]"
+        },
+        {
+          "name": "convert",
+          "properties": "version",
+          "type": "real"
+        },
+        {
+          "name": "convert",
+          "properties": "issueDate,effectiveDate,expiryDate",
+          "type": "date"
+        },
+        {
+          "name": "insert",
+          "value": "digitalData.page"
+        }
+      ],
+      "destination": "FS.event",
+      "debug": true
+    }
+  ]
+}

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -13,6 +13,7 @@ const item = {
   size: 5,
   type: true,
   empty: '',
+  saleDate: '12-26-2020',
 };
 
 describe('convert operator unit tests', () => {
@@ -85,6 +86,17 @@ describe('convert operator unit tests', () => {
     expect(stringBool.type).to.eq('true');
     expect(stringBool.tax).to.eq('1.99'); // non-converted properties remain
     expect(item.type).to.eq(true); // don't mutate the actual data layer
+  });
+
+  it('it should convert to date', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'saleDate,tax', type: 'date' });
+    const [date] = operator.handleData([item])!;
+
+    expect(date).to.not.be.null;
+    expect(date!.saleDate.toString()).to.eq(new Date('12-26-2020').toString());
+    expect(date.tax).to.eq(item.tax); // failed conversions should be the original value
+    expect(date.stock).to.eq('10'); // non-converted properties remain
+    expect(item.saleDate).to.eq('12-26-2020'); // don't mutate the actual data layer
   });
 
   it('it should convert CSV input', () => {


### PR DESCRIPTION
This PR adds the CEDDL Page spec.  There is some light conversion of the data into more semantic types useful to FullStory.  I added a `date` type to the `ConvertOperator`.  This will allow us to take a `Date` object converted from a string and send it to FullStory with the `_date` suffix.