### PR TITLE
Add Web Embed Lab Testing

### DIFF
--- a/examples/ceddl-fs/index.html
+++ b/examples/ceddl-fs/index.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Data Layer Observer Example: basic embed</title>
+    <meta charset="utf-8" />
+    <script>
+      /* These are examples of static data that will be read on load */
+      window.exampleData = {
+        page: {
+          pageName: 'basic embed',
+          pageInfo: {
+            pageID: '1234'
+          }
+        }
+      }
+      window.adInformation = {
+        accountID: 'abcd'
+      }
+      window.ops = {
+        clusterInfo: {
+          id: '444-111-11231',
+          load: 0.4
+        }
+      }
+
+      /* This function will receive information as the DLO rules find it */
+      function ruleDestination(info) {
+        console.log('ruleDestination received:', info);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Data Layer Observer Example: basic embed</h1>
+
+    <p>Take a look at the source code of this page to see how the DLO reads rules and configuration.</p>
+    <p>The Javascript console will show you output that demonstrates the rules in action.</p>
+
+    <script>
+      window['_dlo_previewMode'] = true;
+      window['_dlo_readOnLoad'] = true;
+      window['_dlo_validateRules'] = true;
+
+      window['_dlo_rules'] = [
+        {
+          "id": "fs-event-ceddl-cart",
+          "description": "send CEDDL cart's cartID and price properties to FS.event as a 'View Cart' event",
+          "source": "digitalData.cart[(cartID,price)]",
+          "operators": [
+            {
+              "name": "insert",
+              "value": "View Cart"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-cart-not-items",
+          "description": "send CEDDL cart properties except items list to FS.event as a 'View Cart' event",
+          "source": "digitalData.cart",
+          "operators": [
+            {
+              "name": "query",
+              "select": "$[!(items)]"
+            },
+            {
+              "name": "insert",
+              "value": "View Cart"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-cart-convert",
+          "description": "converts and sends CEDDL cart properties to FS.event as a 'View Cart' event",
+          "source": "digitalData.cart",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "convert",
+              "properties": "basePrice,priceWithTax,cartTotal",
+              "type": "real"
+            },
+            {
+              "name": "insert",
+              "value": "View Cart"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-page-omit-convert",
+          "description": "convert and send CEDDL page properties to FS.event as a 'Page' event",
+          "source": "digitalData.page",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "query",
+              "select": "$[!(destinationURL,referringURL)]"
+            },
+            {
+              "name": "convert",
+              "properties": "version",
+              "type": "real"
+            },
+            {
+              "name": "convert",
+              "properties": "issueDate,effectiveDate,expiryDate",
+              "type": "date"
+            },
+            {
+              "name": "insert",
+              "value": "digitalData.page"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-product",
+          "description": "send the latest CEDDL product's primaryCategory, sku, productID, and productName properties to FS.event as a 'View Product' event",
+          "source": "digitalData.product[-1]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "query",
+              "select": "$[(primaryCategory, sku, productID, productName)]"
+            },
+            {
+              "name": "insert",
+              "value": "View Product"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-transaction-id-total",
+          "description": "send CEDDL transaction's transactionID and total properties to FS.event as a 'Order Completed' event",
+          "source": "digitalData.transaction[(transactionID,total)]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "insert",
+              "value": "Order Completed"
+            }
+          ],
+          "destination": "FS.event"        
+        },
+        {
+          "id": "fs-uservars-ceddl-user-all",
+          "description": "send all CEDDL user properties to FS.setUserVars",
+          "source": "digitalData.user.profile[0]",
+          "operators": [
+            {
+              "name": "flatten"
+            }
+          ],
+          "destination": "FS.setUserVars"
+        },
+        {
+          "id": "fs-identify-ceddl-user-all",
+          "description": "send all CEDDL user properties to FS.identify using the profileID as the FullStory uid",
+          "source": "digitalData.user.profile[0]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "insert",
+              "select": "profileID"
+            }
+          ],
+          "destination": "FS.identify"
+        },
+        {
+          "id": "fs-identify-ceddl-user-allowed",
+          "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
+          "source": "digitalData.user.profile[0]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "query",
+              "select": "$[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]"
+            },
+            {
+              "name": "insert",
+              "select": "profileID"
+            }
+          ],
+          "destination": "FS.identify"
+        }
+      ];
+    </script>
+    <script async="true" src="../../build/dlo.js"></script>
+
+    <script>
+      // Set up the CEDDL data
+      window.digitalData = {
+        pageInstanceID: '755ebb86-60b5-451e-92d3-044157d29965',
+        page: {
+          pageInfo: {
+            pageID: '1745',
+            pageName: 'The Fruit Shoppe',
+            destinationURL: 'https://fruitshoppe.firebaseapp.com/',
+            referringURL: 'https://www.google.com/url?&q=The%20Fruit%20Shoppe',
+            sysEnv: 'desktop',
+            variant: '2',
+            version: '1.14',
+            breadcrumbs: ['home', 'Products'],
+            author: 'D Falco',
+            issueDate: '2020-06-23',
+            effectiveDate: '2020-07-23',
+            expiryDate: '2021-06-23',
+            language: 'en-US',
+            industryCodes: '7372',
+            publisher: 'FullStory',
+          },
+          category: {
+            primaryCategory: 'homepage',
+          },
+        },
+        product: [{
+          productInfo: {
+            productID: '668ebb86-60b5-451e-92d3-044157d27823',
+            productName: 'Cosmic Crisp Apple',
+            description: 'A crisp and cosmic apple',
+            productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+            productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+            productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+            manufacturer: 'Washington State Apple Farm',
+            sku: 'cca-1234',
+            color: 'red and white',
+            size: 'medium',
+          },
+          category: {
+            primaryCategory: 'fruit',
+          },
+          linkedProduct: [],
+        }],
+        cart: {
+          cartID: 'cart-1234',
+          price: {
+            basePrice: 15.55,
+            voucherCode: '',
+            voucherDiscount: 0,
+            currency: 'USD',
+            taxRate: 0.09,
+            shipping: 5.0,
+            shippingMethod: 'UPS-Ground',
+            priceWithTax: 16.95,
+            cartTotal: 21.95,
+          },
+          item: [{
+            productInfo: {
+              productID: '668ebb86-60b5-451e-92d3-044157d27823',
+              productName: 'Cosmic Crisp Apple',
+              description: 'A crisp and cosmic apple',
+              productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+              productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+              productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+              manufacturer: 'Washington State Apple Farm',
+              sku: 'cca-1234',
+              color: 'red and white',
+              size: 'medium',
+            },
+            category: { primaryCategory: 'fruit' },
+            price: {
+              basePrice: 15.55,
+              voucherCode: '',
+              voucherDiscount: 0,
+              currency: 'USD',
+              taxRate: 0.09,
+              shipping: 5.0,
+              shippingMethod: 'UPS-Ground',
+              priceWithTax: 16.95,
+            },
+            quantity: 1,
+            linkedProduct: [],
+            attributes: {},
+          }],
+          attributes: {},
+        },
+        transaction: {
+          transactionID: 'tr-235098236',
+          profile: {
+            profileInfo: {
+              profileID: 'pr-12333211',
+              userName: 'JohnyAppleseed',
+            },
+            address: {
+              line1: '123 Easy St.',
+              line2: '',
+              city: 'Athens',
+              stateProvince: 'GA',
+              postalCode: '30606',
+              country: 'USA',
+            },
+            shippingAddress: {
+              line1: '123 Easy St.',
+              line2: '',
+              city: 'Athens',
+              stateProvince: 'GA',
+              postalCode: '30606',
+              country: 'USA',
+            },
+          },
+          total: {
+            basePrice: 15.55,
+            voucherCode: '',
+            voucherDiscount: 0,
+            currency: 'USD',
+            taxRate: 0.09,
+            shipping: 5.0,
+            shippingMethod: 'UPS-Ground',
+            priceWithTax: 16.95,
+            transactionTotal: 16.95,
+          },
+          attributes: {},
+          item: [{
+            productInfo: {
+              productID: '668ebb86-60b5-451e-92d3-044157d27823',
+              productName: 'Cosmic Crisp Apple',
+              description: 'A crisp and cosmic apple',
+              productURL: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823',
+              productImage: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/image',
+              productThumbnail: 'https://fruitshoppe.firebaseapp.com/product/668ebb86-60b5-451e-92d3-044157d27823/thumbnail',
+              manufacturer: 'Washington State Apple Farm',
+              sku: 'cca-1234',
+              color: 'red and white',
+              size: 'medium',
+            },
+            category: { primaryCategory: 'fruit' },
+            price: {
+              basePrice: 15.55,
+              voucherCode: '',
+              voucherDiscount: 0,
+              currency: 'USD',
+              taxRate: 0.09,
+              shipping: 5.0,
+              shippingMethod: 'UPS-Ground',
+              priceWithTax: 16.95,
+            },
+            quantity: 1,
+            linkedProduct: [],
+            attributes: {},
+          }],
+        },
+        event: [{
+          eventInfo: {
+            eventName: 'Cart Item Added',
+            eventAction: 'cart-item-added',
+            eventPoints: 11,
+            type: 'cart-modifier',
+            timeStamp: new Date(),
+            effect: 'cart has a new item',
+          },
+          category: {
+            primaryCategory: 'cart',
+            attributes: {},
+          },
+        }],
+        component: [{
+          componentInfo: {
+            componentID: 'c-54123',
+            componentName: 'Cosmic Crisp Promo Video',
+            description: 'A video showing you just how cosmic and just how crisp is this apple.',
+          },
+          category: {
+            primaryCategory: 'promo-video',
+            componentType: 'video',
+            attributes: {},
+          },
+        }],
+        user: {
+          segment: {},
+          profile: [{
+            profileInfo: {
+              profileID: 'pr-12333211',
+              userName: 'JohnyAppleseed',
+            },
+            address: {
+              line1: '123 Easy St.',
+              line2: '',
+              city: 'Athens',
+              stateProvince: 'GA',
+              postalCode: '30606',
+              country: 'USA',
+            },
+            social: {},
+            attributes: {},
+          }],
+        },
+        privacy: {
+          accessCategories: [{
+            categoryName: 'analytics',
+            domains: ['fruitshoppe.firebaseapp.com'],
+          }],
+        },
+        version: "1.0",
+      };
+
+    </script>
+  </body>
+</html>

