### PR TITLE
add debug stats

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -125,11 +125,21 @@ export default class DataHandler {
     return handledData;
   }
 
-  private static sizeOfPayload(obj: any): number {
-    return JSON.stringify(obj).length * 2;
+  /**
+   * Calculate the size of a JSON.stringified object.
+   * @param obj the object to stringify and calculate
+   * @param stringBytes number of bytes for a string (defaults to UTF16 two bytes)
+   */
+  private static sizeOfPayload(obj: any, stringBytes = 2): number {
+    return JSON.stringify(obj).length * stringBytes;
   }
 
-  private static sizeOfValues(obj: any): number {
+  /**
+   * Calculate the aggregate size of all values within an object.
+   * @param obj the object with values to calculate
+   * @param stringBytes number of bytes for a string (defaults to UTF16 two bytes)
+   */
+  private static sizeOfValues(obj: any, stringBytes = 2): number {
     let size = 0;
 
     if (typeof obj === 'object') {
@@ -142,7 +152,7 @@ export default class DataHandler {
             }
             break;
           case 'string':
-            size += (obj[prop] as string).length * 2;
+            size += (obj[prop] as string).length * stringBytes;
             break;
           case 'number':
             size += 8;
@@ -159,6 +169,11 @@ export default class DataHandler {
     return size;
   }
 
+  /**
+   * Counts the number of properties in an object. Properties that have object values are not counted, but their
+   * children are.
+   * @param obj the object to count all properties
+   */
   private static numProperties(obj: any): number {
     let count = 0;
 

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -45,7 +45,7 @@ export class FunctionOperator implements Operator {
       case 'function':
         return [func.apply(actualThisArg, data)];
       case 'string':
-        return select(func).apply(actualThisArg, data);
+        return [select(func).apply(actualThisArg, data)];
       default:
         // NOTE this will stop the handler
         return null;

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -163,10 +163,12 @@ describe('DataHandler unit tests', () => {
     expect(exit).to.contain(`digitalData.page handleData exit\n[${JSON.stringify(basicDigitalData.page.pageInfo)}]`);
 
     const [getterOutput] = expectParams(console, 'debug');
-    expect(getterOutput).to.contain(`  [1] getter output\n  [${JSON.stringify(basicDigitalData.page.pageInfo)}]`);
+    expect(getterOutput).to.contain('  [1] getter output');
+    expect(getterOutput).to.contain(`[${JSON.stringify(basicDigitalData.page.pageInfo)}]`);
 
     const [echoOutput] = expectParams(console, 'debug');
-    expect(echoOutput).to.contain(`  [0] echo output\n  [${JSON.stringify(basicDigitalData.page)}]`);
+    expect(echoOutput).to.contain('  [0] echo output');
+    expect(echoOutput).to.contain(`[${JSON.stringify(basicDigitalData.page)}]`);
 
     const [entry] = expectParams(console, 'debug');
     expect(entry).to.contain(`digitalData.page handleData entry\n[${JSON.stringify(basicDigitalData.page)}]`);


### PR DESCRIPTION
This PR adds additional debug, which helps calculate the number of properties and data sizes.  A bug was also found related to the function operator where it was not wrapping the returned data in a list.  (Every operator should return a list.)