### PR TITLE
Van/suffix bug index

### DIFF
--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -46,7 +46,8 @@ export class SuffixOperator implements Operator {
   readonly maxDepth: number;
 
   constructor(public options: SuffixOperatorOptions) {
-    const { index = 0, maxDepth = 10 } = options;
+    // NOTE the index is -1 because payloads to FS.event or FS.setUserVars are the last in the list of args
+    const { index = -1, maxDepth = 10 } = options;
 
     this.index = index;
     this.maxDepth = maxDepth;

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -159,8 +159,9 @@ export class SuffixOperator implements Operator {
   }
 
   handleData(data: any[]): any[] | null {
+    const index = this.index >= 0 ? this.index : data.length + this.index;
     const suffixedData = data;
-    suffixedData[this.index] = this.mapToSuffix(suffixedData[this.index]);
+    suffixedData[index] = this.mapToSuffix(suffixedData[index]);
 
     return suffixedData;
   }

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -235,4 +235,14 @@ describe('suffix operator unit test', () => {
     // @ts-ignore
     expect(suffixedObject.b_obj.a_obj.b_obj.a_obj).to.be.undefined;
   });
+
+  it('it should suffix using a negative index', () => {
+    const message = 'Hello World';
+
+    const operator = new SuffixOperator({ name: 'suffix', index: -1 });
+    const [eventName, suffixedObject] = operator.handleData(['Message Event', { message }])!;
+
+    expect(eventName).to.eq('Message Event');
+    expect(suffixedObject.message_str).to.eq(message);
+  });
 });


### PR DESCRIPTION
This PR addresses a bug with the `SuffixOperator`.  The intent was to always declare the following in the script:

```
window['_dlo_beforeDestination'] = { name: "suffix" };
```

This meant that before the destination, we would always suffix.  What I saw in integration testing is that the default index was 0.  So for an FS.identify call, the wrong arg was being suffixed.  I've set the default suffix index to be -1 (the last item in the destination function args).  This defaults to suffixing the payload correctly and not the proceeding event name for example.