### PR TITLE
bug fix for boolean and nulls

### DIFF
--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -34,13 +34,13 @@ export class ConvertOperator implements Operator {
       case 'bool': return (value === 'true' || value === 'TRUE' || value === 'True');
       case 'date': return new Date(value);
       case 'int':
-        if (value === null) {
+        if (!value) {
           return 0;
         }
         return parseInt(value, 10);
 
       case 'real':
-        if (value === null) {
+        if (!value) {
           return 0.0;
         }
         return parseFloat(value);

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -75,7 +75,7 @@ export class ConvertOperator implements Operator {
     });
 
     const clone = data.slice();
-    clone.splice(this.index, 0, converted);
+    clone.splice(this.index, 1, converted);
 
     return clone;
   }

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -31,10 +31,20 @@ export class ConvertOperator implements Operator {
 
   static convert(type: ConvertibleType, value: any) {
     switch (type) {
-      case 'bool': return Boolean(value).valueOf();
+      case 'bool': return (value === 'true' || value === 'TRUE' || value === 'True');
       case 'date': return new Date(value);
-      case 'int': return parseInt(value, 10);
-      case 'real': return parseFloat(value);
+      case 'int':
+        if (value === null) {
+          return 0;
+        }
+        return parseInt(value, 10);
+
+      case 'real':
+        if (value === null) {
+          return 0.0;
+        }
+        return parseFloat(value);
+
       case 'string':
         switch (typeof value) {
           case 'boolean': return Boolean(value).toString();

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -137,11 +137,13 @@ describe('convert operator unit tests', () => {
     const operator = OperatorFactory.create('convert', {
       name: 'convert', properties: 'quantity', type: 'int', index: 1,
     });
-    const [event, int] = operator.handleData(['Product View', item])!;
+    const [event, int, last, rest] = operator.handleData(['Product View', item, 'dlo'])!;
 
     expect(event).to.not.be.null;
     expect(int).to.not.be.null;
     expect(int.quantity).to.eq(10);
+    expect(last).to.eq('dlo');
+    expect(rest).to.be.undefined;
   });
 
   it('it should not fail if NaN is the result of conversion', () => {

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -9,11 +9,12 @@ const item = {
   stock: '10',
   price: '29.99',
   tax: '1.99',
-  available: 'true',
+  available: 'false',
   size: 5,
   type: true,
   empty: '',
   saleDate: '12-26-2020',
+  vat: null,
 };
 
 describe('convert operator unit tests', () => {
@@ -66,9 +67,9 @@ describe('convert operator unit tests', () => {
     const [bool] = operator.handleData([item])!;
 
     expect(bool).to.not.be.null;
-    expect(bool!.available).to.eq(true);
+    expect(bool!.available).to.eq(false);
     expect(bool.stock).to.eq('10'); // non-converted properties remain
-    expect(item.available).to.eq('true'); // don't mutate the actual data layer
+    expect(item.available).to.eq('false'); // don't mutate the actual data layer
   });
 
   it('it should convert to string', () => {
@@ -161,5 +162,21 @@ describe('convert operator unit tests', () => {
 
     expect(real).to.not.be.null;
     expect(real.empty).to.eq(item.empty);
+  });
+
+  it('it should convert null int or real to zero', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'real' });
+    const [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real!.vat).to.eq(0.0);
+    expect(real!.nothing).to.be.undefined;
+
+    operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'int' });
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.vat).to.eq(0);
+    expect(int!.nothing).to.be.undefined;
   });
 });

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -154,7 +154,7 @@ describe('convert operator unit tests', () => {
     const [int] = operator.handleData([item])!;
 
     expect(int).to.not.be.null;
-    expect(int.empty).to.eq(item.empty);
+    expect(int.empty).to.eq(0);
 
     operator = OperatorFactory.create('convert', {
       name: 'convert', properties: 'empty', type: 'real',
@@ -163,7 +163,7 @@ describe('convert operator unit tests', () => {
     const [real] = operator.handleData([item])!;
 
     expect(real).to.not.be.null;
-    expect(real.empty).to.eq(item.empty);
+    expect(real.empty).to.eq(0);
   });
 
   it('it should convert null int or real to zero', () => {
@@ -172,13 +172,13 @@ describe('convert operator unit tests', () => {
 
     expect(real).to.not.be.null;
     expect(real!.vat).to.eq(0.0);
-    expect(real!.nothing).to.be.undefined;
+    expect(real!.nothing).to.eq(0.0);
 
     operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'int' });
     const [int] = operator.handleData([item])!;
 
     expect(int).to.not.be.null;
     expect(int!.vat).to.eq(0);
-    expect(int!.nothing).to.be.undefined;
+    expect(int!.nothing).to.eq(0);
   });
 });


### PR DESCRIPTION
I fixed a bug in how the boolean conversion from a `'true'` or `'false'` was done.

The other scenario encountered was if a rule wanted to always try to convert a value to a real or int.  If the value was null, we'd actually leave it as is but console.error that we couldn't convert.  This can get noisy and gives the appearance of an error when none really exists.  So this fix also assumes that a null being converted to an int/real yields a zero value.  It's worth thinking through if there are any undesirable side-effects.  A similar question is whether other type conversion of null (e.g. `string`) should provide a default value such as the empty string.