--- a/examples/ceddl-fs/index.html
+++ b/examples/ceddl-fs/index.html
@@ -1,206 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Data Layer Observer Example: basic embed</title>
+    <title>Data Layer Observer Example: CEDDL to FullStory</title>
     <meta charset="utf-8" />
-    <script>
-      /* These are examples of static data that will be read on load */
-      window.exampleData = {
-        page: {
-          pageName: 'basic embed',
-          pageInfo: {
-            pageID: '1234'
-          }
-        }
-      }
-      window.adInformation = {
-        accountID: 'abcd'
-      }
-      window.ops = {
-        clusterInfo: {
-          id: '444-111-11231',
-          load: 0.4
-        }
-      }
-
-      /* This function will receive information as the DLO rules find it */
-      function ruleDestination(info) {
-        console.log('ruleDestination received:', info);
-      }
-    </script>
-  </head>
-  <body>
-    <h1>Data Layer Observer Example: basic embed</h1>
-
-    <p>Take a look at the source code of this page to see how the DLO reads rules and configuration.</p>
-    <p>The Javascript console will show you output that demonstrates the rules in action.</p>
-
-    <script>
-      window['_dlo_previewMode'] = true;
-      window['_dlo_readOnLoad'] = true;
-      window['_dlo_validateRules'] = true;
-
-      window['_dlo_rules'] = [
-        {
-          "id": "fs-event-ceddl-cart",
-          "description": "send CEDDL cart's cartID and price properties to FS.event as a 'View Cart' event",
-          "source": "digitalData.cart[(cartID,price)]",
-          "operators": [
-            {
-              "name": "insert",
-              "value": "View Cart"
-            }
-          ],
-          "destination": "FS.event"
-        },
-        {
-          "id": "fs-event-ceddl-cart-not-items",
-          "description": "send CEDDL cart properties except items list to FS.event as a 'View Cart' event",
-          "source": "digitalData.cart",
-          "operators": [
-            {
-              "name": "query",
-              "select": "$[!(items)]"
-            },
-            {
-              "name": "insert",
-              "value": "View Cart"
-            }
-          ],
-          "destination": "FS.event"
-        },
-        {
-          "id": "fs-event-ceddl-cart-convert",
-          "description": "converts and sends CEDDL cart properties to FS.event as a 'View Cart' event",
-          "source": "digitalData.cart",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "convert",
-              "properties": "basePrice,priceWithTax,cartTotal",
-              "type": "real"
-            },
-            {
-              "name": "insert",
-              "value": "View Cart"
-            }
-          ],
-          "destination": "FS.event"
-        },
-        {
-          "id": "fs-event-ceddl-page-omit-convert",
-          "description": "convert and send CEDDL page properties to FS.event as a 'Page' event",
-          "source": "digitalData.page",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "query",
-              "select": "$[!(destinationURL,referringURL)]"
-            },
-            {
-              "name": "convert",
-              "properties": "version",
-              "type": "real"
-            },
-            {
-              "name": "convert",
-              "properties": "issueDate,effectiveDate,expiryDate",
-              "type": "date"
-            },
-            {
-              "name": "insert",
-              "value": "digitalData.page"
-            }
-          ],
-          "destination": "FS.event"
-        },
-        {
-          "id": "fs-event-ceddl-product",
-          "description": "send the latest CEDDL product's primaryCategory, sku, productID, and productName properties to FS.event as a 'View Product' event",
-          "source": "digitalData.product[-1]",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "query",
-              "select": "$[(primaryCategory, sku, productID, productName)]"
-            },
-            {
-              "name": "insert",
-              "value": "View Product"
-            }
-          ],
-          "destination": "FS.event"
-        },
-        {
-          "id": "fs-event-ceddl-transaction-id-total",
-          "description": "send CEDDL transaction's transactionID and total properties to FS.event as a 'Order Completed' event",
-          "source": "digitalData.transaction[(transactionID,total)]",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "insert",
-              "value": "Order Completed"
-            }
-          ],
-          "destination": "FS.event"        
-        },
-        {
-          "id": "fs-uservars-ceddl-user-all",
-          "description": "send all CEDDL user properties to FS.setUserVars",
-          "source": "digitalData.user.profile[0]",
-          "operators": [
-            {
-              "name": "flatten"
-            }
-          ],
-          "destination": "FS.setUserVars"
-        },
-        {
-          "id": "fs-identify-ceddl-user-all",
-          "description": "send all CEDDL user properties to FS.identify using the profileID as the FullStory uid",
-          "source": "digitalData.user.profile[0]",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "insert",
-              "select": "profileID"
-            }
-          ],
-          "destination": "FS.identify"
-        },
-        {
-          "id": "fs-identify-ceddl-user-allowed",
-          "description": "send only known CEDDL user properties to FS.identify using the profileID as the FullStory uid",
-          "source": "digitalData.user.profile[0]",
-          "operators": [
-            {
-              "name": "flatten"
-            },
-            {
-              "name": "query",
-              "select": "$[(profileID,userName,line1,line2,city,stateProvince,postalCode,country)]"
-            },
-            {
-              "name": "insert",
-              "select": "profileID"
-            }
-          ],
-          "destination": "FS.identify"
-        }
-      ];
-    </script>
-    <script async="true" src="../../build/dlo.js"></script>
-
     <script>
       // Set up the CEDDL data
       window.digitalData = {
@@ -406,7 +208,116 @@
         },
         version: "1.0",
       };
-
     </script>
