### PR TITLE
add FS.event appender

### DIFF
--- a/src/embed/init.ts
+++ b/src/embed/init.ts
@@ -5,6 +5,10 @@ import { DataLayerObserver } from '../observer';
 /*
 This is where we initialize the DataLayerObserver from this info:
 
+// A custom log appender; a console appender is used if one is not specified
+// Default is null
+window['_dlo_appender'] = null;
+
 // OperatorOptions that is always used just before before the destination
 // Default is null
 window['_dlo_beforeDestination'] = null;
@@ -77,6 +81,7 @@ function _dlo_initializeFromWindow() {
   }
 
   win._dlo_observer = new DataLayerObserver({
+    appender: win._dlo_appender || undefined,
     beforeDestination: win._dlo_beforeDestination || undefined,
     previewMode: win._dlo_previewMode === true,
     previewDestination: win._dlo_previewDestination || undefined,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -1,7 +1,7 @@
 import { OperatorOptions, Operator } from './operator';
 import { BuiltinOptions, OperatorFactory } from './factory';
 import DataHandler from './handler';
-import { Logger } from './utils/logger';
+import { Logger, LogAppender } from './utils/logger';
 import { FunctionOperator } from './operators';
 
 /**
@@ -10,6 +10,7 @@ import { FunctionOperator } from './operators';
  * Required
  *  rules: a list of pre-configured DataLayerRules
  * Optional
+ *  appender: a custom log appender
  *  beforeDestination: OperatorOptions that is always used just before before the destination
  *  previewMode: redirects output from a destination to previewDestination when testing rules
  *  previewDestination: output destination using selection syntax for with previewMode
@@ -18,6 +19,7 @@ import { FunctionOperator } from './operators';
  *  urlValidator: a function used to validate a DataLayerRule's `url`
  */
 export interface DataLayerConfig {
+  appender?: LogAppender;
   beforeDestination?: OperatorOptions;
   previewDestination?: string;
   previewMode?: boolean;
@@ -78,7 +80,11 @@ export class DataLayerObserver {
     readOnLoad: false,
     validateRules: true,
   }) {
-    const { rules } = config;
+    const { appender, rules } = config;
+    if (appender) {
+      Logger.getInstance().appender = appender;
+    }
+
     if (rules) {
       rules.forEach((rule: DataLayerRule) => this.processRule(rule));
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -55,7 +55,7 @@ export interface LogEvent {
 export class Logger {
   private static instance: Logger;
 
-  appender = new ConsoleAppender();
+  appender: LogAppender = new ConsoleAppender();
 
   level = 1;
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -8,6 +8,7 @@ import Console from './mocks/console';
 import FullStory from './mocks/fullstory-recording';
 import { expectParams, expectNoCalls, expectCall } from './utils/mocha';
 import { Operator, OperatorOptions } from '../src/operator';
+import { LogEvent } from '../src/utils/logger';
 
 class EchoOperator implements Operator {
   options: OperatorOptions = {
@@ -290,5 +291,30 @@ describe('DataLayerObserver unit tests', () => {
     expect((category as PageCategory).primaryCategory).to.eq(
       globalMock.digitalData.page.category.primaryCategory.toUpperCase(),
     );
+  });
+
+  it('it should register a custom log appender', () => {
+    expectNoCalls(globalMock.FS, 'event');
+
+    const observer = new DataLayerObserver({
+      appender: {
+        log: (event: LogEvent) => {
+          // eslint-disable-next-line camelcase
+          const { level: level_int, message: message_str, datalayer: datalayer_str } = event;
+          globalMock.FS.event('Data Layer Observer', { level_int, message_str, datalayer_str }, 'dataLayerObserver');
+        },
+      },
+      readOnLoad: true,
+      rules: [
+        { source: 'digitalData.nonExistent', operators: [], destination: 'console.log' },
+      ],
+    });
+
+    expect(observer).to.not.be.undefined;
+
+    const [eventName, event, source] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('Data Layer Observer');
+    expect(event).to.not.be.undefined;
+    expect(source).to.eq('dataLayerObserver');
   });
 });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -296,14 +296,20 @@ describe('DataLayerObserver unit tests', () => {
   it('it should register a custom log appender', () => {
     expectNoCalls(globalMock.FS, 'event');
 
+    class FullStoryAppender {
+      constructor(private fs: FullStory) {
+        // sets this.fs
+      }
+
+      log(event: LogEvent) {
+        // eslint-disable-next-line camelcase
+        const { level: level_int, message: message_str, datalayer: datalayer_str } = event;
+        this.fs.event('Data Layer Observer', { level_int, message_str, datalayer_str }, 'dataLayerObserver');
+      }
+    }
+
     const observer = new DataLayerObserver({
-      appender: {
-        log: (event: LogEvent) => {
-          // eslint-disable-next-line camelcase
-          const { level: level_int, message: message_str, datalayer: datalayer_str } = event;
-          globalMock.FS.event('Data Layer Observer', { level_int, message_str, datalayer_str }, 'dataLayerObserver');
-        },
-      },
+      appender: new FullStoryAppender(globalMock.FS),
       readOnLoad: true,
       rules: [
         { source: 'digitalData.nonExistent', operators: [], destination: 'console.log' },


### PR DESCRIPTION
Looks like we had support for the custom log appender but it was not available to declare as an option to `init`.  This PR allows mounting `FS.event` as an appender so that we can pipe logs/errors to FullStory.  Usage would be similar to:

```
window['_dlo_appender'] = {
      log: ({ level: level_int, message: message_str, datalayer: datalayer_str }) => {
        const FS = window[window['_fs_namespace']];
        console.log({ level_int, message_str, datalayer_str })
        if (FS) FS.event('Data Layer Observer', { level_int, message_str, datalayer_str }, 'dataLayerObserver')
      }
    };
```