### PR TITLE
The fan out operator properties parameter is now optional.

### DIFF
--- a/src/operators/fan-out.ts
+++ b/src/operators/fan-out.ts
@@ -7,7 +7,7 @@ export interface FanOutOperatorOptions extends OperatorOptions {
 export class FanOutOperator implements Operator {
   static specification = {
     index: { required: false, type: ['number'] },
-    properties: { required: true, type: ['string'] },
+    properties: { required: false, type: ['string'] },
   };
 
   readonly index: number;
@@ -26,16 +26,41 @@ export class FanOutOperator implements Operator {
 
   /*
   The FanOutOperator is a special case.
+
   `handleData` returns an array of objects that each should have the remaining operators run on them.
+
   If a property value is an array then each item in the array is fanned out.
+
+  If there are no declared properties then:
+  - if it's an array then return all items
+  - else return all 'own' properties that are objects
   */
   handleData(data: any[]): any[] | null {
-    if (typeof data[this.index] !== 'object') {
-      throw new Error('Can only fan out property names on objects');
+    const datum = data[this.index];
+    if (typeof datum !== 'object' && Array.isArray(datum) === false) {
+      throw new Error('Can only fan out arrays or properties on objects');
     }
     const plucked: any[] = [];
+
+    // If properties is empty then work on the datum itself
+    if (this.properties.length === 0) {
+      if (Array.isArray(datum)) {
+        plucked.push(...datum);
+      } else {
+        Object.values(datum).forEach((value: any) => {
+          if (Array.isArray(value)) {
+            plucked.push(...value);
+          } else if (typeof value === 'object') {
+            plucked.push(value);
+          }
+          // We don't pluck non-object and non-array properties
+        });
+      }
+      return plucked;
+    }
+
     for (let i = 0; i < this.properties.length; i += 1) {
-      const value = data[this.index][this.properties[i]];
+      const value = datum[this.properties[i]];
       if (Array.isArray(value)) {
         plucked.push(...value);
       } else {

--- a/test/operator-fan-out.spec.ts
+++ b/test/operator-fan-out.spec.ts
@@ -53,6 +53,63 @@ describe('fan out operator unit tests', () => {
     expect(callParameters[3][0].minie).to.equal('moe');
   });
 
+  it('it should fan out arrays without properties', () => {
+    const callParameters: any[] = [];
+
+    const observer = new DataLayerObserver({
+      rules: [
+        {
+          source: 'item.list',
+          operators: [
+            { name: 'fan-out' },
+          ],
+          destination: (...params: any[]) => {
+            callParameters.push(params);
+          },
+          monitor: false,
+        },
+      ],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+    expect(callParameters.length).to.equal(2);
+    // @ts-ignore
+    expect(callParameters[0][0].eenie).to.equal('meenie');
+    // @ts-ignore
+    expect(callParameters[1][0].minie).to.equal('moe');
+  });
+
+  it('it should fan out objects without properties', () => {
+    const callParameters: any[] = [];
+
+    const observer = new DataLayerObserver({
+      rules: [
+        {
+          source: 'item',
+          operators: [
+            { name: 'fan-out' },
+            { name: 'flatten' },
+          ],
+          destination: (...params: any[]) => {
+            callParameters.push(params);
+          },
+          monitor: false,
+        },
+      ],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+    expect(callParameters.length).to.equal(4);
+    // @ts-ignore
+    expect(callParameters[0][0].index).to.equal(true);
+    // @ts-ignore
+    expect(callParameters[1][0].middle).to.equal(false);
+    // @ts-ignore
+    expect(callParameters[2][0].eenie).to.equal('meenie');
+    // @ts-ignore
+    expect(callParameters[3][0].minie).to.equal('moe');
+  });
+
   it('it should handle string properties', () => {
     const callParameters: any[] = [];
 


### PR DESCRIPTION
If the rule writer leaves out the `properties` parameter of the fan out operator then for an array it fans out every item in the array and for a non-array object it fans out all values of the object.