### PR TITLE
Rollup configuration to leave the `window` alone

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,14 +5,16 @@ export default {
   input: 'src/embed/init.ts',
   output: [
     {
-      format: 'cjs',
+      format: 'iife',
       file: 'build/dlo.js'
     },
     {
       file: 'build/dlo.min.js',
       format: 'cjs',
       name: 'version',
-      plugins: [terser()]
+      plugins: [terser({
+        enclose: true
+      })]
     }
   ],
   plugins: [


### PR DESCRIPTION
Change the rollup config for the bundle build so it no longer writes properties to the window.