### PR TITLE
Add the fan out operator.

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,20 +6,23 @@ import {
   ConvertOperator, ConvertOperatorOptions,
   QueryOperator, QueryOperatorOptions,
   RenameOperator, RenameOperatorOptions,
+  FanOutOperator, FanOutOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
 
 /**
  * Declares known, built-in Operators.
  */
-export type BuiltinOperator = typeof ConvertOperator | typeof FlattenOperator | typeof FunctionOperator |
-  typeof InsertOperator | typeof SuffixOperator | typeof QueryOperator | typeof RenameOperator;
+export type BuiltinOperator = typeof ConvertOperator | typeof FlattenOperator
+  | typeof FunctionOperator | typeof InsertOperator | typeof SuffixOperator
+  | typeof QueryOperator | typeof RenameOperator | typeof FanOutOperator;
 
 /**
  * Declares known, built-in OperatorOptions.
  */
-export type BuiltinOptions = ConvertOperatorOptions | FlattenOperatorOptions | FunctionOperatorOptions
-  | InsertOperatorOptions | SuffixOperatorOptions | QueryOperatorOptions | RenameOperatorOptions;
+export type BuiltinOptions = ConvertOperatorOptions | FlattenOperatorOptions
+  | FunctionOperatorOptions | InsertOperatorOptions | SuffixOperatorOptions
+  | QueryOperatorOptions | RenameOperatorOptions | FanOutOperatorOptions;
 
 /**
  * OperatorFactory creates instances built-in Operators. Since DataLayerRule can define OperatorOptions at runtime,
@@ -34,6 +37,7 @@ export class OperatorFactory {
     suffix: SuffixOperator,
     query: QueryOperator,
     rename: RenameOperator,
+    'fan-out': FanOutOperator,
   };
 
   /**

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -140,8 +140,6 @@ export default class DataHandler {
       } catch (err) {
         Logger.getInstance().error(`Operator ${name} failed for ${path} at step ${i}`,
           path);
-        // @eslint-disable-next-line
-        console.error(err.message);
         return null;
       }
     }

--- a/src/operators/fan-out.ts
+++ b/src/operators/fan-out.ts
@@ -1,0 +1,52 @@
+import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+
+export interface FanOutOperatorOptions extends OperatorOptions {
+  properties: string | string[];
+}
+
+export class FanOutOperator implements Operator {
+  static specification = {
+    index: { required: false, type: ['number'] },
+    properties: { required: true, type: ['string'] },
+  };
+
+  readonly index: number;
+
+  readonly properties: string[];
+
+  constructor(public options: FanOutOperatorOptions) {
+    const { index = 0, properties = [] } = options;
+    this.index = index;
+    if (typeof properties === 'string') {
+      this.properties = [properties];
+    } else {
+      this.properties = properties;
+    }
+  }
+
+  /*
+  The FanOutOperator is a special case.
+  `handleData` returns an array of objects that each should have the remaining operators run on them.
+  If a property value is an array then each item in the array is fanned out.
+  */
+  handleData(data: any[]): any[] | null {
+    if (typeof data[this.index] !== 'object') {
+      throw new Error('Can only fan out property names on objects');
+    }
+    const plucked: any[] = [];
+    for (let i = 0; i < this.properties.length; i += 1) {
+      const value = data[this.index][this.properties[i]];
+      if (Array.isArray(value)) {
+        plucked.push(...value);
+      } else {
+        plucked.push(value);
+      }
+    }
+    return plucked;
+  }
+
+  validate() {
+    const validator = new OperatorValidator(this.options);
+    validator.validate(FanOutOperator.specification);
+  }
+}

