### PR TITLE
Add function shim

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -48,7 +48,7 @@ export function createEventType(path: string) {
  */
 export function createEvent(target: any, property: string, value: any, path: string): CustomEvent<DataLayerDetail> {
   return new CustomEvent<DataLayerDetail>(createEventType(path), {
-    detail: typeof target === 'function' ? new FunctionDetail(path, property, value)
+    detail: typeof target[property] === 'function' ? new FunctionDetail(path, property, value)
       : new PropertyDetail(path, property, value),
   });
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -34,7 +34,7 @@ export default class DataHandler {
   constructor(target: DataLayerTarget | string, public debug = false) {
     this.target = typeof target === 'string' ? new DataLayerTarget(target) : target;
 
-    if (!this.target.object) {
+    if (!this.target.subject) {
       throw new Error(`Data layer ${typeof target === 'string' ? target : target.path} not found on page`);
     }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,7 +16,7 @@ export default class DataHandler {
 
   private operators: Operator[] = [];
 
-  private target: DataLayerTarget;
+  readonly target: DataLayerTarget;
 
   private timeoutId: number | null = null;
 

--- a/src/monitor-factory.ts
+++ b/src/monitor-factory.ts
@@ -1,0 +1,58 @@
+import Monitor from './monitor';
+import ShimMonitor from './monitor-shim';
+
+/**
+ * Because only a single Monitor can exist on an object's property and various DataHandlers
+ * may be interested, MonitorFactory controls creation and removal of Monitors.
+ */
+export default class MonitorFactory {
+  private static instance: MonitorFactory;
+
+  private monitors: { [path: string]: Monitor } = {};
+
+  private constructor() {
+    // keeps constructor private
+  }
+
+  static getInstance(): MonitorFactory {
+    if (!MonitorFactory.instance) {
+      MonitorFactory.instance = new MonitorFactory();
+    }
+
+    return MonitorFactory.instance;
+  }
+
+  /**
+   * Creates a Monitor. If a Monitor has already been created, it will be returned.
+   * @param object that applies to the Monitor
+   * @param property in the object to Monitor
+   * @param path describing the object
+   */
+  create(object: Object, property: string, path: string): Monitor {
+    const key = typeof (object as any)[property] === 'function' ? path : `${path}.${property}`;
+
+    if (!this.monitors[key]) {
+      this.monitors[key] = new ShimMonitor(object, property, path);
+    }
+
+    return this.monitors[key];
+  }
+
+  /**
+   * Removes a Monitor.
+   * @param path identifying the Monitor to be removed
+   * @param fuzzy when true removes all Monitors that start with the path
+   */
+  remove(path: string, fuzzy = false) {
+    const paths = fuzzy ? Object.getOwnPropertyNames(this.monitors).filter((key) => key.startsWith(path)) : [path];
+
+    paths.forEach((monitorPath) => {
+      const monitor = this.monitors[monitorPath];
+
+      if (monitor) {
+        monitor.remove();
+        delete this.monitors[monitorPath];
+      }
+    });
+  }
+}

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -24,15 +24,14 @@ export default abstract class Monitor {
 
       this.copy();
 
-      switch (typeof object) {
-        case 'object':
-          this.addPropertyMonitor(object, property);
-          break;
-        case 'function':
-          // TODO
-          break;
-        default:
-          throw new Error(`Monitor can not be added to unsupported type ${typeof this.object}`);
+      if (typeof object !== 'object' && typeof object[property] !== 'function') {
+        throw new Error(`Unsupported type ${typeof object}`);
+      }
+
+      if (typeof object[property] === 'function') {
+        this.addFunctionMonitor();
+      } else {
+        this.addPropertyMonitor();
       }
     }
   }
@@ -59,10 +58,13 @@ export default abstract class Monitor {
 
   /**
    * Watches for changes on properties within an object.
-   * @param target the object containing the property
-   * @param property the property to watch
    */
-  abstract addPropertyMonitor(target: any, property: string): void;
+  abstract addPropertyMonitor(): void;
+
+  /**
+   * Watches for function calls.
+   */
+  abstract addFunctionMonitor(): void;
 
   /**
    * Stops watching for changes and function calls.

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -116,7 +116,7 @@ export class DataLayerObserver {
    * Adds monitor to a target in the data layer. If a monitor already exists, calling this
    * function will result in a no-op.
    * @param target to add monitors into
-   * @param property to monitor; if not property is given, the monitor is added to the target itself
+   * @param property to monitor; if property is not given, the monitor is added to the target itself
    */
   static addMonitor(target: DataLayerTarget) {
     const {

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -3,10 +3,8 @@ import { BuiltinOptions, OperatorFactory } from './factory';
 import DataHandler from './handler';
 import { Logger, LogAppender } from './utils/logger';
 import { FunctionOperator } from './operators';
-import Monitor from './monitor';
-import ShimMonitor from './monitor-shim';
 import DataLayerTarget from './target';
-import { select } from './selector';
+import MonitorFactory from './monitor-factory';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -72,8 +70,6 @@ export class DataLayerObserver {
 
   listeners: { [path: string]: EventListener[] } = {};
 
-  monitors: { [path: string]: { [property: string]: Monitor } } = {};
-
   /**
    * Creates a DataLayerObserver. If no DataLayerConfig is provided, the following settings will be
    * used:
@@ -122,26 +118,20 @@ export class DataLayerObserver {
    * @param target to add monitors into
    * @param property to monitor; if not property is given, the monitor is added to the target itself
    */
-  addMonitor(target: DataLayerTarget, property?: string) {
-    const { subject, path } = target;
+  static addMonitor(target: DataLayerTarget) {
+    const {
+      subject, path, property, parent, parentPath,
+    } = target;
 
-    if (!this.monitors[path]) {
-      this.monitors[path] = {};
+    if (typeof subject === 'object') {
+      MonitorFactory.getInstance().create(parent, property, parentPath); // monitor the parent for re-assignments
+      Object.getOwnPropertyNames(subject).forEach((childProperty: string) => {
+        MonitorFactory.getInstance().create(subject, childProperty, path); // monitor the child properties
+      });
     }
 
-    // NOTE we can only shim a property once
-    if (property) {
-      if (!this.monitors[target.path][property]) {
-        this.monitors[path][property] = new ShimMonitor(subject, property, path);
-      }
-    } else {
-      // NOTE this is also used to create a function monitor
-      const lastProperty = target.path.substring(target.path.lastIndexOf('.') + 1);
-      const parentPath = target.path.substring(0, target.path.lastIndexOf('.'));
-
-      if (!this.monitors[target.path][lastProperty]) {
-        this.monitors[path][lastProperty] = new ShimMonitor(select(parentPath), lastProperty, path);
-      }
+    if (typeof subject === 'function') {
+      MonitorFactory.getInstance().create(parent, property, path);
     }
   }
 
@@ -255,29 +245,19 @@ export class DataLayerObserver {
           this.removeHandler(handler);
         }
 
-        if (typeof target.subject === 'object') {
-          if (monitor) {
-            Object.getOwnPropertyNames(target.subject).forEach((property) => {
-              try {
-                this.addMonitor(target, property);
-              } catch (err) {
-                Logger.getInstance().warn(`Failed to create monitor on ${property} for rule ${id}`, source);
-              }
-            });
-          }
-
-          if (readOnLoad) {
-            try {
-              handler.fireEvent();
-            } catch (err) {
-              Logger.getInstance().error(`Failed to read on load for rule ${id}`, source);
-            }
-          }
-        } else {
+        if (readOnLoad && typeof target.subject === 'object') {
           try {
-            this.addMonitor(target);
+            handler.fireEvent();
           } catch (err) {
-            Logger.getInstance().warn(`Failed to create function monitor for rule ${id}`, source);
+            Logger.getInstance().error(`Failed to read on load for rule ${id}`, source);
+          }
+        }
+
+        if (typeof target.subject === 'function' || monitor) {
+          try {
+            DataLayerObserver.addMonitor(target);
+          } catch (err) {
+            Logger.getInstance().warn(`Failed to create monitor for rule ${id}`, source);
           }
         }
       } catch (err) {
@@ -312,18 +292,5 @@ export class DataLayerObserver {
     if (i > -1) {
       this.handlers.splice(i, 1);
     }
-  }
-
-  /**
-   * Removes a monitor from watching property changes or function calls.
-   * @param path to the data layer object that have monitors created
-   * @param property of the specific monitor to remove, else all monitors are removed
-   */
-  removeMonitor(path: string, property?: string) {
-    const properties = property ? [property] : Object.getOwnPropertyNames(this.monitors[path]);
-    properties.forEach((prop) => {
-      this.monitors[path][prop].remove();
-      delete this.monitors[path][prop];
-    });
   }
 }

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,24 +1,22 @@
 import { parsePath, ElementKind, select } from './selector';
 
 /**
- * DataLayerTarget refers to the object to be observed from a data layer.
- * Selectors are commonly used to access objects in a data layer; however, a selector can sometimes return
+ * DataLayerTarget refers to the subject to be observed from a data layer.
+ * Selectors are commonly used to access objects or functions in a data layer; however, a selector can sometimes return
  * a copy of an object. For example, picking or omitting returns an intermediate object - not the original
- * object from the data layer. DataLayerTarget retains the object and path to that object for the purposes
- * of storing a reference to the actual data layer object.
+ * object from the data layer. DataLayerTarget retains the subject and path to the subject for the purposes
+ * of storing a reference to the actual data layer object or function.
  */
 export default class DataLayerTarget {
-  readonly object: any;
+  readonly subject: Object | Function;
 
   readonly path: string;
 
   get value(): any {
-    return typeof this.object === 'object' ? select(this.selector) : null;
+    return typeof this.subject === 'object' ? select(this.selector) : null;
   }
 
-  id: number;
-
-  constructor(public readonly selector: string, object?: any) {
+  constructor(public readonly selector: string) {
     const parsedPath = parsePath(selector);
 
     if (!parsedPath) {
@@ -41,8 +39,8 @@ export default class DataLayerTarget {
         }
       }
     }
-    this.id = Date.now();
+
     this.path = !path ? selector : path;
-    this.object = object || select(this.path);
+    this.subject = select(this.path);
   }
 }

--- a/src/target.ts
+++ b/src/target.ts
@@ -12,8 +12,40 @@ export default class DataLayerTarget {
 
   readonly path: string;
 
+  /**
+   * Returns the value of the subject by executing the selector.
+   */
   get value(): any {
-    return typeof this.subject === 'object' ? select(this.selector) : null;
+    return select(this.selector);
+  }
+
+  /**
+   * Returns the property name of the subject.
+   */
+  get property(): string {
+    return this.path.substring(this.path.lastIndexOf('.') + 1);
+  }
+
+  /**
+   * Returns the parent object that contains the subject.
+   */
+  get parent(): any {
+    return select(this.parentPath);
+  }
+
+  /**
+   * Returns the path to the parent that contains the subject.
+   */
+  get parentPath(): string {
+    return this.path.substring(0, this.path.lastIndexOf('.'));
+  }
+
+  /**
+   * Returns the parent's property name.
+   */
+  get parentProperty(): string {
+    const parentPath = this.path.substring(0, this.path.lastIndexOf('.'));
+    return parentPath.substring(parentPath.lastIndexOf('.') + 1);
   }
 
   constructor(public readonly selector: string) {

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -15,6 +15,7 @@ import { Operator, OperatorOptions } from '../src/operator';
 import { LogEvent } from '../src/utils/logger';
 import DataHandler from '../src/handler';
 import { MockClass } from './mocks/mock';
+import MonitorFactory from '../src/monitor-factory';
 
 class EchoOperator implements Operator {
   options: OperatorOptions = {
@@ -468,7 +469,7 @@ describe('DataLayerObserver unit tests', () => {
     }, DataHandler.debounceTime * 1.5);
 
     // remove monitors and re-check
-    observer.removeMonitor('digitalData.cart');
+    MonitorFactory.getInstance().remove('digitalData.cart.cartID');
 
     globalMock.digitalData.cart.cartID = 'cart-0000';
 
@@ -481,7 +482,7 @@ describe('DataLayerObserver unit tests', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
-  it('function calls should trigger the data handler', (done) => {
+  it('function calls should trigger the data handler', () => {
     let args: any[] = [];
 
     const hit: any = {
@@ -508,12 +509,9 @@ describe('DataLayerObserver unit tests', () => {
     globalMock.dataLayer.push(hit);
 
     // check the function args
-    setTimeout(() => {
-      expect(args.length).to.eq(1);
-      expect(args[0]).to.eq(hit);
-
-      done();
-    }, DataHandler.debounceTime * 1.5);
+    // NOTE that functions are not debounced and called synchronously
+    expect(args.length).to.eq(1);
+    expect(args[0]).to.eq(hit);
 
     ExpectObserver.getInstance().cleanup(observer);
   });

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -9,6 +9,7 @@ import { expectEventListener } from './utils/mocha';
 import { createEventType } from '../src/event';
 
 interface GlobalMock {
+  dataLayer: any[],
   digitalData: CEDDL,
 }
 
@@ -17,11 +18,13 @@ let globalMock: GlobalMock;
 describe('ShimMonitor unit tests', () => {
   beforeEach(() => {
     (globalThis as any).digitalData = deepcopy(basicDigitalData); // NOTE copy so mutations don't pollute tests
+    (globalThis as any).dataLayer = [];
     globalMock = globalThis as any;
   });
 
   afterEach(() => {
     delete (globalThis as any).digitalData;
+    delete (globalThis as any).dataLayer;
   });
 
   it('it should create a property Monitor', () => {
@@ -61,6 +64,49 @@ describe('ShimMonitor unit tests', () => {
     expect(cartMonitor).to.not.be.undefined;
 
     globalMock.digitalData.cart.cartID = 'cart-5678';
+  });
+
+  it('it should emit args from function calls', (done) => {
+    const path = 'dataLayer';
+    const hit: any = {
+      page: 'homepage',
+    };
+
+    expectEventListener(createEventType(path), [hit], done); // NOTE the value emitted is a list of args
+
+    const listMonitor = new ShimMonitor(globalMock.dataLayer, 'push', path);
+    expect(listMonitor).to.not.be.undefined;
+
+    const length = globalMock.dataLayer.push(hit);
+    expect(length).to.eq(1);
+  });
+
+  it('it should emit variadic args from function calls', (done) => {
+    const path = 'dataLayer';
+
+    expectEventListener(createEventType(path), [1, 2, 3], done); // NOTE the value emitted is a list of args
+
+    const listMonitor = new ShimMonitor(globalMock.dataLayer, 'push', path);
+    expect(listMonitor).to.not.be.undefined;
+
+    const length = globalMock.dataLayer.push(1, 2, 3);
+    expect(length).to.eq(3);
+  });
+
+  it('it should emit args but trap function exceptions', (done) => {
+    const path = 'dataLayer';
+    (globalThis as any).dataLayer.error = (message: string) => {
+      throw new Error(message);
+    };
+
+    expectEventListener(createEventType(path), ['Hello World'], done); // NOTE the value emitted is a list of args
+
+    const listMonitor = new ShimMonitor(globalMock.dataLayer, 'error', path);
+    expect(listMonitor).to.not.be.undefined;
+
+    // @ts-ignore
+    const ret = globalMock.dataLayer.error('Hello World');
+    expect(ret).to.eq(null);
   });
 
   it('it should remove a monitor and reassign the original value', () => {

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -109,6 +109,26 @@ describe('ShimMonitor unit tests', () => {
     expect(ret).to.eq(null);
   });
 
+  it('it should emit args and not fail because of dispatch related exceptions', () => {
+    const path = 'digitalData.fn';
+    (globalThis as any).dataLayer.fn = () => true;
+
+    // this will simulate a handler's exception
+    const listener = () => {
+      throw new Error();
+    };
+    window.addEventListener(createEventType(path), listener);
+
+    const fnMonitor = new ShimMonitor(globalMock.dataLayer, 'fn', path);
+    expect(fnMonitor).to.not.be.undefined;
+
+    // @ts-ignore
+    const ret = globalMock.dataLayer.fn();
+    expect(ret).to.eq(true);
+
+    window.removeEventListener(createEventType(path), listener);
+  });
+
   it('it should remove a monitor and reassign the original value', () => {
     const o = { message: 'Hello World' };
 

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -71,8 +71,7 @@ export function expectEventListener(type: string, expectedValue: any, done: Moch
     if (customEvent.detail.args) {
       expect(customEvent.detail.args).to.not.be.undefined;
       expect(customEvent.detail.args!.length).to.eq(expectedValue.length);
-
-      customEvent.detail.args!.forEach((arg: any, i: number) => expect(expectedValue[i] === arg));
+      expect(customEvent.detail.args!).to.eql(expectedValue);
     }
 
     done();

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { MockClass, Call } from '../mocks/mock';
 import { DataLayerDetail } from '../../src/event';
 import { DataLayerObserver, DataLayerConfig } from '../../src/observer';
+import MonitorFactory from '../../src/monitor-factory';
 
 /**
  * Tests whether a call queue has one Call and returns it.
@@ -106,10 +107,6 @@ export class ExpectObserver {
       expect(observer.handlers.length).to.eq(config.rules.length);
     }
 
-    if (config.rules.find((rule) => rule.monitor === undefined || rule.monitor === true)) {
-      expect(Object.getOwnPropertyNames(observer.monitors).length).be.greaterThan(0);
-    }
-
     this.observers.push(observer);
 
     return observer;
@@ -150,6 +147,7 @@ export class ExpectObserver {
    */
   private destroy(observer: DataLayerObserver) {
     observer.handlers.forEach((handler) => {
+      MonitorFactory.getInstance().remove(handler.target.path, true);
       handler.stop();
     });
 


### PR DESCRIPTION
Initial function shim implementation added.  I'm going to revisit and cleanup.  The `DataLayerTarget` and `DataLayerObserver.addMonitor` are a bit messy.  You have to walk back up to the parent to get a reference to it and the `property` (i.e. function).