### PR TITLE
Refactor logger for message cleanup

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -13,7 +13,7 @@ import DataLayerTarget from './target';
  * Required
  *  rules: a list of pre-configured DataLayerRules
  * Optional
- *  appender: a custom log appender
+ *  appender: a custom log appender or string alias (e.g. fullstory or console)
  *  beforeDestination: OperatorOptions that is always used just before before the destination
  *  previewMode: redirects output from a destination to previewDestination when testing rules
  *  previewDestination: output destination using selection syntax for with previewMode
@@ -22,7 +22,7 @@ import DataLayerTarget from './target';
  *  urlValidator: a function used to validate a DataLayerRule's `url`
  */
 export interface DataLayerConfig {
-  appender?: LogAppender;
+  appender?: string | LogAppender;
   beforeDestination?: OperatorOptions;
   previewDestination?: string;
   previewMode?: boolean;
@@ -91,7 +91,11 @@ export class DataLayerObserver {
   }) {
     const { appender, rules } = config;
     if (appender) {
-      Logger.getInstance().appender = appender;
+      if (typeof appender === 'string') {
+        Logger.getInstance(appender);
+      } else {
+        Logger.getInstance().appender = appender;
+      }
     }
 
     if (rules) {


### PR DESCRIPTION
I refactor the logger a bit to do two things:

1. Allow a more generic way to provide context.  Previously, important identifiers like rule ID, selector, path, etc got put into the message because that was all we had.  This is problematic because when there are multiple identifiers, the message can be rather long.  Another issue is that we sometimes use selector, source, and path interchangeably.  Now that these are better defined from the shim PR, we can send these to FullStory as discrete name:value pairs in a custom payload.

2. Add an option to configure FullStory as the log appender.  This was possible before, but the code was part of the window expando.  Now the code is in Logger, and you'll do `window['_dlo_appender'] = 'fullstory'`.  We'll still accept a custom `LogAppender` but code was added to also conditionally accept a string alias like `fullstory` and `console`.