+  </head>
+  <body>
+    <h1>Data Layer Observer Example: CEDDL to FullStory</h1>
+
+    <p>Take a look at the source code of this page to see how the DLO reads rules and configuration.</p>
+    <p>The Javascript console will show you output that demonstrates the rules in action.</p>
+
+    <script>
+      window['_dlo_previewMode'] = true;
+      window['_dlo_readOnLoad'] = true;
+      window['_dlo_validateRules'] = true;
+
+      window['_dlo_rules'] = [
+        {
+          "id": "fs-event-ceddl-cart-convert",
+          "description": "converts and sends CEDDL cart properties to FS.event as a 'View Cart' event",
+          "source": "digitalData.cart",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "convert",
+              "properties": "basePrice,priceWithTax,cartTotal",
+              "type": "real"
+            },
+            {
+              "name": "insert",
+              "value": "View Cart"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-page-omit-convert",
+          "description": "convert and send CEDDL page properties to FS.event as a 'Page' event",
+          "source": "digitalData.page",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "query",
+              "select": "$[!(destinationURL,referringURL)]"
+            },
+            {
+              "name": "convert",
+              "properties": "version",
+              "type": "real"
+            },
+            {
+              "name": "convert",
+              "properties": "issueDate,effectiveDate,expiryDate",
+              "type": "date"
+            },
+            {
+              "name": "insert",
+              "value": "digitalData.page"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-event-ceddl-product",
+          "description": "send the latest CEDDL product's primaryCategory, sku, productID, and productName properties to FS.event as a 'View Product' event",
+          "source": "digitalData.product[-1]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "query",
+              "select": "$[(primaryCategory, sku, productID, productName)]"
+            },
+            {
+              "name": "insert",
+              "value": "View Product"
+            }
+          ],
+          "destination": "FS.event"
+        },
+        {
+          "id": "fs-uservars-ceddl-user-all",
+          "description": "send all CEDDL user properties to FS.setUserVars",
+          "source": "digitalData.user.profile[0]",
+          "operators": [
+            {
+              "name": "flatten"
+            }
+          ],
+          "destination": "FS.setUserVars"
+        },
+        {
+          "id": "fs-identify-ceddl-user-all",
+          "description": "send all CEDDL user properties to FS.identify using the profileID as the FullStory uid",
+          "source": "digitalData.user.profile[0]",
+          "operators": [
+            {
+              "name": "flatten"
+            },
+            {
+              "name": "insert",
+              "select": "profileID"
+            }
+          ],
+          "destination": "FS.identify"
+        }
+      ];
+    </script>
+    <script async="true" src="../../build/dlo.js"></script>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,6 +12,10 @@
         <a href="./basic-embed/">Basic Embed</a>:
         <p>A single HTML file that demonstrates how to use the script as an embedded script</p>
       </li>
+      <li>
+        <a href="./ceddl-fs/">CEDDL to FullStory</a>:
+        <p>Demonstrates how to map CEDDL data to FullStory events</p>
+      </li>
     </ul>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3355,9 +3355,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.61",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
-          "integrity": "sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q==",
+          "version": "8.10.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.62.tgz",
+          "integrity": "sha512-76fupxOYVxk36kb7O/6KtrAPZ9jnSK3+qisAX4tQMEuGNdlvl7ycwatlHqjoE6jHfVtXFM3pCrCixZOidc5cuw==",
           "dev": true
         }
       }
@@ -4797,9 +4797,9 @@
       }
     },
     "web-embed-lab": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/web-embed-lab/-/web-embed-lab-0.2.11.tgz",
-      "integrity": "sha512-dpFrpYetSDAN4oGikwwsp1QESjC3/3iTTLOGT/IFGZXlw1cp4uNKVjMRqW4moeQfjh4/fbr2rcOmi9jKm47zCw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/web-embed-lab/-/web-embed-lab-0.2.12.tgz",
+      "integrity": "sha512-KRcblPX6iTg4psNctrv/okcTN0qWlGpryn2Wrr4ktYPskcIGCyxMNHJQl4jJ6EdAU24RSb9ra0Qs6s6ud8PL5w==",
       "dev": true,
       "requires": {
         "go-npm": "^0.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,12 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
@@ -353,6 +359,31 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
       "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/tough-cookie": {
       "version": "4.0.0",
@@ -469,6 +500,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -707,11 +744,30 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -748,6 +804,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "caching-transform": {
@@ -792,6 +854,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -1184,6 +1255,21 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
       "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
       "dev": true
+    },
+    "decompress-zip": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
+      "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
+      "dev": true,
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      }
     },
     "dedent": {
       "version": "0.7.0",
@@ -2029,6 +2115,29 @@
       "dev": true,
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2117,6 +2226,17 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "go-npm": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/go-npm/-/go-npm-0.1.9.tgz",
+      "integrity": "sha1-hcExXcsFVB7GOmAjjdOePAowcE8=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "request": "^2.81.0",
+        "tar": "^2.2.1"
+      }
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -3169,6 +3289,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+      "dev": true
+    },
     "mocha": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz",