--- a/src/operators/fan-out.ts
+++ b/src/operators/fan-out.ts
@@ -18,7 +18,7 @@ export class FanOutOperator implements Operator {
     const { index = 0, properties = [] } = options;
     this.index = index;
     if (typeof properties === 'string') {
-      this.properties = [properties];
+      this.properties = properties.split(',').map((val) => val.trim());
     } else {
       this.properties = properties;
     }

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,6 +1,7 @@
 export * from './convert';
 export * from './flatten';
 export * from './function';
+export * from './fan-out';
 export * from './insert';
 export * from './suffix';
 export * from './rename';

--- a/test/operator-fan-out.spec.ts
+++ b/test/operator-fan-out.spec.ts
@@ -1,0 +1,60 @@
+import 'mocha';
+import { expect } from 'chai';
+import deepcopy from 'deepcopy';
+
+import { DataLayerObserver } from '../src/observer';
+
+const item = {
+  'left-hand': { fingers: { index: true, thumb: false } },
+  'right-hand': { fingers: { middle: false, pinky: true } },
+  list: [
+    { eenie: 'meenie' },
+    { minie: 'moe' },
+  ],
+};
+
+// @ts-ignore
+function handleDestination(...params: any[]) {
+  (globalThis as any).callParameters.push(params);
+}
+
+describe('fan out operator unit tests', () => {
+  beforeEach(() => {
+    (globalThis as any).item = deepcopy(item);
+    (globalThis as any).handleDestination = handleDestination;
+    (globalThis as any).callParameters = [];
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).item;
+    delete (globalThis as any).callParameters;
+  });
+
+  it('it should fan out properties', () => {
+    const observer = new DataLayerObserver({
+      rules: [
+        {
+          source: 'item',
+          operators: [
+            { name: 'fan-out', properties: ['left-hand', 'right-hand', 'list'] },
+            { name: 'flatten' },
+          ],
+          destination: 'globalThis.handleDestination',
+          monitor: false,
+        },
+      ],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+    const callParams: object[] = (globalThis as any).callParameters;
+    expect(callParams.length).to.equal(4);
+    // @ts-ignore
+    expect(callParams[0][0].index).to.equal(true);
+    // @ts-ignore
+    expect(callParams[1][0].middle).to.equal(false);
+    // @ts-ignore
+    expect(callParams[2][0].eenie).to.equal('meenie');
+    // @ts-ignore
+    expect(callParams[3][0].minie).to.equal('moe');
+  });
+});

--- a/test/operator-fan-out.spec.ts
+++ b/test/operator-fan-out.spec.ts
@@ -13,24 +13,18 @@ const item = {
   ],
 };
 
-// @ts-ignore
-function handleDestination(...params: any[]) {
-  (globalThis as any).callParameters.push(params);
-}
-
 describe('fan out operator unit tests', () => {
   beforeEach(() => {
     (globalThis as any).item = deepcopy(item);
-    (globalThis as any).handleDestination = handleDestination;
-    (globalThis as any).callParameters = [];
   });
 
   afterEach(() => {
     delete (globalThis as any).item;
-    delete (globalThis as any).callParameters;
   });
 
   it('it should fan out properties', () => {
+    const callParameters: any[] = [];
+
     const observer = new DataLayerObserver({
       rules: [
         {
@@ -39,22 +33,54 @@ describe('fan out operator unit tests', () => {
             { name: 'fan-out', properties: ['left-hand', 'right-hand', 'list'] },
             { name: 'flatten' },
           ],
-          destination: 'globalThis.handleDestination',
+          destination: (...params: any[]) => {
+            callParameters.push(params);
+          },
           monitor: false,
         },
       ],
       readOnLoad: true,
     });
     expect(observer).to.not.be.undefined;
-    const callParams: object[] = (globalThis as any).callParameters;
-    expect(callParams.length).to.equal(4);
+    expect(callParameters.length).to.equal(4);
     // @ts-ignore
-    expect(callParams[0][0].index).to.equal(true);
+    expect(callParameters[0][0].index).to.equal(true);
     // @ts-ignore
-    expect(callParams[1][0].middle).to.equal(false);
+    expect(callParameters[1][0].middle).to.equal(false);
     // @ts-ignore
-    expect(callParams[2][0].eenie).to.equal('meenie');
+    expect(callParameters[2][0].eenie).to.equal('meenie');
     // @ts-ignore
-    expect(callParams[3][0].minie).to.equal('moe');
+    expect(callParameters[3][0].minie).to.equal('moe');
+  });
+
+  it('it should handle string properties', () => {
+    const callParameters: any[] = [];
+
+    const observer = new DataLayerObserver({
+      rules: [
+        {
+          source: 'item',
+          operators: [
+            { name: 'fan-out', properties: 'left-hand, right-hand,list' },
+            { name: 'flatten' },
+          ],
+          destination: (...params: any[]) => {
+            callParameters.push(params);
+          },
+          monitor: false,
+        },
+      ],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+    expect(callParameters.length).to.equal(4);
+    // @ts-ignore
+    expect(callParameters[0][0].index).to.equal(true);
+    // @ts-ignore
+    expect(callParameters[1][0].middle).to.equal(false);
+    // @ts-ignore
+    expect(callParameters[2][0].eenie).to.equal('meenie');
+    // @ts-ignore
+    expect(callParameters[3][0].minie).to.equal('moe');
   });
 });


### PR DESCRIPTION
The fan out operator allows us to specify a set of properties on a source that each should have the remaining rules applied to them. It needs a special case in the Handler so it's a bit different than the other operators.