### PR TITLE
add ceddl transaction rules

### DIFF
--- a/examples/rules/ceddl-transaction-fullstory.json
+++ b/examples/rules/ceddl-transaction-fullstory.json
@@ -1,0 +1,19 @@
+{
+  "rules": [
+    {
+      "id": "fs-event-ceddl-transaction-id-total",
+      "description": "send CEDDL transaction's transactionID and total properties to FS.event as a 'Order Completed' event",
+      "source": "digitalData.transaction[(transactionID,total)]",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+        {
+          "name": "insert",
+          "value": "Order Completed"
+        }
+      ],
+      "destination": "FS.event"
+    }
+  ]
+}


### PR DESCRIPTION
This turned out to be pretty basic.  It simply aligns our "Order Completed" event name seen in documentation as a rule.

There's a stretch goal that we could pursue as a follow on in next iteration.  Normally the Order Completed event carries with it a `products` array.  That in turn fires N "Product Purchased" events.  What we lack in this rule set is the products purchased, and I don't think that's too detrimental.  But a possibility is that we create a `foreach` operator that would execute the remaining operator for each element in the `items` list.  The result would emulate the `Product Purchased` event and be helpful for other use cases where lists of objects are encountered.