@@ -3214,6 +3340,28 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ngrok": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-3.2.7.tgz",
+      "integrity": "sha512-B7K15HM0qRZplL2aO/yfxixYubH0M50Pfu0fa4PDcmXP7RC+wyYzu6YtX77BBHHCfbwCzkObX6YdO8ThpCR6Lg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^8.10.50",
+        "@types/request": "^2.48.2",
+        "decompress-zip": "^0.3.2",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.7",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.61",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.61.tgz",
+          "integrity": "sha512-l+zSbvT8TPRaCxL1l9cwHCb0tSqGAGcjPJFItGGYat5oCTiq1uQQKYg5m7AF1mgnEBzFXGLJ2LRmNjtreRX76Q==",
+          "dev": true
+        }
+      }
+    },
     "node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -3221,6 +3369,15 @@
       "dev": true,
       "requires": {
         "process-on-spawn": "^1.0.0"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -3723,6 +3880,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -3797,6 +3960,26 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
@@ -4209,6 +4392,12 @@
         "es-abstract": "^1.17.5"
       }
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -4310,6 +4499,17 @@
         }
       }
     },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
     "terser": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -4367,6 +4567,26 @@
         "is-number": "^7.0.0"
       }
     },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -4386,6 +4606,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
     },
     "ts-node": {
       "version": "8.10.2",
@@ -4568,6 +4794,16 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "web-embed-lab": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/web-embed-lab/-/web-embed-lab-0.2.11.tgz",
+      "integrity": "sha512-dpFrpYetSDAN4oGikwwsp1QESjC3/3iTTLOGT/IFGZXlw1cp4uNKVjMRqW4moeQfjh4/fbr2rcOmi9jKm47zCw==",
+      "dev": true,
+      "requires": {
+        "go-npm": "^0.1.9",
+        "ngrok": "^3.2.5"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "watch": "rollup --config -w",
     "examples": "npm run build && http-server",
     "test": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/*.spec.ts test/**/*.spec.ts",
-    "lint": "eslint --ext .ts src/** test/**",
-    "lint:fix": "eslint --ext .ts --fix src/** test/**"
+    "test:wel-auto-formulate": "cd ./test/web-embed-lab && ./auto-formulate.sh",
+    "test:wel-runner": "npm run build && cd ./test/web-embed-lab && ./run-tests.sh",
+    "lint": "eslint --ext .ts src/** test/mocks/** test/utils/** test/*.ts",
+    "lint:fix": "eslint --ext .ts --fix src/**  test/mocks/** test/utils/** test/*.ts"
   },
   "husky": {
     "hooks": {
@@ -18,7 +20,7 @@
   },
   "lint-staged": {
     "src/**": "eslint --ext .ts --fix",
-    "test/**": "eslint --ext .ts --fix"
+    "test/**": "eslint --ext .ts --fix --ignore-pattern=test/web-embed-lab/**"
   },
   "repository": {
     "type": "git",
@@ -58,6 +60,7 @@
     "rollup-plugin-terser": "^6.1.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.5"
+    "typescript": "^3.9.5",
+    "web-embed-lab": "^0.2.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "rollup --config -w",
     "examples": "npm run build && http-server",
     "test": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/*.spec.ts test/**/*.spec.ts",
-    "test:wel-auto-formulate": "cd ./test/web-embed-lab && ./auto-formulate.sh",
+    "test:wel-auto-formulate": "npm run examples & cd ./test/web-embed-lab && ./auto-formulate.sh",
     "test:wel-runner": "npm run build && cd ./test/web-embed-lab && ./run-tests.sh",
     "lint": "eslint --ext .ts src/** test/mocks/** test/utils/** test/*.ts",
     "lint:fix": "eslint --ext .ts --fix src/**  test/mocks/** test/utils/** test/*.ts"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "source-map-support": "^0.5.19",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.5",
-    "web-embed-lab": "^0.2.11"
+    "web-embed-lab": "^0.2.12"
   }
 }

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -85,7 +85,7 @@ export class ConvertOperator implements Operator {
     validator.validate(ConvertOperator.specification);
 
     const { type } = this.options;
-    if (type !== 'bool' && type !== 'int' && type !== 'real' && type !== 'string') {
+    if (type !== 'bool' && type !== 'int' && type !== 'real' && type !== 'string' && type !== 'date') {
       throw validator.throwError('type', `unknown type '${type}' used`);
     }
   }

--- a/test/web-embed-lab/.gitignore
+++ b/test/web-embed-lab/.gitignore
@@ -1,0 +1,4 @@
+/page-formulas/
+/captures/
+/certs/
+.env

--- a/test/web-embed-lab/.gitignore
+++ b/test/web-embed-lab/.gitignore
@@ -1,3 +1,4 @@
+ngrok-auto-formulate-config.yml
 /page-formulas/
 /captures/
 /certs/

--- a/test/web-embed-lab/README.md
+++ b/test/web-embed-lab/README.md
@@ -6,7 +6,7 @@ Web Embed Lab (WEL) is an [open source tool](https://github.com/fullstorydev/web
 
 WEL uses Browserstack and ngrok so you'll need to set up a `.env` configuration file or environment variables to give WEL the information it needs.  Read the [environment vars doc](https://github.com/fullstorydev/web-embed-lab/blob/master/docs/ENVIRONMENT_VARS.md) in the WEL repo for details.
 
-You'll also need to copy the `ngrok-auto-formulate-config.yml.example` into `ngrok-auto-formulate-config.yml.example`
+You'll also need to copy the `ngrok-auto-formulate-config.yml.example` into `ngrok-auto-formulate-config.yml.example` and update it with your ngrok API key.
 
 To test the DLO with WEL, there are two npm targets:
 

--- a/test/web-embed-lab/README.md
+++ b/test/web-embed-lab/README.md
@@ -1,0 +1,23 @@
+# Web Embed Lab
+
+The Web Embed Lab (WEL) is an [open source tool](https://github.com/fullstorydev/web-embed-lab) used to test that embedded scripts (like the DLO) don't negatively effect customer sites.
+
+## Configuration
+
+The WEL uses Browserstack so you'll need to set up a `.env` configuration file or environment variables to give the WEL the information it needs for your Browserstack account.  Read the [environment vars doc](https://github.com/fullstorydev/web-embed-lab/blob/master/docs/ENVIRONMENT_VARS.md) in the WEL repo for details.
+
+To test the DLO with the WEL, there are two npm targets:
+
+## Autoformulate
+
+The following command will capture example sites "freeze dry" them into replayable pages (WEL calls them "page formulas") in which we can run tests.
+
+	npm run test:wel-auto-formulate
+
+
+## Run tests
+
+The following command will run tests in the replayable pages that were captured using the command above.
+
+	npm run test:wel-runner
+

--- a/test/web-embed-lab/README.md
+++ b/test/web-embed-lab/README.md
@@ -1,23 +1,27 @@
 # Web Embed Lab
 
-The Web Embed Lab (WEL) is an [open source tool](https://github.com/fullstorydev/web-embed-lab) used to test that embedded scripts (like the DLO) don't negatively effect customer sites.
+Web Embed Lab (WEL) is an [open source tool](https://github.com/fullstorydev/web-embed-lab) used to test that embedded scripts (like the DLO) don't negatively affect customer sites.
 
 ## Configuration
 
-The WEL uses Browserstack so you'll need to set up a `.env` configuration file or environment variables to give the WEL the information it needs for your Browserstack account.  Read the [environment vars doc](https://github.com/fullstorydev/web-embed-lab/blob/master/docs/ENVIRONMENT_VARS.md) in the WEL repo for details.
+WEL uses Browserstack and ngrok so you'll need to set up a `.env` configuration file or environment variables to give WEL the information it needs.  Read the [environment vars doc](https://github.com/fullstorydev/web-embed-lab/blob/master/docs/ENVIRONMENT_VARS.md) in the WEL repo for details.
 
-To test the DLO with the WEL, there are two npm targets:
+You'll also need to copy the `ngrok-auto-formulate-config.yml.example` into `ngrok-auto-formulate-config.yml.example`
+
+To test the DLO with WEL, there are two npm targets:
 
 ## Autoformulate
 
 The following command will capture example sites "freeze dry" them into replayable pages (WEL calls them "page formulas") in which we can run tests.
 
+```bash
 	npm run test:wel-auto-formulate
-
+```
 
 ## Run tests
 
 The following command will run tests in the replayable pages that were captured using the command above.
 
+```bash
 	npm run test:wel-runner
-
+```

--- a/test/web-embed-lab/auto-formulate.conf.json
+++ b/test/web-embed-lab/auto-formulate.conf.json
@@ -13,8 +13,37 @@
       "sites": [
         {
           "name": "basic-embed",
-          "url": "https://tfs.ngrok.io/examples/basic-embed/",
-          "close-pause": 10
+          "url": "https://dlowel.ngrok.io/examples/basic-embed/",
+          "close-pause": 5,
+          "modifiers": [
+            {
+              "mime-type-selectors": ["text/html"],
+              "replacements": [
+                {
+                  "selector": "<script async=\"true\" src=\"../../build/dlo.js\">(?s:.*)</script>",
+                  "replacement": "<!-- removed original script -->",
+                  "all": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "ceddl-fs",
+          "url": "https://dlowel.ngrok.io/examples/ceddl-fs/",
+          "close-pause": 5,
+          "modifiers": [
+            {
+              "mime-type-selectors": ["text/html"],
+              "replacements": [
+                {
+                  "selector": "<script async=\"true\" src=\"../../build/dlo.js\">(?s:.*)</script>",
+                  "replacement": "<!-- removed original script -->",
+                  "all": true
+                }
+              ]
+            }
+          ]
         }
       ]
     }
@@ -26,8 +55,26 @@
       "probe-basis": {
         "dom-shape": {
           "relative": {
-            "depth": [-5, 5],
-            "width": [-5, 5]
+            "depth": 0,
+            "width": 0
+          }
+        },
+        "exceptions": {
+          "relative": {
+            "comment": "this is 1 because one of the rules is bogus",
+            "count": 1
+          }
+        }
+      }
+    },
+    {
+      "capture-name": "ceddl-fs",
+      "formula-name": "ceddl-fs",
+      "probe-basis": {
+        "dom-shape": {
+          "relative": {
+            "depth": 0,
+            "width": 0
           }
         },
         "exceptions": {

--- a/test/web-embed-lab/auto-formulate.conf.json
+++ b/test/web-embed-lab/auto-formulate.conf.json
@@ -1,0 +1,41 @@
+{
+  "captures": [
+    {
+      "browser-configuration":     {
+        "name": "Chrome 75",
+        "os": "Windows",
+        "osVersion": "10",
+        "browserName": "Chrome",
+        "browserVersion": "75.0",
+        "resolution": "1024x768",
+        "browserstack.console": "verbose"
+      },
+      "sites": [
+        {
+          "name": "basic-embed",
+          "url": "https://tfs.ngrok.io/examples/basic-embed/",
+          "close-pause": 10
+        }
+      ]
+    }
+  ],
+  "formulations": [
+    {
+      "capture-name": "basic-embed",
+      "formula-name": "basic-embed",
+      "probe-basis": {
+        "dom-shape": {
+          "relative": {
+            "depth": [-5, 5],
+            "width": [-5, 5]
+          }
+        },
+        "exceptions": {
+          "relative": {
+            "count": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/web-embed-lab/auto-formulate.sh
+++ b/test/web-embed-lab/auto-formulate.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+killall ngrok
 set -e
+
+ngrok http -config=./ngrok-auto-formulate-config.yml -subdomain=dlowel 8080 &
 
 rm -rf ./captures/*
 rm -rf ./page-formulas/*
 FRONT_END_DIST=../../node_modules/web-embed-lab/static/ auto-formulate ./auto-formulate.conf.json ./page-formulas/
+
+set +e
+killall ngrok

--- a/test/web-embed-lab/auto-formulate.sh
+++ b/test/web-embed-lab/auto-formulate.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+rm -rf ./captures/*
+rm -rf ./page-formulas/*
+FRONT_END_DIST=../../node_modules/web-embed-lab/static/ auto-formulate ./auto-formulate.conf.json ./page-formulas/

--- a/test/web-embed-lab/ngrok-auto-formulate-config.yml.example
+++ b/test/web-embed-lab/ngrok-auto-formulate-config.yml.example
@@ -1,0 +1,3 @@
+authtoken: <YOUR AUTH TOKEN HERE>
+web_addr: false
+console_ui: false

--- a/test/web-embed-lab/run-tests.sh
+++ b/test/web-embed-lab/run-tests.sh
@@ -6,3 +6,4 @@ FRONT_END_DIST=../../node_modules/web-embed-lab/static/ runner ./page-formulas/ 
 
 set +e
 killall ngrok
+echo "Finished test"

--- a/test/web-embed-lab/run-tests.sh
+++ b/test/web-embed-lab/run-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+FRONT_END_DIST=../../node_modules/web-embed-lab/static/ runner ./page-formulas/ ./test-probes/ ../../build/dlo.js ./runner.conf.json

--- a/test/web-embed-lab/run-tests.sh
+++ b/test/web-embed-lab/run-tests.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+killall ngrok
 set -e
 
 FRONT_END_DIST=../../node_modules/web-embed-lab/static/ runner ./page-formulas/ ./test-probes/ ../../build/dlo.js ./runner.conf.json
+
+set +e
+killall ngrok

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -1,7 +1,8 @@
 {
   "comment": "This experiment tests the sites of the largest users of FullStory",
   "page-formulas": [
-    { "name": "basic-embed" }
+    { "name": "basic-embed" },
+    { "name": "ceddl-fs" }
   ],
   "browser-configurations": [
     {
@@ -32,7 +33,8 @@
   "test-runs": [
     {
       "page-formulas": [
-        "basic-embed"
+        "basic-embed",
+        "ceddl-fs"
       ],
       "test-probes": [
         "dom-shape",

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -12,22 +12,6 @@
       "browserName" : "Chrome",
       "browserVersion" : "83.0",
       "resolution" : "1024x768"
-    },
-    {
-      "name": "Desktop Firefox 1",
-      "os": "Windows",
-      "osVersion": "10",
-      "browserName": "Firefox",
-      "browserVersion": "77",
-      "resolution": "1024x768"
-    },
-    {
-      "name": "Desktop Safari 1",
-      "os" : "OS X",
-      "os_version" : "Catalina",
-      "browserName" : "Safari",
-      "browser_version" : "13.1",
-      "resolution": "1024x768"
     }
   ],
   "test-runs": [

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -1,0 +1,47 @@
+{
+  "comment": "This experiment tests the sites of the largest users of FullStory",
+  "page-formulas": [
+    { "name": "basic-embed" }
+  ],
+  "browser-configurations": [
+    {
+      "name": "Desktop Chrome 1",
+      "os": "Windows",
+      "osVersion" : "10",
+      "browserName" : "Chrome",
+      "browserVersion" : "83.0",
+      "resolution" : "1024x768"
+    },
+    {
+      "name": "Desktop Firefox 1",
+      "os": "Windows",
+      "osVersion": "10",
+      "browserName": "Firefox",
+      "browserVersion": "77",
+      "resolution": "1024x768"
+    },
+    {
+      "name": "Desktop Safari 1",
+      "os" : "OS X",
+      "os_version" : "Catalina",
+      "browserName" : "Safari",
+      "browser_version" : "13.1",
+      "resolution": "1024x768"
+    }
+  ],
+  "test-runs": [
+    {
+      "page-formulas": [
+        "basic-embed"
+      ],
+      "test-probes": [
+        "dom-shape",
+        "exceptions"
+      ],
+      "browsers": [
+        "Desktop Chrome 1"
+      ],
+      "head-snippet": "<script> console.log('Head snippet'); </script>"
+    }
+  ]
+}

--- a/test/web-embed-lab/test-probes/dom-shape/test.js
+++ b/test/web-embed-lab/test-probes/dom-shape/test.js
@@ -1,0 +1,83 @@
+/**
+DOM shape test probe
+*/
+class DOMShapeProbe {
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@property {bool} success - true if the data collection was successful
+	@property {int} width - DOM width
+	@property {int} depth - DOM depth
+	*/
+	async gatherBaselineData(){
+		console.log('Baseline DOM shape')
+		const [width, depth] = this._findWidthAndDepth()
+		return {
+			success: true,
+			width: width,
+			depth: depth
+		}
+	}
+
+	/**
+	@return {Object} the results of the probe
+	@property {bool} passed
+	@property {int} width - DOM width
+	@property {int} depth - DOM depth
+	*/
+	async probe(basis, baseline){
+		console.log('Probing DOM shape', baseline)
+
+		const [width, depth] = this._findWidthAndDepth()
+		const results = {
+			passed: true,
+			depth: depth,
+			width: width
+		}
+		if(!basis) return results
+
+		for(const prop of ["depth", "width"]){
+			if(typeof basis[prop] === 'undefined'){
+				continue
+			}
+			if(window.__welValueMatches(results[prop], basis[prop]) === false){
+				results.passed = false
+			}
+		}
+
+		if(typeof basis["relative"] !== 'object'){
+			return results
+		}
+
+		const relativeBasis = basis["relative"]
+		for(const prop of ["depth", "width"]){
+			if(typeof relativeBasis[prop] === 'undefined'){
+				continue
+			}
+			if(window.__welValueMatches(results[prop], relativeBasis[prop], baseline[prop]) === false){
+				results.passed = false
+			}
+		}
+		return results
+	}
+
+	// returns [width, depth]
+	_findWidthAndDepth(){
+		const shape = this._findShape(document.body)
+		let width = 0;
+		for(let i=0; i < shape.rows.length; i++){
+			width = Math.max(width, shape.rows[i].length)
+		}
+		return [width, shape.rows.length]
+	}
+
+	_findShape(element, depth=0, results={ rows: [] }){
+		if(!results.rows[depth]) results.rows[depth] = []
+		results.rows[depth].push(element.children.length)
+		for(let i=0; i < element.children.length; i++){
+			this._findShape(element.children[i], depth + 1, results)
+		}
+		return results
+	}
+}
+
+window.__welProbes['dom-shape'] = new DOMShapeProbe()

--- a/test/web-embed-lab/test-probes/exceptions/test.js
+++ b/test/web-embed-lab/test-probes/exceptions/test.js
@@ -1,0 +1,68 @@
+
+class ExceptionsProbe {
+	constructor(){
+		window._exceptionCount = 0
+		window._oldErrorPrototype = window.Error.prototype
+		window.Error = function(...params){
+			if(this instanceof window.Error === false){
+				return new Error(...params)
+			}
+			window._exceptionCount = window._exceptionCount + 1
+			return window._oldErrorPrototype.constructor.call(this, ...params)
+		}
+		window.Error.prototype = window._oldErrorPrototype
+	}
+
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} true if the data collection was successful
+	@return {Object.count} total number of throws exceptions
+	*/
+	async gatherBaselineData(){
+		console.log('Exceptions baseline')
+		if(typeof window._exceptionCount !== 'number'){
+			return {
+				success: false,
+				error: 'window._exceptionCount does not exist'
+			}
+		}
+		return {
+			success: true,
+			count: window._exceptionCount
+		}
+	}
+
+	/**
+	@param {object} results - the object on which to set result attributes
+	*/
+	async probe(basis, baseline){
+		const results = {
+			passed: true,
+			count: window._exceptionCount
+		}
+		if(!basis){
+			return results
+		}
+
+		if(typeof basis.count !== 'undefined'){
+			if(window.__welValueMatches(results.count, basis.count) === false){
+				results.passed = false
+			}
+		}
+
+		if(typeof basis.relative !== 'object'){
+			return results
+		}
+		if(typeof basis.relative.count === 'undefined'){
+			return results
+		}
+
+		if(window.__welValueMatches(results.count, basis.relative.count, baseline.count) === false){
+			results.passed = false
+		}
+
+		return results
+	}
+}
+
+window.__welProbes['exceptions'] = new ExceptionsProbe()

--- a/test/web-embed-lab/test-probes/fs-backend/test.js
+++ b/test/web-embed-lab/test-probes/fs-backend/test.js
@@ -1,0 +1,194 @@
+/**
+FullStory test probe sets up interceptors for FS network data.
+This means the tests aren't dependent on the FS service.
+Currently no tests are run against the captured data.
+*/
+
+/** The canned response for /rec/page requests */
+const pageResponse = {
+	Consented: false,
+	CookieDomain: "localhost",
+	Blocks: [],
+	Watches: [],
+	AjaxWatches: [],
+	UserIntId: "999",
+	SessionIntId: "123",
+	PageIntId: "321",
+	EmbedToken: "",
+	GetCurrentSessionEnabled: true,
+	ResourceUploadingEnabled: false,
+	AjaxWatcherEnabled: true,
+	ConsoleWatcherEnabled: true,
+	PageStart: new Date().getTime()
+};
+
+/**
+FullStoryEndpoint is a base class for mock endpoints for the FullStory backend
+*/
+class FullStoryEndpoint {
+	/* Route the send request to an appropriate handler method */
+	handleSend(xhr) {
+		let methodName = "handleSend" + xhr._openedMethod;
+		if (typeof this[methodName] !== "function") {
+			console.error("Unhandled method", xhr._openedMethod, url, ...args);
+			return;
+		}
+		convertXHRToMock(xhr)
+		return this[methodName](xhr);
+	}
+}
+
+/**
+Overwrites several properties of XMLHttpRequest so that they are mutable.
+This is a dead-simple form of mocking XHR but it works for fs.js.
+*/
+function convertXHRToMock(xhr){
+	Object.defineProperty(xhr, "response", {
+		set: function(val) { this._newResponseVal = val; },
+		get: function() { return this._newResponseVal; }
+	});
+	Object.defineProperty(xhr, "responseText", {
+		get: function() { return JSON.stringify(this._newResponseVal); }
+	});
+	Object.defineProperty(xhr, "status", {
+		set: function(val) { this._newStatusVal = val; },
+		get: function() { return this._newStatusVal; }
+	});
+	Object.defineProperty(xhr, "statusText", {
+		get: function() { return 'OK'; }
+	});
+	Object.defineProperty(xhr, "readyState", {
+		set: function(val) { this._newReadyStateVal = val; },
+		get: function() { return this._newReadyStateVal; }
+	});
+}
+
+// Handles /rec/page
+class FullStoryPageEndpoint extends FullStoryEndpoint {
+	handleSendPOST(xhr) {
+		pageResponse.PageStart = new Date().getTime();
+		xhr.response = JSON.parse(JSON.stringify(pageResponse)); // clones pageResponse
+		xhr.status = 200;
+		xhr.readyState = 4;
+		xhr.onreadystatechange()
+	}
+}
+
+// Handles /rec/bundle
+class FullStoryBundleEndpoint extends FullStoryEndpoint {
+	handleSendPOST(xhr) {
+		xhr.response = {
+			BundleTime: new Date().getTime()
+		};
+		xhr.status = 200;
+		xhr.readyState = 4;
+		xhr.onreadystatechange()
+	}
+}
+
+// Handles /rec/newResources
+class FullStoryNewResourcesEndpoint extends FullStoryEndpoint {
+	handleSendPOST(xhr) {
+		xhr.response = {};
+		xhr.status = 200;
+		xhr.readyState = 4;
+		xhr.onreadystatechange()
+	}
+}
+
+// Handles /rec/uploadResource
+class FullStoryUploadResourceEndpoint extends FullStoryEndpoint {
+	handleSendPOST(xhr) {
+		xhr.response = {};
+		xhr.status = 200;
+		xhr.readyState = 4;
+		xhr.onreadystatechange()
+	}
+}
+
+// This is the URL for the FS recording backend after being rewritten by the prober
+const fsURLPrefix = "/__wel_absolute/rs.fullstory.com/rec/";
+// This is the original URL for the FS recording backend
+const fsAbsoluteURLPrefix = "https://rs.fullstory.com/rec/"
+
+/**
+FullStoryBackendProbe is a test probe that installs a mock FullStory backend
+The /rec/except endpoint is hit by setting the `src` attribute on an Image so is not an XHR request
+*/
+class FullStoryBackendProbe {
+	constructor() {
+		this.pageEndpoint = new FullStoryPageEndpoint();
+		this.bundleEndpoint = new FullStoryBundleEndpoint();
+		this.newResourcesEndpoint = new FullStoryNewResourcesEndpoint();
+		this.uploadResourceEndpoint = new FullStoryUploadResourceEndpoint();
+
+		const self = this;
+
+		/**
+		Monkey patch the XHR.open method so that we can rewrite the fs URLs
+		*/
+		const originalOpen = XMLHttpRequest.prototype.open;
+		XMLHttpRequest.prototype.open = function() {
+			if (arguments[1].startsWith(fsURLPrefix)) {
+				arguments[1] =
+					fsAbsoluteURLPrefix +
+					arguments[1].substring(fsURLPrefix.length);
+			}
+			this._openedMethod = arguments[0]
+			this._openedURL = arguments[1]
+			return originalOpen.apply(this, arguments);
+		}
+		/**
+		Monkey patch the XHR.send method so that we can intercept recording requests
+		*/
+		const originalSend = XMLHttpRequest.prototype.send;
+		XMLHttpRequest.prototype.send = function() {
+			if (this._openedURL.startsWith(fsAbsoluteURLPrefix)) {
+				let path = this._openedURL.substring(fsAbsoluteURLPrefix.length);
+				if (path.indexOf("?") > 0) {
+					path = path.substring(0, path.indexOf("?"));
+				}
+
+				// Note: /rec/except is called by setting the `src` attribute of an Image, not by XHR
+
+				switch (path) {
+					case "page":
+						self.pageEndpoint.handleSend(this);
+						return;
+					case "bundle":
+						self.bundleEndpoint.handleSend(this);
+						return;
+					case "newResources":
+						self.newResourcesEndpoint.handleSend(this);
+						return;
+					case "uploadResource":
+						self.uploadResourceEndpoint.handleSend(this);
+						return;
+					default:
+						console.log("Unknown fs path", path, this._openedURL);
+				}
+			}
+			return originalSend.apply(this, arguments);
+		};
+	}
+
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} true if the data collection was successful
+	*/
+	async gatherBaselineData(){
+		console.log('Baseline FS backend')
+		return { success: true }
+	}
+
+	/**
+	@return {object} the results of the probe
+	*/
+	async probe(basis) {
+		// Currently does nothing.
+		// Eventually may do things like check that data has or hasn't been recorded.
+		return { passed: true };
+	}
+}
+
+window.__welProbes["fs-backend"] = new FullStoryBackendProbe();

--- a/test/web-embed-lab/test-probes/heap/test.js
+++ b/test/web-embed-lab/test-probes/heap/test.js
@@ -1,0 +1,143 @@
+
+/**
+HeapProbe is a test probe that tests heap memory sizes.
+It uses data in window._welHeapMemoryData which is provided by the prober-extension
+*/
+class HeapProbe {
+	constructor() {
+		console.log('Heap probe constructed')
+	}
+
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} true if the data collection was successful
+	@return {Object.heapMemoryData} total number of throws exceptions
+	*/
+	async gatherBaselineData(){
+		console.log('Heap baseline')
+		try {
+			await this._requestAndWaitForHeapMemory()
+			const heapMemoryData = this._latestHeapMemoryData()
+			return {
+				success: heapMemoryData !== null,
+				heapMemoryData: heapMemoryData
+			}
+		} catch (e) {
+			console.log('Error gathering heap baseline ' + e)
+			return {
+				success: false,
+				heapMemoryData: null,
+				comment: 'Error gathering heap baseline ' + e
+			}
+		}
+	}
+
+	/**
+	@return {Object} the results of the probe
+	@return {Object.passed}
+	@return {Object.heapMemoryData}
+	*/
+	async probe(basis, baseline) {
+		console.log('Probing heap')
+		try {
+			const result = {
+				passed: true,
+				heapMemoryData: null
+			}
+
+			if(!basis || Object.keys(basis).length == 0) {
+				result.passed = true
+				return result
+			}
+			await this._requestAndWaitForHeapMemory()
+			result.heapMemoryData = this._latestHeapMemoryData()
+
+			if(result.heapMemoryData === null){
+				result.passed = false
+				result.error = 'No heap memory data found.'
+				return result
+			}
+
+			if(result.heapMemoryData === null){
+				console.error('No heap memory data')
+				result.passed = false
+				return result
+			}
+
+			for(let key of Object.keys(basis)) {
+				if(key === 'relative') continue
+				const individualPass = this._testHeapMemoryKey(key, basis[key])
+				if(individualPass === false){
+					result.passed = false
+				}
+			}
+
+			if(typeof basis.relative === 'undefined'){
+				return result
+			}
+
+			for(let key of Object.keys(basis.relative)){
+				const individualPass = this._testHeapMemoryKey(key, basis.relative[key], baseline[key])
+				if(individualPass === false){
+					result.passed = false
+				}
+			}
+
+			return result
+		} catch (e) {
+			console.error('Heap probe error: ' + e + ' ' + e.lineNumber)
+			return {
+				passed: false,
+				error: 'Error: ' + e
+			}
+		}
+	}
+
+	_testHeapMemoryKey(key, basis, baseline=undefined){
+		const latestValue = this._latestHeapMemoryDataValue(key)
+		console.log('testing: ' + key + ' ' + latestValue + ' ' + basis)
+		if(baseline !== undefined) console.log('with baseline', baseline)
+		if(latestValue === null){
+			console.error('Heap memory test key does not exist', key)
+			return false
+		}
+		return window.__welValueMatches(latestValue, basis, baseline)
+	}
+
+	_latestHeapMemoryData(){
+		if(!window._welHeapMemoryData || window._welHeapMemoryData.length === 0) return null
+		return window._welHeapMemoryData[window._welHeapMemoryData.length - 1]
+	}
+
+	_latestHeapMemoryDataValue(key){
+		const latestMemoryData = this._latestHeapMemoryData()
+		if(latestMemoryData === null) return null
+		if(typeof latestMemoryData[key] === 'undefined') return null
+		return latestMemoryData[key]
+	}
+
+	async _requestAndWaitForHeapMemory(){
+		console.log("Starting heap profiler")
+		window.postMessage({ action: 'relay-to-background', subAction: 'enable-heap-profiler' }, '*')
+		window.__welWaitFor(1000)
+
+		window._welHeapMemoryData = []
+		let waitMilliseconds = 1000
+		let startTime = Date.now()
+		const totalWaits = 9
+		let waitsRemaining = totalWaits
+		while(window._welHeapMemoryData.length === 0 && waitsRemaining >= 0){
+			if (waitsRemaining % 3 === 0) {
+				console.log("Requesting heap")
+				window.postMessage({ action: 'relay-to-background', subAction: 'snapshot-heap' }, '*')
+			}
+			waitsRemaining -= 1
+			await window.__welWaitFor(waitMilliseconds)
+		}
+		if (window._welHeapMemoryData.length === 0) {
+			console.log("Did not receive a heap snapshot")
+		}
+	}
+}
+
+window.__welProbes["heap"] = new HeapProbe();

--- a/test/web-embed-lab/test-probes/performance/test.js
+++ b/test/web-embed-lab/test-probes/performance/test.js
@@ -1,0 +1,203 @@
+
+
+/**
+PerformanceProbe is a test probe that tests data in window._welPerformanceData
+*/
+class PerformanceProbe {
+	constructor() {
+		console.log('Performance probe constructed')
+	}
+
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} true if the data collection was successful
+	@return {Object.performanceData}
+	*/
+	async gatherBaselineData(){
+		console.log('Performance baseline')
+		if(!window._welPerformanceData){
+			return {
+				success: false,
+				error: 'No performance data was found'
+			}
+		}
+
+		return {
+			success: true,
+			performanceData: window._welPerformanceData[window._welPerformanceData.length - 1]
+		}
+	}
+
+	/**
+	@return {object} the results of the probe
+	@return {Object.passed}
+	@return {Object.performanceData}
+	*/
+	async probe(basis, baseline) {
+		console.log('Probing performance')
+		const result = {
+			passed: true,
+			description: ''
+		}
+
+		if(window._welPerformanceData){
+			result.performanceData = window._welPerformanceData[window._welPerformanceData.length - 1]
+		} else {
+			result.performanceData = null
+		}
+
+		if(!basis) {
+			return result
+		}
+
+		if(result.performanceData === null){
+			console.error('No performance data')
+			result.passed = false
+			return result
+		}
+
+		for(let key of Object.keys(basis)) {
+			if(key === 'relative') continue
+			const individualPass = this._testPerformanceKey(key, basis[key])
+			if(individualPass.passed === false){
+				result.passed = false
+				if(individualPass.description){
+					result.description += individualPass.description + ' '
+				}
+			}
+		}
+
+		if(typeof basis.relative === 'undefined'){
+			return result
+		}
+
+		for(let key of Object.keys(basis.relative)){
+			const baselineValue = this._readBaselineValue(key, baseline)
+			if (baselineValue === null) {
+				result.passed = false
+				result.description += 'Failed to read baseline value for relative test of ' + key + ' '
+				continue
+			}
+			const individualPass = this._testPerformanceKey(key, basis.relative[key], baselineValue, baseline)
+			if(individualPass.passed === false){
+				result.passed = false
+				if(individualPass.description){
+					result.description += individualPass.description + ' '
+				}
+			}
+		}
+
+		return result
+	}
+
+	_testPerformanceKey(key, basis=undefined, baselineValue=undefined, baseline=undefined){
+		if(typeof basis === 'undefined'){
+			return {
+				passed: false,
+				description: key + ' has no basis'
+			}
+		}
+		if(typeof basis.value === 'undefined'){
+			return {
+				passed: false,
+				description: key + ' has no basis.value'
+			}
+		}
+		let probeValue = this._latestPerformanceValue(key)
+		if(probeValue === null) {
+			console.error('Invalid performance key: ' + key)
+			return {
+				passed: false,
+				description: 'Invalid performance key: ' + key
+			}
+		}
+
+		if(typeof basis.subtract === 'string'){
+			let subtractionValue = this._latestPerformanceValue(basis.subtract)
+			if(subtractionValue === null){
+				console.error('Invalid subtract basis: ' + key + ' ' + basis.subtract)
+				return {
+					passed: false,
+					description: 'Invalid subtract basis: ' + key + ' ' + basis.subtract
+				}
+			}
+			probeValue = probeValue - subtractionValue
+
+			if(typeof baselineValue !== 'undefined'){
+				subtractionValue = this._readBaselineValue(basis.subtract, baseline)
+				if (typeof subtractionValue !== 'number') {
+					console.error('Did not find baseline subtraction value: ' + basis.subtract)
+					return {
+						passed: false,
+						description: 'Unknown baseline subtraction value: ' + basis.subtract
+					}
+				}
+				baselineValue = baselineValue - subtractionValue
+			}
+
+		}
+
+		if(window.__welValueMatches(probeValue, basis.value, baselineValue)){
+			return { passed: true }
+		}
+
+		let description = key + ' (' + probeValue + ') did not match ' + basis.value
+		if(baselineValue){
+			description += ' with baseline ' + baselineValue + ' resulting in ' + (probeValue - baselineValue)
+		}
+		return {
+			passed: false,
+			description: description
+		}
+	}
+
+	_readBaselineValue(key, baseline) {
+		const perfData = baseline['performanceData']
+		if (typeof perfData !== 'object') return null
+		const metrics = perfData['metrics']
+		if (Array.isArray(metrics) == false) return null
+		for(const metric of metrics) {
+			if (metric['name'] === key) return metric['value']
+		}
+		return null
+	}
+
+	_latestPerformanceValue(key){
+		const data = this._latestPerformanceData()
+		if (data === null) return null
+		for(let metric of data.metrics){
+			if(metric.name === key) return metric.value
+		}
+		return null
+	}
+
+	_latestPerformanceData(){
+		if(!window._welPerformanceData) return null
+		return window._welPerformanceData[window._welPerformanceData.length - 1]
+	}
+
+	_latestEmbedScriptHeapMemory(){
+		if(!window._welHeapMemoryData) return null
+		return window._welHeapMemoryData[window._welHeapMemoryData.length - 1].embedScriptMemory
+	}
+
+	_logPerformanceData(index=-1, name=null){
+		if(!window._welPerformanceData){
+			console.error('No performance data found')
+			return
+		}
+		if(index < 0){
+			index = window._welPerformanceData.length - 1
+		}
+		if(index >= window._welPerformanceData.length){
+			console.log('Invalid index', index, 'length is', window._welPerformanceData.length)
+			return
+		}
+		for(let metric of window._welPerformanceData[index].metrics){
+			if(name !== null && metric.name !== name) continue
+			console.log(metric.name, metric.value)
+		}
+	}
+}
+
+window.__welProbes["performance"] = new PerformanceProbe();

--- a/test/web-embed-lab/test-probes/selector-count/test.js
+++ b/test/web-embed-lab/test-probes/selector-count/test.js
@@ -1,0 +1,94 @@
+/**
+Selector count test probe queries each selector in the basis and fails only if the counts match
+Example basis:
+	{
+		"body > h1": 3,
+		"#bogus-id": 0,
+		"#real-id": 1,
+		"relative": {
+			"h1": 0,
+			"img": 0
+		}
+	}
+
+Note: relative tests must be against selectors in SelectorCountProbe.BaselineSelectors
+*/
+
+class SelectorCountProbe {
+	/**
+	The return object contains the number of matches to each selector in SelectorCountProbe.BaselineSelectors
+	{
+		success: true,
+		'h1': 1,
+		'h2': 10,
+		'div > img': 9,
+		...
+	}
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} always true
+	*/
+	async gatherBaselineData(){
+		console.log('Selector count baseline')
+		const result = {
+			success: true,
+		}
+		for(let selector of SelectorCountProbe.BaselineSelectors) {
+			result[selector] = document.querySelectorAll(selector).length
+		}
+		return result
+	}
+
+	/**
+	@return {object} the results of the probe
+	*/
+	async probe(basis, baseline){
+		console.log("Probing selector count")
+		const results = {
+			passed: true,
+			failed: [] // List of selectors with the wrong count
+		}
+		if(!basis) return results
+
+		for(let selector of Object.keys(basis)){
+			if(basis.hasOwnProperty(selector) === false) continue
+			if(selector === 'relative') continue
+			const probeValue = document.querySelectorAll(selector).length
+			results[selector] = probeValue
+
+			if(window.__welValueMatches(probeValue, basis[selector]) === false){
+				results.passed = false
+				results.failed.push(selector)
+			}
+		}
+
+		if(typeof basis.relative === 'undefined'){
+			return results
+		}
+
+		for(let selector of Object.keys(basis.relative)){
+			if(basis.relative.hasOwnProperty(selector) === false) continue
+			if(typeof baseline[selector] !== 'number'){
+				results.passed = false
+				console.error('Selector-count could not match relative basis selector with baseline: ' + selector)
+				results.failed.push('relative: ' + selector)
+				continue
+			}
+			const probeValue = document.querySelectorAll(selector).length
+			results['relative: ' + selector] = probeValue - baseline[selector]
+			if(window.__welValueMatches(probeValue, basis.relative[selector], baseline[selector]) === false) {
+				results.passed = false
+				results.failed.push('relative: ' + selector)
+			}
+		}
+		return results
+	}
+}
+SelectorCountProbe.BaselineSelectors = [
+	'div > img',
+	'h1', 'h2', 'h3', 'h4', 'h5',
+	'form', 'input', 'textarea',
+	'img', 'video', 'audio',
+	'section', 'header', 'footer'
+]
+
+window.__welProbes['selector-count'] = new SelectorCountProbe()

--- a/test/web-embed-lab/test-probes/text-equals/test.js
+++ b/test/web-embed-lab/test-probes/text-equals/test.js
@@ -1,0 +1,97 @@
+/**
+Text equals test probe queries each selector in the basis
+It fails if there is at least one match and the first match's text values isn't equal to the basis
+Example basis:
+	{
+		"body > h1": "Vanilla",
+		"#should-be-empty": "",
+		"relative": [
+			"h1", "li"
+		]
+	}
+
+	NOTE: selectors in relative array must also be in TextEqualsProbe.BaselineSelectors
+*/
+class TextEqualsProbe {
+	/**
+	@return {Object} data collected when the target embed script *is not* loaded
+	@return {Object.success} always true
+	*/
+	async gatherBaselineData(){
+		console.log('Text equals baseline')
+		const result = {
+			success: true,
+		}
+		for(const selector of TextEqualsProbe.BaselineSelectors) {
+			const matchedElements = document.querySelectorAll(selector)
+			result[selector] = Array.from(matchedElements).map(el => {
+				return el.innerText || el.innerHTML
+			})
+		}
+		return result
+	}
+
+	/**
+	@return {object} the results of the probe
+	*/
+	async probe(basis, baseline){
+		console.log("Probing text equals")
+		if(!basis) return { passed: true }
+		const results = {
+			passed: true,
+			failed: [] // List of selectors that don't match
+		}
+		for(let selector of Object.keys(basis)){
+			if(basis.hasOwnProperty(selector) === false) continue
+			if(selector === 'relative') continue
+
+			results[selector] = this._getText(selector)
+			if(results[selector] !== basis[selector]){
+				results.passed = false
+				results.failed.push(selector)
+			}
+		}
+
+		if(typeof basis.relative === 'undefined'){
+			return results
+		}
+
+		// basis.relative is an array (not an object like other probes) of selectors
+		for(let selector of basis.relative) {
+			if(Array.isArray(baseline[selector]) === false){
+				console.error('Unknown baseline value for relative selector: ' + selector)
+				results.passed = false
+				results.failed.push('relative: ' + selector)
+				continue
+			}
+			let baselineValue = baseline[selector].length > 0 ? baseline[selector][0] : null
+
+			const probeResult = this._getText(selector)
+			results['relative: ' + selector] = probeResult
+
+			if(probeResult !== baselineValue){
+				console.error('Mismatched probe result (' + probeResult + ') and baseline value: ' + baselineValue + ' for selector ' + selector)
+				results.passed = false
+				results.failed.push('relative: ' + selector)
+				continue
+			}
+		}
+
+		return results
+	}
+
+	/**
+	@return (innerText || innerHTML) or null if no selector match
+	*/
+	_getText(selector){
+		const matchedElement = document.querySelector(selector)
+		if(matchedElement === null || typeof matchedElement === 'undefined') return null
+		return matchedElement.innerText || matchedElement.innerHTML
+	}
+}
+TextEqualsProbe.BaselineSelectors = [
+	'h1', 'h2', 'h3', 'h4', 'h5',
+	'p', 'li', 'input', 'textarea'
+]
+
+window.__welProbes['text-equals'] = new TextEqualsProbe()


### PR DESCRIPTION
This PR sets up two new npm run targets: `test:wel-auto-formulate` and `test:wel-runner`

`test:wel-auto-formulate` uses the Web Embed Lab to test the DLO in the context of two example pages, one which is the most basic setup (`examples/basic-embed`) and a new one that tests CEDDL to FullStory rules (`examples/ceddl-fs`).

I'll add docs about setup once I've heard from @van-fs about this general direction, but to run the tests the user needs  to set up two files (both in the `test/web-embed-lab/` dir) that configure the WEL with ngrok and Browserstack keys. Basically, the user has to copy and fill out the *.example files in that dir (removing the `.example` extension).