### PR TITLE
Add shim property change listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,6 +1292,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepcopy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deepcopy/-/deepcopy-2.1.0.tgz",
+      "integrity": "sha512-8cZeTb1ZKC3bdSCP6XOM1IsTczIO73fdqtwa2B0N15eAz7gmyhQo+mc5gnFuulsgN3vIQYmTgbmQVKalH1dKvQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.8"
+      }
+    },
     "default-require-extensions": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "chai": "^4.2.0",
+    "deepcopy": "^2.1.0",
     "eslint": "^7.4.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",

--- a/src/event.ts
+++ b/src/event.ts
@@ -14,7 +14,7 @@ export enum DataLayerEventType {
  * See https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail
  */
 export interface DataLayerDetail {
-  value?: object; // value of a property assignment
+  value?: any; // value of a property assignment
 
   args?: any[]; // args passed to a function
 
@@ -34,7 +34,7 @@ export class FunctionDetail implements DataLayerDetail {
  * PropertyDetail provides metadata specific to property (i.e. value) changes.
  */
 export class PropertyDetail implements DataLayerDetail {
-  constructor(public target: object, public value: object, public path: string) {
+  constructor(public target: object, public value: any, public path: string) {
     // use constructor params
   }
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,12 +1,12 @@
 /* eslint-disable max-classes-per-file */
 
 /**
- * Defines CustomEvent types.
+ * Defines CustomEvent types. Types will be prefixed with a DLO namespace.
  * See https://developer.mozilla.org/en-US/docs/Web/API/Event/type
+ * @param path that identifies the data layer object that created the event
  */
-export enum DataLayerEventType {
-  PROPERTY = '_dlo_DataLayerProperty',
-  FUNCTION = '_dlo_DataLayerFunction',
+export function createEventType(path: string) {
+  return `datalayerobserver/${path}`;
 }
 
 /**
@@ -25,7 +25,7 @@ export interface DataLayerDetail {
  * FunctionDetail provides metadata specific to function invocations.
  */
 export class FunctionDetail implements DataLayerDetail {
-  constructor(public target: object, public args: any[], public path: string) {
+  constructor(public path: string, public property: string, public args: any[]) {
     // use constructor params
   }
 }
@@ -34,7 +34,7 @@ export class FunctionDetail implements DataLayerDetail {
  * PropertyDetail provides metadata specific to property (i.e. value) changes.
  */
 export class PropertyDetail implements DataLayerDetail {
-  constructor(public target: object, public value: any, public path: string) {
+  constructor(public path: string, public property: string, public value: any) {
     // use constructor params
   }
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -1,15 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
 /**
- * Defines CustomEvent types. Types will be prefixed with a DLO namespace.
- * See https://developer.mozilla.org/en-US/docs/Web/API/Event/type
- * @param path that identifies the data layer object that created the event
- */
-export function createEventType(path: string) {
-  return `datalayerobserver/${path}`;
-}
-
-/**
  * DataLayerDetail provides additional metadata about the data layer event to event handlers.
  * See https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/detail
  */
@@ -37,4 +28,27 @@ export class PropertyDetail implements DataLayerDetail {
   constructor(public path: string, public property: string, public value: any) {
     // use constructor params
   }
+}
+
+/**
+ * Defines CustomEvent types. Types will be prefixed with a DLO namespace.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Event/type
+ * @param path that identifies the data layer object that created the event
+ */
+export function createEventType(path: string) {
+  return `datalayerobserver/${path}`;
+}
+
+/**
+ * Builds a CustomEvent used to broadcast changes.
+ * @param target that triggered the event (see https://developer.mozilla.org/en-US/docs/Web/API/Event/target)
+ * @param property that triggered the event
+ * @param value that was emitted by the target
+ * @param path to the target
+ */
+export function createEvent(target: any, property: string, value: any, path: string): CustomEvent<DataLayerDetail> {
+  return new CustomEvent<DataLayerDetail>(createEventType(path), {
+    detail: typeof target === 'function' ? new FunctionDetail(path, property, value)
+      : new PropertyDetail(path, property, value),
+  });
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -10,6 +10,8 @@ import DataLayerTarget from './target';
  * registered operators.
  */
 export default class DataHandler {
+  static readonly debounceTime = 250;
+
   private listener: EventListener | null = null;
 
   private operators: Operator[] = [];
@@ -73,7 +75,7 @@ export default class DataHandler {
 
         this.timeoutId = window.setTimeout(() => {
           this.handleData(result);
-        }, 250);
+        }, DataHandler.debounceTime);
       } else {
         this.handleData(args || []);
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,7 +1,8 @@
 import { Logger } from './utils/logger';
 import { Operator } from './operator';
-import { DataLayerEventType, DataLayerDetail, PropertyDetail } from './event';
+import { DataLayerDetail, createEventType } from './event';
 import { select } from './selector';
+import DataLayerTarget from './target';
 
 /**
  * DataHandler listens for changes from lower level PropertyListeners. Events emitted from
@@ -9,9 +10,11 @@ import { select } from './selector';
  * registered operators.
  */
 export default class DataHandler {
+  private listener: EventListener | null = null;
+
   private operators: Operator[] = [];
 
-  readonly target: any;
+  readonly target: DataLayerTarget;
 
   // external tooling can override the console debugger
   debugger = (message: string, data?: any, indent?: string) => console.debug(
@@ -24,59 +27,47 @@ export default class DataHandler {
    * @param debug true optionally enables debugging data transformation (defaults to console.debug)
    * @throws will throw an error if the data layer is not found (i.e. undefined or null)
    */
-  constructor(private readonly path: string, public debug = false) {
-    this.target = select(path);
+  constructor(target: DataLayerTarget | string, public debug = false) {
+    this.target = typeof target === 'string' ? new DataLayerTarget(target) : target;
 
-    // guards against trying to register an observer on a non-existent datalayer
-    // this could happen if the data layer is dynamically loaded after DLO starts
-    if (!this.target) {
-      throw new Error(`Data layer ${path} not found on page`);
+    if (!this.target.object) {
+      throw new Error(`Data layer ${typeof target === 'string' ? target : target.path} not found on page`);
     }
+
+    // begin handling data by listening for events
+    this.start();
   }
 
   /**
    * Manually emit the current value of the observed target property.
-   * @throws will throw an error if the target's property is not an object
    */
-  fireEvent() {
-    const value = select(this.path);
-    const type = typeof value;
-
-    if (type === 'object') {
-      this.handleEvent(new CustomEvent<DataLayerDetail>(DataLayerEventType.PROPERTY, {
-        detail: new PropertyDetail(this.target, value, this.path),
-      }));
-    } else {
-      throw new Error(`${this.path} (${type}) is not a supported type`);
+  fireEvent(value = this.target.value) {
+    if (value) {
+      this.handleData([value]);
     }
   }
 
   /**
-   * Handles the incoming event. This function implements EventListener to also support
+   * Handles the incoming event. This function implements EventListener to support
    * addEventListener() browser APIs and Data Layer Observer events.
    * @param event a browser Event or CustomEvent emitted
    */
   handleEvent(event: CustomEvent<DataLayerDetail>): void {
-    const { detail: { args, value, path }, type } = event;
+    const { detail: { args, value }, type } = event;
+    const { path, selector } = this.target;
 
-    // since window is the event dispatcher, use the path in DataLayerDetail to decide if this
-    // DataHandler should process the data
-    if (this.path === path) {
-      if (value === undefined && args === undefined) {
-        Logger.getInstance().warn(`${this.path} emitted no data`, this.path);
+    if (value === undefined && args === undefined) {
+      Logger.getInstance().warn(`${path} emitted no data`, path);
+    } else if (type === createEventType(path)) {
+      if (value) {
+        // NOTE even though a value change occurred, handleData expects the root data layer object
+        // so select the source and send it to handle data
+        this.handleData([select(selector)]);
       } else {
-        switch (type) {
-          case DataLayerEventType.PROPERTY:
-            // NOTE even though the data layer emitted a changed value, run the selector and pass off to handler
-            this.handleData([select(path)]);
-            break;
-          case DataLayerEventType.FUNCTION:
-            this.handleData(args || []);
-            break;
-          default:
-            Logger.getInstance().warn(`Unknown event type ${type}`);
-        }
+        this.handleData(args || []);
       }
+    } else {
+      Logger.getInstance().warn(`EventListener received unexpected event ${type}`, path);
     }
   }
 
@@ -85,7 +76,9 @@ export default class DataHandler {
    * @param data the data as an array of values emitted from the data layer
    */
   private handleData(data: any[] | null): any[] | null {
-    this.runDebugger(`${this.path} handleData entry`, data);
+    const { path } = this.target;
+
+    this.runDebugger(`${path} handleData entry`, data);
 
     let handledData = data;
 
@@ -114,14 +107,14 @@ export default class DataHandler {
 
         this.runDebugger(`[${i}] ${name} output ${stats}`, handledData, '  ');
       } catch (err) {
-        Logger.getInstance().error(`Operator ${name} failed for ${this.path} at step ${i}`,
-          this.path);
+        Logger.getInstance().error(`Operator ${name} failed for ${path} at step ${i}`,
+          path);
         console.error(err.message);
         return null;
       }
     }
 
-    this.runDebugger(`${this.path} handleData exit`, handledData);
+    this.runDebugger(`${path} handleData exit`, handledData);
 
     return handledData;
   }
@@ -203,5 +196,23 @@ export default class DataHandler {
    */
   push(...operators: Operator[]): void {
     operators.forEach((operator) => this.operators.push(operator));
+  }
+
+  /**
+   * Starts listening for data layer changes or function calls.
+   */
+  start() {
+    if (!this.listener) {
+      this.listener = (e: Event) => this.handleEvent(e as CustomEvent);
+      window.addEventListener(createEventType(this.target.path), this.listener);
+    }
+  }
+
+  /**
+   * Stops listening for data layer changes or function calls.
+   */
+  stop() {
+    window.removeEventListener(createEventType(this.target.path), this.listener as EventListener);
+    this.listener = null;
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -71,11 +71,14 @@ export default class DataHandler {
 
         // NOTE even though a value change occurred, handleData expects the root data layer object
         // so select the source and send it to handle data
-        const result: any[] = [select(selector)];
+        const result: any = select(selector);
 
-        this.timeoutId = window.setTimeout(() => {
-          this.handleData(result);
-        }, DataHandler.debounceTime);
+        // only handle data if the selector actually returns something with data
+        if (result) {
+          this.timeoutId = window.setTimeout(() => {
+            this.handleData([result]);
+          }, DataHandler.debounceTime);
+        }
       } else {
         this.handleData(args || []);
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -67,7 +67,8 @@ export default class DataHandler {
       } else {
         switch (type) {
           case DataLayerEventType.PROPERTY:
-            this.handleData([value]);
+            // NOTE even though the data layer emitted a changed value, run the selector and pass off to handler
+            this.handleData([select(path)]);
             break;
           case DataLayerEventType.FUNCTION:
             this.handleData(args || []);

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -1,0 +1,32 @@
+import Monitor from './monitor';
+import { Logger } from './utils/logger';
+
+/**
+ * ShimMonitor watches for changes and function calls through a shim technique.
+ */
+export default class ShimMonitor extends Monitor {
+  addPropertyMonitor(target: any, property: string) {
+    Object.defineProperty(target, property, {
+      enumerable: true,
+      get: () => this.state,
+      set: (value: any) => {
+        this.state = value;
+        this.emit(value);
+      },
+    });
+  }
+
+  remove() {
+    try {
+      // remove the getter/setter if it's a property monitor
+      if (typeof this.target[this.property] !== 'function') {
+        delete this.target[this.property].get;
+        delete this.target[this.property].set;
+      } else {
+        this.target[this.property] = this.state;
+      }
+    } catch (err) {
+      Logger.getInstance().error(`Failed to remove listener on ${this.property}`, this.source);
+    }
+  }
+}

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -11,12 +11,12 @@ export default class ShimMonitor extends Monitor {
 
   private writable: boolean | undefined = true;
 
-  addPropertyMonitor(target: any, property: string) {
-    if (Object.isFrozen(target)) {
+  addPropertyMonitor(object: any, property: string) {
+    if (Object.isFrozen(object)) {
       throw new Error('Failed to monitor frozen object');
     }
 
-    if (Object.isSealed(target)) {
+    if (Object.isSealed(object)) {
       throw new Error('Failed to monitor sealed object');
     }
 
@@ -30,7 +30,7 @@ export default class ShimMonitor extends Monitor {
     }
 
     // define a new property and default to a more malleable property if descriptor is undefined
-    Object.defineProperty(target, property, {
+    Object.defineProperty(object, property, {
       configurable: this.configurable,
       enumerable: this.enumerable,
       get: () => this.state,
@@ -50,7 +50,7 @@ export default class ShimMonitor extends Monitor {
         writable: this.writable,
       });
     } catch (err) {
-      Logger.getInstance().error(`Failed to remove listener on ${this.property}`, this.source);
+      Logger.getInstance().error(`Failed to remove listener on ${this.property}`, this.path);
     }
   }
 }

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -20,7 +20,7 @@ export default class ShimMonitor extends Monitor {
       throw new Error('Failed to monitor sealed object');
     }
 
-    const descriptor = Object.getOwnPropertyDescriptor(this.target, this.property);
+    const descriptor = Object.getOwnPropertyDescriptor(this.object, this.property);
 
     if (descriptor) {
       const { configurable, enumerable, writable } = descriptor;
@@ -43,7 +43,7 @@ export default class ShimMonitor extends Monitor {
 
   remove() {
     try {
-      Object.defineProperty(this.target, this.property, {
+      Object.defineProperty(this.object, this.property, {
         enumerable: this.enumerable,
         configurable: this.configurable,
         value: this.state,

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,6 +1,4 @@
-import {
-  DataLayerDetail, PropertyDetail, FunctionDetail, createEventType,
-} from './event';
+import { createEvent } from './event';
 import { Logger } from './utils/logger';
 
 /**
@@ -11,12 +9,12 @@ export default abstract class Monitor {
 
   /**
    * Creates a Monitor.
-   * @param target object containing the property or function to watch
+   * @param object containing the property or function to watch
    * @param property to watch (can hold a value or function)
    * @param path to the data layer object
    */
-  constructor(protected target: any, protected property: string, protected path: string) {
-    if (!target) {
+  constructor(protected object: any, protected property: string, protected path: string) {
+    if (!object) {
       throw new Error('Monitor could not find target');
     } else {
       if (path.endsWith(property)) {
@@ -26,15 +24,15 @@ export default abstract class Monitor {
 
       this.copy();
 
-      switch (typeof target) {
+      switch (typeof object) {
         case 'object':
-          this.addPropertyMonitor(target, property);
+          this.addPropertyMonitor(object, property);
           break;
         case 'function':
           // TODO
           break;
         default:
-          throw new Error(`Monitor can not be added to unsupported type ${typeof this.target}`);
+          throw new Error(`Monitor can not be added to unsupported type ${typeof this.object}`);
       }
     }
   }
@@ -44,16 +42,7 @@ export default abstract class Monitor {
    * @param property the property to clone and save
    */
   protected copy(): void {
-    this.state = this.target[this.property];
-  }
-
-  /**
-   * Builds a CustomEvent's `detail` used to broadcast changes.
-   * @param value the property changed or function arguments
-   */
-  private createDetail(value: any): DataLayerDetail {
-    return typeof this.target === 'function' ? new FunctionDetail(this.path, this.property, value)
-      : new PropertyDetail(this.path, this.property, value);
+    this.state = this.object[this.property];
   }
 
   /**
@@ -61,10 +50,8 @@ export default abstract class Monitor {
    * @param value the property changed or function arguments
    */
   protected emit(value: any) {
-    // TODO (van) emit would be a good place to put a debounce feature
     try {
-      window.dispatchEvent(new CustomEvent<DataLayerDetail>(createEventType(this.path),
-        { detail: this.createDetail(value) }));
+      window.dispatchEvent(createEvent(this.object, this.property, value, this.path));
     } catch (err) {
       Logger.getInstance().error(`Failed to broadcast change for ${this.property}`, this.path);
     }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,0 +1,87 @@
+import {
+  DataLayerEventType, DataLayerDetail, PropertyDetail, FunctionDetail,
+} from './event';
+import { Logger } from './utils/logger';
+
+/**
+ * Monitor watches for property changes or function calls.
+ */
+export default abstract class Monitor {
+  protected state: any;
+
+  readonly type: DataLayerEventType;
+
+  /**
+   * Creates a Monitor.
+   * @param target the object containing the property to watch or function
+   * @param property the property to watch (can hold a value or function)
+   * @param source the source (e.g. selector) used to disambiguate who fired the event
+   */
+  constructor(protected target: any, protected property: string, protected source: string) {
+    if (!this.target) {
+      throw new Error('Monitor could not find target');
+    } else {
+      this.copy();
+
+      switch (typeof this.target) {
+        case 'object':
+          this.type = DataLayerEventType.PROPERTY;
+          this.addPropertyMonitor(target, property);
+          break;
+        case 'function':
+          this.type = DataLayerEventType.FUNCTION;
+          // TODO
+          break;
+        default:
+          throw new Error(`Monitor has unsupported type ${typeof this.target}`);
+      }
+    }
+  }
+
+  /**
+   * Shallow copies a property:value pair to allow referencing and calling "real" values.
+   * @param property the property to clone and save
+   */
+  protected copy(): void {
+    this.state = this.target[this.property];
+  }
+
+  /**
+   * Builds a CustomEvent's `detail` used to broadcast changes.
+   * @param value the property changed or function arguments
+   */
+  private createDetail(value: any): DataLayerDetail {
+    switch (this.type) {
+      case DataLayerEventType.PROPERTY:
+        return new PropertyDetail(this.target, value, this.source);
+      case DataLayerEventType.FUNCTION:
+        return new FunctionDetail(this.target, value, this.source);
+      default:
+        throw new Error(`Unknown event type ${this.type}`);
+    }
+  }
+
+  /**
+   * Broadcasts changes or function calls using `window.dispatchEvent`.
+   * @param value the property changed or function arguments
+   */
+  protected emit(value: any) {
+    try {
+      window.dispatchEvent(new CustomEvent<DataLayerDetail>(this.type, { detail: this.createDetail(value) }));
+    } catch (err) {
+      Logger.getInstance().error(`Failed to broadcast change for ${this.property}`, this.source);
+    }
+  }
+
+  /**
+   * Watches for changes on properties within an object.
+   * @param target the object containing the property
+   * @param property the property to watch
+   */
+  abstract addPropertyMonitor(target: any, property: string): void;
+
+  /**
+   * Stops watching for changes and function calls.
+   */
+  abstract remove(): void;
+}

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -214,7 +214,8 @@ export class DataLayerObserver {
             // find the path to the actual reference in the data layer by selecting with a path
             const path = source.substring(0, braketPos === -1 ? source.length : braketPos);
             const ref = select(path);
-
+            const frozen = Object.isFrozen(ref);
+            console.log(frozen);
             Object.getOwnPropertyNames(target).forEach((property) => this.addMonitor(ref, property, source));
 
             window.addEventListener(DataLayerEventType.PROPERTY, (e: Event) => handler.handleEvent(e as CustomEvent));

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -37,7 +37,7 @@ export interface DataLayerConfig {
  *
  * Required
  *  source: data layer target using selector syntax
- *  destination: destination function using selector syntax
+ *  destination: destination function using selector syntax or native function
  * Optional
  *  id: optional identifier for the rule
  *  description: optional description of the rule
@@ -51,7 +51,7 @@ export interface DataLayerRule {
   debug?: boolean;
   source: string;
   operators?: OperatorOptions[];
-  destination: string;
+  destination: string | Function;
   readOnLoad?: boolean;
   url?: string;
   id?: string;

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -214,8 +214,7 @@ export class DataLayerObserver {
             // find the path to the actual reference in the data layer by selecting with a path
             const path = source.substring(0, braketPos === -1 ? source.length : braketPos);
             const ref = select(path);
-            const frozen = Object.isFrozen(ref);
-            console.log(frozen);
+
             Object.getOwnPropertyNames(target).forEach((property) => this.addMonitor(ref, property, source));
 
             window.addEventListener(DataLayerEventType.PROPERTY, (e: Event) => handler.handleEvent(e as CustomEvent));

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -43,6 +43,7 @@ export interface DataLayerConfig {
  *  id: optional identifier for the rule
  *  description: optional description of the rule
  *  debug: true if the rule should print debug for each Operator transformation
+ *  monitor: true if property changes or function calls should rerun the operators
  *  operators: list of OperatorOptions to transform data before a destination
  *  readOnLoad: rule-specific readOnLoad (see DataLayerConfig readOnLoad)
  *  url: regular expression used to enable the rule when the page URL matches
@@ -290,6 +291,10 @@ export class DataLayerObserver {
     }
   }
 
+  /**
+   * Removes a monitor from watching property changes or function calls.
+   * @param monitor
+   */
   removeMonitor(monitor: Monitor) {
     const i = this.monitors.indexOf(monitor);
     if (i > -1) {

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -4,7 +4,7 @@
 // Memoized Paths or false if the path cannot be parsed
 const parsedPaths: { [path: string]: Path | false } = {};
 
-enum ElementKind {
+export enum ElementKind {
   Pluck = 'pluck', // color
   Index = 'index', // colors[-2]
   Pick = 'pick', // colors[(favorite, hated, ...)]
@@ -425,7 +425,7 @@ export class Path {
 }
 
 // Parses and then memoizes a path for future calls
-function parsePath(path: string): Path | false {
+export function parsePath(path: string): Path | false {
   if (typeof parsedPaths[path] === 'undefined') {
     try {
       parsedPaths[path] = new Path(path);

--- a/src/target.ts
+++ b/src/target.ts
@@ -16,6 +16,8 @@ export default class DataLayerTarget {
     return typeof this.object === 'object' ? select(this.selector) : null;
   }
 
+  id: number;
+
   constructor(public readonly selector: string, object?: any) {
     const parsedPath = parsePath(selector);
 
@@ -39,7 +41,7 @@ export default class DataLayerTarget {
         }
       }
     }
-
+    this.id = Date.now();
     this.path = !path ? selector : path;
     this.object = object || select(this.path);
   }

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,0 +1,46 @@
+import { parsePath, ElementKind, select } from './selector';
+
+/**
+ * DataLayerTarget refers to the object to be observed from a data layer.
+ * Selectors are commonly used to access objects in a data layer; however, a selector can sometimes return
+ * a copy of an object. For example, picking or omitting returns an intermediate object - not the original
+ * object from the data layer. DataLayerTarget retains the object and path to that object for the purposes
+ * of storing a reference to the actual data layer object.
+ */
+export default class DataLayerTarget {
+  readonly object: any;
+
+  readonly path: string;
+
+  get value(): any {
+    return typeof this.object === 'object' ? select(this.selector) : null;
+  }
+
+  constructor(public readonly selector: string, object?: any) {
+    const parsedPath = parsePath(selector);
+
+    if (!parsedPath) {
+      throw new Error('Failed to parse target selector');
+    }
+
+    const { elements } = parsedPath;
+
+    let path: string = '';
+
+    for (let i = 0; i < elements.length; i += 1) {
+      const { kind, raw, brackets } = elements[i];
+      // traverse the path elements to the point where a copy would otherwise be returned
+      if (kind !== ElementKind.Pluck && kind !== ElementKind.Index) {
+        if (brackets) {
+          path = selector.substring(0, selector.indexOf(`[${brackets.op.raw}]`));
+          break;
+        } else {
+          throw new Error(`Brackets expected in ${raw} but not found`);
+        }
+      }
+    }
+
+    this.path = !path ? selector : path;
+    this.object = object || select(this.path);
+  }
+}

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -10,6 +10,7 @@ import { basicDigitalData, PageInfo, Page } from './mocks/CEDDL';
 import { Operator, OperatorOptions } from '../src/operator';
 import { DataLayerDetail, PropertyDetail, createEvent } from '../src/event';
 import { expectNoCalls, expectParams } from './utils/mocha';
+import DataLayerTarget from '../src/target';
 
 const originalConsole = globalThis.console;
 const console = new Console();
@@ -288,6 +289,24 @@ describe('DataHandler unit tests', () => {
 
     setTimeout(() => {
       expect(seen.length).to.eq(1);
+      done();
+    }, DataHandler.debounceTime * 1.5);
+  });
+
+  it('an object with no properties selected from an event should not be handled', (done) => {
+    const handler = new DataHandler(new DataLayerTarget('digitalData.page.pageInfo[(missingProperty)]'));
+
+    const seen: any = [];
+
+    const echo = new EchoOperator(seen);
+    handler.push(echo);
+
+    (globalThis as any).digitalData.page.pageInfo.pageID = '1234';
+    handler.handleEvent(createEvent((globalThis as any).digitalData.page, 'pageInfo',
+      (globalThis as any).digitalData.page.pageInfo, 'digitalData.page.pageInfo'));
+
+    setTimeout(() => {
+      expect(seen.length).to.eq(0);
       done();
     }, DataHandler.debounceTime * 1.5);
   });

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -224,7 +224,13 @@ describe('DataHandler unit tests', () => {
     // @ts-ignore
     basicDigitalData.fn = () => console.log('Hello World'); // eslint-disable-line no-console
     const handler = new DataHandler('digitalData.fn');
-    expect(() => handler.fireEvent()).to.throw();
+
+    const seen: any = [];
+
+    const echo = new EchoOperator(seen);
+    handler.push(echo);
+
+    expect(seen.length).to.eq(0);
   });
 
   it('events with unknown types should not be handled', () => {
@@ -236,7 +242,7 @@ describe('DataHandler unit tests', () => {
     handler.push(echo);
 
     handler.handleEvent(new CustomEvent<DataLayerDetail>('unknownType', {
-      detail: new PropertyDetail(basicDigitalData.page.pageInfo, basicDigitalData.page, 'digitalData.page.pageInfo'),
+      detail: new PropertyDetail('digitalData.page', 'pageInfo', basicDigitalData.page.pageInfo),
     }));
 
     expect(seen.length).to.eq(0);

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -3,15 +3,17 @@ import { expect } from 'chai';
 import deepcopy from 'deepcopy';
 import 'mocha';
 
-import { DataLayerObserver } from '../src/observer';
 import {
   basicDigitalData, CEDDL, PageCategory, Cart, TotalCartPrice,
 } from './mocks/CEDDL';
 import Console from './mocks/console';
 import FullStory from './mocks/fullstory-recording';
-import { expectParams, expectNoCalls, expectCall } from './utils/mocha';
+import {
+  expectParams, expectNoCalls, expectCall, ExpectObserver,
+} from './utils/mocha';
 import { Operator, OperatorOptions } from '../src/operator';
 import { LogEvent } from '../src/utils/logger';
+import DataHandler from '../src/handler';
 
 class EchoOperator implements Operator {
   options: OperatorOptions = {
@@ -83,36 +85,36 @@ describe('DataLayerObserver unit tests', () => {
   });
 
   it('it should initialize with defaults', () => {
-    const observer = new DataLayerObserver();
-    expect(observer).to.not.be.undefined;
-    expect(observer).to.not.be.null;
+    const observer = ExpectObserver.getInstance().default();
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should automatically parse config rules', () => {
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       rules: [{
         source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', monitor: false,
       }],
     });
-    expect(observer.handlers.length).to.eq(1);
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('rules without a source and destination are invalid', () => {
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       rules: [
         // @ts-ignore
-        { operators: [], destination: 'console.log' },
+        { operators: [], destination: 'console.log', monitor: false },
         // @ts-ignore
         { source: 'digitalData.page.pageInfo', operators: [], monitor: false },
       ],
-    });
+    }, false);
     expect(observer.handlers.length).to.eq(0);
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should read a data layer on-load for all rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       readOnLoad: true,
       rules: [
         {
@@ -124,19 +126,19 @@ describe('DataLayerObserver unit tests', () => {
       ],
     });
 
-    expect(observer).to.not.be.undefined;
-
     const [productInfo] = expectParams(globalMock.console, 'log');
     expect(productInfo).to.eq(globalMock.digitalData.product[0].productInfo);
 
     const [pageInfo] = expectParams(globalMock.console, 'log');
     expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should read a data layer on-load for specific rules', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       rules: [
         {
           source: 'digitalData.page.pageInfo',
@@ -157,21 +159,23 @@ describe('DataLayerObserver unit tests', () => {
     expect(pageInfo).to.eq(globalMock.digitalData.page.pageInfo);
 
     expectNoCalls(globalMock.console, 'log');
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should allow custom operators to be registered', () => {
-    const observer = new DataLayerObserver();
-
+    const observer = ExpectObserver.getInstance().default();
     observer.registerOperator('echo', new EchoOperator());
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('invalid operators should remove a handler', () => {
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       validateRules: true,
       rules: [{
         source: 'digitalData.page.pageInfo', operators: [], destination: 'console.log', monitor: false,
       }],
-    });
+    }, false);
 
     expect(observer.handlers.length).to.eq(1);
 
@@ -181,12 +185,14 @@ describe('DataLayerObserver unit tests', () => {
     expect(() => observer.addOperator(observer.handlers[0], operator)).to.throw();
 
     expect(observer.handlers.length).to.eq(0);
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should not register operators with existing names', () => {
-    const observer = new DataLayerObserver();
-
+    const observer = ExpectObserver.getInstance().default();
     expect(() => { observer.registerOperator('function', new EchoOperator()); }).to.throw();
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('only valid pages should process a rule', () => {
@@ -194,7 +200,7 @@ describe('DataLayerObserver unit tests', () => {
 
     const urlValidator = (url: string | undefined) => (url ? RegExp(url).test('https://www.fullstory.com/cart') : true);
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       readOnLoad: true,
       urlValidator,
       rules: [
@@ -209,7 +215,7 @@ describe('DataLayerObserver unit tests', () => {
           source: 'digitalData.cart', operators: [], destination: 'console.log', url: '/cart$', monitor: false,
         },
       ],
-    });
+    }, false);
 
     expect(observer.handlers.length).to.eq(1);
 
@@ -217,13 +223,15 @@ describe('DataLayerObserver unit tests', () => {
     expect(cart).to.eq(globalMock.digitalData.cart);
 
     expectNoCalls(globalMock.console, 'log');
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('previewMode defaults to console.log', () => {
     expectNoCalls(globalMock.console, 'log');
     expectNoCalls(globalMock.FS, 'setUserVars');
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       previewMode: true,
       readOnLoad: true,
       rules: [
@@ -242,13 +250,15 @@ describe('DataLayerObserver unit tests', () => {
     expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
 
     expectNoCalls(globalMock.FS, 'setUserVars');
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('previewMode can be configured', () => {
     expectNoCalls(globalMock.console, 'debug');
     expectNoCalls(globalMock.FS, 'setUserVars');
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       previewMode: true,
       previewDestination: 'console.debug',
       readOnLoad: true,
@@ -268,12 +278,14 @@ describe('DataLayerObserver unit tests', () => {
     expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
 
     expectNoCalls(globalMock.FS, 'setUserVars');
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('debug can be enabled for a specific rule', () => {
     expectNoCalls(globalMock.console, 'debug');
 
-    const observer = new DataLayerObserver();
+    const observer = ExpectObserver.getInstance().default();
 
     expect(observer).to.not.be.undefined;
 
@@ -300,12 +312,14 @@ describe('DataLayerObserver unit tests', () => {
 
     // NOTE there should only be 4 debug statements for the first rule - one each for: entry, toUpper, function (destination), exit
     expectCall(globalMock.console, 'debug', 4);
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should register and call an operator before the destination', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    const observer = new DataLayerObserver({ beforeDestination: { name: 'toUpper' }, rules: [] });
+    const observer = ExpectObserver.getInstance().create({ beforeDestination: { name: 'toUpper' }, rules: [] });
 
     expect(observer).to.not.be.undefined;
 
@@ -325,6 +339,8 @@ describe('DataLayerObserver unit tests', () => {
     expect((category as PageCategory).primaryCategory).to.eq(
       globalMock.digitalData.page.category.primaryCategory.toUpperCase(),
     );
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('it should register a custom log appender', () => {
@@ -342,7 +358,7 @@ describe('DataLayerObserver unit tests', () => {
       }
     }
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       appender: new FullStoryAppender(globalMock.FS),
       readOnLoad: true,
       rules: [
@@ -350,7 +366,7 @@ describe('DataLayerObserver unit tests', () => {
           source: 'digitalData.nonExistent', operators: [], destination: 'console.log', monitor: false,
         },
       ],
-    });
+    }, false);
 
     expect(observer).to.not.be.undefined;
 
@@ -358,24 +374,27 @@ describe('DataLayerObserver unit tests', () => {
     expect(eventName).to.eq('Data Layer Observer');
     expect(event).to.not.be.undefined;
     expect(source).to.eq('dataLayerObserver');
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 
   it('updating properties should trigger the data handler', (done) => {
     let changes: any[] = [];
 
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       rules: [
         {
           source: 'digitalData.cart[(cartID,price)]',
           operators: [],
           destination: (...data: any[]) => {
+            // NOTE use a local destination to prevent cross-test pollution
             changes = data;
           },
           readOnLoad: true,
           // monitor: true, // NOTE the default is true
         },
       ],
-    });
+    }, true);
 
     expect(observer).to.not.be.undefined;
     expect(globalMock.digitalData.cart).to.not.be.undefined;
@@ -391,7 +410,7 @@ describe('DataLayerObserver unit tests', () => {
       const [reassigned] = changes;
       expect(reassigned.cartID).to.eq('cart-5678');
       expect((reassigned as Cart).item).to.be.undefined; // ensure selector picked
-    }, 300);
+    }, DataHandler.debounceTime * 1.5);
 
     const updatedPrice: TotalCartPrice = {
       basePrice: 15.55,
@@ -413,24 +432,27 @@ describe('DataLayerObserver unit tests', () => {
       expect((shippingChange as Cart).price).to.eq(updatedPrice);
       expect((shippingChange as Cart).item).to.be.undefined; // ensure selector picked
 
+      ExpectObserver.getInstance().cleanup(observer);
       done();
-    }, 300);
+    }, DataHandler.debounceTime * 1.5);
   });
 
   it('it should not add monitors for an invalid rule', () => {
-    const observer = new DataLayerObserver({
+    const observer = ExpectObserver.getInstance().create({
       rules: [
         {
           source: 'digitalData.cart[(cartID,price)]',
           operators: [],
           destination: 'console.log',
-          readOnLoad: true,
+          readOnLoad: false,
           // monitor: true, // NOTE the default is true
         },
       ],
-    });
+    }, true);
 
     expect(observer).to.not.be.undefined;
     expect(globalMock.digitalData.cart).to.not.be.undefined;
+
+    ExpectObserver.getInstance().cleanup(observer);
   });
 });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { expect } from 'chai';
+import deepcopy from 'deepcopy';
 import 'mocha';
 
 import { DataLayerObserver } from '../src/observer';
@@ -69,7 +70,7 @@ let globalMock: GlobalMock;
 
 describe('DataLayerObserver unit tests', () => {
   beforeEach(() => {
-    (globalThis as any).digitalData = { ...basicDigitalData }; // NOTE copy so mutations don't pollute tests
+    (globalThis as any).digitalData = deepcopy(basicDigitalData); // NOTE copy so mutations don't pollute tests
     (globalThis as any).console = new Console();
     (globalThis as any).FS = new FullStory();
     globalMock = globalThis as any;

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -95,6 +95,10 @@ describe('test selection paths', () => {
     expect(select('favorites.films.action', testData)).to.eq('Rogue One');
   });
 
+  it('dot notation should return a reference to the object', () => {
+    expect(select('favorites', testData)).to.eq(testData.favorites);
+  });
+
   it('should respect index notation', () => {
     expect(select('cities[0]', testData)).to.eq('Seattle');
     expect(select('cities[1]', testData)).to.eq('Atlanta');
@@ -117,6 +121,11 @@ describe('test selection paths', () => {
     expect(select('favorites[(totally, bogus)]', testData)).to.be.undefined;
   });
 
+  it('pick notation should return a new object', () => {
+    expect(select('favorites.films[(action,adventure,rom com)]', testData)).to.not.eq(testData.favorites.films);
+    expect(select('favorites.films[(action,adventure,rom com)]', testData)).to.eql(testData.favorites.films);
+  });
+
   it('should respect omit notation', () => {
     expect(select('favorites[!(color)]', testData).color).to.be.undefined;
     expect(select('favorites[!(color)]', testData).number).to.eq(25);
@@ -124,6 +133,13 @@ describe('test selection paths', () => {
     expect(select('favorites[!(color, number)]', testData).color).to.be.undefined;
     expect(select('favorites[!(color, number)]', testData).number).to.be.undefined;
     expect(select('favorites[!(color, number)]', testData).pickle).to.eq('dill');
+  });
+
+  it('omit notation should return a new object', () => {
+    expect(select('favorites.films[!(rom com)]', testData)).to.not.eq(testData.favorites.films);
+
+    const { action, adventure } = testData.favorites.films;
+    expect(select('favorites.films[!(rom com)]', testData)).to.eql({ action, adventure });
   });
 
   it('should respect prefix notation', () => {
@@ -137,6 +153,13 @@ describe('test selection paths', () => {
     expect(select('favorites[^(col, bogus)]', testData).bogus).to.be.undefined;
   });
 
+  it('prefix notation should return a new object', () => {
+    expect(select('favorites.films[^(a)]', testData)).to.not.eq(testData.favorites.films);
+
+    const { action, adventure } = testData.favorites.films;
+    expect(select('favorites.films[^(a)]', testData)).to.eql({ action, adventure });
+  });
+
   it('should respect suffix notation', () => {
     expect(select('favorites[$(color)]', testData).color).to.eq('red');
     expect(select('favorites[$(olor)]', testData).color).to.eq('red');
@@ -146,6 +169,13 @@ describe('test selection paths', () => {
     expect(select('favorites[$(bogus, olor)]', testData).bogus).to.be.undefined;
     expect(select('favorites[$(olor, bogus)]', testData).color).to.eq('red');
     expect(select('favorites[$(olor, bogus)]', testData).bogus).to.be.undefined;
+  });
+
+  it('suffix notation should return a new object', () => {
+    expect(select('favorites.films[$(n,e)]', testData)).to.not.eq(testData.favorites.films);
+
+    const { action, adventure } = testData.favorites.films;
+    expect(select('favorites.films[$(n,e)]', testData)).to.eql({ action, adventure });
   });
 
   it('should respect filter notation', () => {
@@ -176,5 +206,9 @@ describe('test selection paths', () => {
     expect(select('favorites[?(number!=25)]', testData)).to.be.undefined;
     expect(select('favorites[?(number!=12)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(number+=25)]', testData)).to.be.undefined;
+  });
+
+  it('filter notation should return a reference to the object', () => {
+    expect(select('favorites.films[?(action=Rogue One)]', testData)).to.eq(testData.favorites.films);
   });
 });

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { DataLayerEventType } from '../src/event';
+import ShimMonitor from '../src/monitor-shim';
+
+import { basicDigitalData, CEDDL } from './mocks/CEDDL';
+import { expectEventListener } from './utils/mocha';
+
+interface GlobalMock {
+  digitalData: CEDDL,
+}
+
+let globalMock: GlobalMock;
+
+describe('ShimMonitor unit tests', () => {
+  beforeEach(() => {
+    (globalThis as any).digitalData = { ...basicDigitalData };
+    globalMock = globalThis as any;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).digitalData;
+  });
+
+  it('it should create a property Monitor', () => {
+    expect(globalMock.digitalData.cart).to.not.be.undefined;
+    expect(globalMock.digitalData.user.profile).to.not.be.undefined;
+
+    const cartMonitor = new ShimMonitor(globalMock.digitalData.cart, 'price', 'digitalData.cart[(cartID,price)]');
+    const userMonitor = new ShimMonitor(globalMock.digitalData.user, 'profile', 'digitalData.user.profile[0]');
+
+    expect(cartMonitor).to.not.be.undefined;
+    expect(userMonitor).to.not.be.undefined;
+
+    const priceDescriptor = Object.getOwnPropertyDescriptor(globalMock.digitalData.cart, 'price');
+    const idDescriptor = Object.getOwnPropertyDescriptor(globalMock.digitalData.cart, 'cartID');
+
+    expect(idDescriptor).to.not.be.undefined;
+    expect(priceDescriptor).to.not.be.undefined;
+
+    expect(priceDescriptor!.get).to.not.be.undefined;
+    expect(priceDescriptor!.set).to.not.be.undefined;
+
+    expect(idDescriptor!.get).to.be.undefined;
+    expect(idDescriptor!.set).to.be.undefined;
+  });
+
+  it('it will throw an error unsupported properties', () => {
+    // fails because the target is a literal and not the cart itself
+    expect(() => new ShimMonitor(globalMock.digitalData.cart.cartID, 'cartID', 'digitalData.cart')).to.throw();
+  });
+
+  it('it should emit the value on change', (done) => {
+    expectEventListener(DataLayerEventType.PROPERTY, 'cart-5678', done);
+
+    const cartMonitor = new ShimMonitor(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor).to.not.be.undefined;
+
+    globalMock.digitalData.cart.cartID = 'cart-5678';
+  });
+
+  it('it should remove a monitor and reassign the original value', () => {
+    const cartMonitor = new ShimMonitor(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor).to.not.be.undefined;
+
+    // TODO once we solve the timing getter/setter bug
+  });
+});

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { MockClass, Call } from '../mocks/mock';
+import { DataLayerEventType, DataLayerDetail } from '../../src/event';
 
 /**
  * Tests whether a call queue has one Call and returns it.
@@ -40,4 +41,40 @@ export function expectParams(mock: MockClass, methodName: string, callQueueLengt
   expect(parameters).to.not.be.undefined;
   expect(parameters).to.not.be.null;
   return parameters;
+}
+
+/**
+ * Create an EventListener that tests the events fired match expected values.
+ * This harness supports async events by using Mocha's done callback.
+ * @param expectedType the expected DataLayerEventType
+ * @param expectedValue the expected value in the object event
+ * @param done Mocha's done callback to signal the tests passed
+ */
+export function expectEventListener(type: DataLayerEventType, expectedValue: any, done: Mocha.Done) {
+  expect(expectedValue).to.not.be.undefined;
+
+  const listener = (event: Event) => {
+    expect(event).to.not.be.undefined;
+    expect(event.type).to.eq(type);
+
+    const customEvent = event as CustomEvent<DataLayerDetail>;
+    expect(customEvent.detail).to.not.be.undefined;
+
+    if (event.type === DataLayerEventType.PROPERTY) {
+      expect(customEvent.detail.value).to.eq(expectedValue);
+    }
+
+    if (event.type === DataLayerEventType.FUNCTION) {
+      expect(customEvent.detail.args).to.not.be.undefined;
+      expect(customEvent.detail.args!.length).to.eq(expectedValue.length);
+
+      customEvent.detail.args!.forEach((arg: any, i: number) => expect(expectedValue[i] === arg));
+    }
+
+    // remove the listener to clean up for the next test
+    window.removeEventListener(type, listener);
+    done();
+  };
+
+  window.addEventListener(type, listener);
 }

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { MockClass, Call } from '../mocks/mock';
-import { DataLayerEventType, DataLayerDetail } from '../../src/event';
+import { DataLayerDetail } from '../../src/event';
 
 /**
  * Tests whether a call queue has one Call and returns it.
@@ -46,11 +46,11 @@ export function expectParams(mock: MockClass, methodName: string, callQueueLengt
 /**
  * Create an EventListener that tests the events fired match expected values.
  * This harness supports async events by using Mocha's done callback.
- * @param expectedType the expected DataLayerEventType
+ * @param expectedType the expected type string
  * @param expectedValue the expected value in the object event
  * @param done Mocha's done callback to signal the tests passed
  */
-export function expectEventListener(type: DataLayerEventType, expectedValue: any, done: Mocha.Done) {
+export function expectEventListener(type: string, expectedValue: any, done: Mocha.Done) {
   expect(expectedValue).to.not.be.undefined;
 
   const listener = (event: Event) => {
@@ -63,11 +63,11 @@ export function expectEventListener(type: DataLayerEventType, expectedValue: any
     const customEvent = event as CustomEvent<DataLayerDetail>;
     expect(customEvent.detail).to.not.be.undefined;
 
-    if (event.type === DataLayerEventType.PROPERTY) {
+    if (customEvent.detail.value) {
       expect(customEvent.detail.value).to.eq(expectedValue);
     }
 
-    if (event.type === DataLayerEventType.FUNCTION) {
+    if (customEvent.detail.args) {
       expect(customEvent.detail.args).to.not.be.undefined;
       expect(customEvent.detail.args!.length).to.eq(expectedValue.length);
 

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -54,6 +54,9 @@ export function expectEventListener(type: DataLayerEventType, expectedValue: any
   expect(expectedValue).to.not.be.undefined;
 
   const listener = (event: Event) => {
+    // remove the listener to clean up for the next test
+    window.removeEventListener(type, listener);
+
     expect(event).to.not.be.undefined;
     expect(event.type).to.eq(type);
 
@@ -71,8 +74,6 @@ export function expectEventListener(type: DataLayerEventType, expectedValue: any
       customEvent.detail.args!.forEach((arg: any, i: number) => expect(expectedValue[i] === arg));
     }
 
-    // remove the listener to clean up for the next test
-    window.removeEventListener(type, listener);
     done();
   };
 

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { MockClass, Call } from '../mocks/mock';
 import { DataLayerDetail } from '../../src/event';
+import { DataLayerObserver, DataLayerConfig } from '../../src/observer';
 
 /**
  * Tests whether a call queue has one Call and returns it.
@@ -78,4 +79,92 @@ export function expectEventListener(type: string, expectedValue: any, done: Moch
   };
 
   window.addEventListener(type, listener);
+}
+
+/**
+ * Manages the lifecycle of DataLayerObservers to clean up properly.
+ */
+export class ExpectObserver {
+  static instance: ExpectObserver;
+
+  observers: DataLayerObserver[];
+
+  private constructor() {
+    this.observers = [];
+  }
+
+  /**
+   * Creates a DataLayerObserver.
+   * @param config that defines the DataLayerConfig
+   * @param expectHandlers when true checks there is a handler for each rule
+   */
+  create(config: DataLayerConfig, expectHandlers = true): DataLayerObserver {
+    const observer = new DataLayerObserver(config);
+    expect(observer).to.not.be.undefined;
+    expect(observer).to.not.be.null;
+
+    if (expectHandlers) {
+      expect(observer.handlers.length).to.eq(config.rules.length);
+    }
+
+    if (config.rules.find((rule) => rule.monitor === undefined || rule.monitor === true)) {
+      expect(Object.getOwnPropertyNames(observer.monitors).length).be.greaterThan(0);
+    }
+
+    this.observers.push(observer);
+
+    return observer;
+  }
+
+  /**
+   * Cleans up an observer by removing its EventListener from the window.
+   * If no observer is defined, all observers previously registered are cleaned up.
+   * @param observer to be cleaned up.
+   */
+  cleanup(observer?: DataLayerObserver) {
+    if (observer) {
+      this.destroy(observer);
+    } else {
+      this.observers.forEach((o) => {
+        this.destroy(o);
+      });
+    }
+  }
+
+  /**
+   * Creates an DataLayerObserver with default DataLayerConfig.
+   */
+  default(): DataLayerObserver {
+    const observer = new DataLayerObserver();
+
+    expect(observer).to.not.be.undefined;
+    expect(observer).to.not.be.null;
+
+    this.observers.push(observer);
+
+    return observer;
+  }
+
+  /**
+   * Cleans up an observer by removing its EventListener from the window.
+   * @param observer to be cleaned up.
+   */
+  private destroy(observer: DataLayerObserver) {
+    observer.handlers.forEach((handler) => {
+      handler.stop();
+    });
+
+    const i = this.observers.indexOf(observer);
+    if (i > -1) {
+      this.observers.splice(i, 1);
+    }
+  }
+
+  static getInstance(): ExpectObserver {
+    if (!ExpectObserver.instance) {
+      ExpectObserver.instance = new ExpectObserver();
+    }
+
+    return ExpectObserver.instance;
+  }
 }


### PR DESCRIPTION
This PR adds the concept of a "monitor" to watch for changes on a property.  I used "monitor" so it wouldn't be confused with implementation, which uses EventListeners.
- The shimming technique applies to all properties in a given object, which would be the result of a selector having been run.  You can optionally not shim `monitor=false` in a rule if you only wanted to `readOnLoad`.
- The specs use NPM deepcopy since I had a few issues with test pollution.
- I had to add `monitor: false` to all our previous observer.spec rules since the default behavior was true and that had side-effects.  That and a lint:fix caused more changes than normal.
- I added some selector.spec tests because I'm explicitly relying on dot notation select to return a reference to an object and not a copy.