### PR TITLE
Rules to send Google tags to Fullstory

### DIFF
--- a/examples/google-tags-fs/index.html
+++ b/examples/google-tags-fs/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <title>Data Layer Observer Example: Google Tags</title>
+    <meta charset='utf-8' />
+    <script>
+      window.digitalData = [
+        {
+          'pageType': 'Home',
+          'pageName': 'Home: Fruit shoppe'
+        },
+        {
+          'gtm.start': 1598892794094,
+          'event': 'gtm.js',
+          'gtm.uniqueEventId': 1
+        },
+        {
+          'userProfile': {
+            'userId': '101',
+            'userType': 'member',
+            'loyaltyProgram': 'early-adopter',
+            'hashedEmail': '555-12232-2332232-232332'
+          }
+        },
+        {
+          'event': 'impressions_loaded',
+          'ecommerce': {
+            'promoView': {
+              'promotions': [
+                {
+                  'id': '1004-Blueberries123321',
+                  'name': 'Fruits',
+                  'creative': 'Blueberries123321',
+                  'position': 'Feature'
+                },
+                {
+                  'id': '1001-Strawberries222333',
+                  'name': 'Fruits',
+                  'creative': 'Strawberries222333',
+                  'position': 'Sub1'
+                }
+              ]
+            }
+          },
+          'gtm.uniqueEventId': 6
+        },
+        {
+          'event': 'gtm.dom',
+          'gtm.uniqueEventId': 12
+        },
+        {
+          'event': 'Social-media Loaded',
+          'gtm.uniqueEventId': 27
+        },
+        {
+          'event': 'recs loaded',
+          'ecommerce': {
+            'impressions': [
+              {
+                'name': 'Heritage Huckleberries',
+                'id': 'P000525722',
+                'price': '2.99',
+                'category': 'homepage product recs',
+                'variant': '',
+                'list': 'homepage product recs',
+                'position': 1,
+                'dimension3': 4.7
+              },
+              {
+                'name': 'Classic Corn',
+                'id': 'P000614444',
+                'price': '4.00',
+                'category': 'homepage product recs',
+                'variant': '',
+                'list': 'homepage product recs',
+                'position': 2,
+                'dimension3': 5
+              },
+            ]
+          },
+          'gtm.uniqueEventId': 28
+        },
+        {
+          'event': 'gtm.load',
+          'gtm.uniqueEventId': 42
+        },
+        {
+          'event': 'gtm.click',
+          'gtm.element': {},
+          'gtm.elementClasses': 'x-icon',
+          'gtm.elementId': '',
+          'gtm.elementTarget': '',
+          'gtm.elementUrl': '',
+          'gtm.uniqueEventId': 45
+        }
+      ];
+    </script>
+  </head>
+  <body>
+    <h1>Data Layer Observer Example: Google Tags</h1>
+
+    <p>
+      Take a look at the source code of this page to see the DLO rules.
+    </p>
+    <p>
+      The Javascript console will show the output of the rules.
+    </p>
+
+    <script>
+      /*
+        Look at the 'basic-embed' example for more configuration options
+      */
+      window['_dlo_previewMode'] = true;
+      window['_dlo_validateRules'] = true;
+
+      window['_dlo_rules'] = [
+    {
+      "id": "fs-ga-page-type",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$[?(pageType, pageName)]" },
+        { "name": "insert", "value": "View Page Type" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-impressions",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.impressions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce impressions" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotions",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.promoView.promotions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce promotions" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-user-vars",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$[?(userProfile)]" },
+        { "name": "flatten"},
+        { "name": "query", "select": "$[?(userId!=-1)]" },
+        { "name": "insert", "select": "userId" }
+      ],
+      "destination": "FS.setUserVars",
+      "readOnLoad": true,
+      "monitor": true
+    }
+      ];
+    </script>
+    <script async='true' src='../../build/dlo.js'></script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -16,6 +16,10 @@
         <a href="./ceddl-fs/">CEDDL to FullStory</a>:
         <p>Demonstrates how to map CEDDL data to FullStory events</p>
       </li>
+      <li>
+        <a href="./google-tags-fs/">Google Tags to FullStory</a>:
+        <p>Demonstrates how to map Google tags to FullStory events</p>
+      </li>
     </ul>
   </body>
 </html>

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -1,0 +1,52 @@
+{
+  "rules": [
+    {
+      "id": "fs-ga-page-type",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$[?(pageType, pageName)]" },
+        { "name": "insert", "value": "View Page Type" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-impressions",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.impressions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce impressions" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotions",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.promoView.promotions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce promotions" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-user-vars",
+      "source": "digitalData",
+      "operators": [
+        { "name": "query", "select": "$[?(userProfile)]" },
+        { "name": "flatten"},
+        { "name": "query", "select": "$[?(userId!=-1)]" },
+        { "name": "insert", "select": "userId" }
+      ],
+      "destination": "FS.setUserVars",
+      "readOnLoad": true,
+      "monitor": true
+    }
+  ]
+}

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -17,7 +17,7 @@
       "operators": [
         { "name": "query", "select": "$.ecommerce.impressions" },
         { "name": "fan-out" },
-        { "name": "insert", "value": "Commerce impressions" }
+        { "name": "insert", "value": "Commerce impression" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
@@ -29,7 +29,7 @@
       "operators": [
         { "name": "query", "select": "$.ecommerce.promoView.promotions" },
         { "name": "fan-out" },
-        { "name": "insert", "value": "Commerce promotions" }
+        { "name": "insert", "value": "Commerce promotion" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "watch": "rollup --config -w",
     "examples": "npm run build && http-server",
     "test": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/*.spec.ts test/**/*.spec.ts",
+    "test:fullstory": "nyc mocha -r ts-node/register -r source-map-support/register -r jsdom-global/register test/fullstory.spec.ts",
     "test:wel-auto-formulate": "npm run examples & cd ./test/web-embed-lab && ./auto-formulate.sh",
     "test:wel-runner": "npm run build && cd ./test/web-embed-lab && ./run-tests.sh",
     "lint": "eslint --ext .ts src/** test/mocks/** test/utils/** test/*.ts",

--- a/src/monitor-factory.ts
+++ b/src/monitor-factory.ts
@@ -32,7 +32,11 @@ export default class MonitorFactory {
     const key = typeof (object as any)[property] === 'function' ? path : `${path}.${property}`;
 
     if (!this.monitors[key]) {
-      this.monitors[key] = new ShimMonitor(object, property, path);
+      const propDescriptor = Object.getOwnPropertyDescriptor(object, property) || null;
+      // functions have no property descriptors but properties need to be configurable (e.g. Array.length is not)
+      if (propDescriptor === null || propDescriptor.configurable) {
+        this.monitors[key] = new ShimMonitor(object, property, path);
+      }
     }
 
     return this.monitors[key];

--- a/src/target.ts
+++ b/src/target.ts
@@ -42,8 +42,8 @@ export default class DataLayerTarget {
    * @param path that describes the path (or some unique identifier) to the property
    * @param selector that can optionally describe a query to be used when accessing the data layer
    */
-  constructor(public readonly subject: Object, public readonly property: string, public readonly path: string,
-    public readonly selector = '') {
+  constructor(public subject: Object, public property: string, public path: string,
+    public selector = '') {
     if (typeof subject !== 'object') {
       throw new Error('Data layer subject must be an object');
     }
@@ -75,6 +75,21 @@ export default class DataLayerTarget {
    */
   query(): any {
     return this.selector ? select(this.selector) : this.value;
+  }
+
+  /**
+   * Converts an Object instance to one that targets a method of the current target
+   * This is mainly used by the observer to convert from targeting an array to targeting array.push
+   */
+  convertToPropertyMethod(methodName: string) {
+    if (this.type !== 'object') {
+      throw new Error('Can only convert targets of type object to a property method target');
+    }
+    this.subject = this.value;
+    // this.path stays as-is because we're setting a new property
+    this.property = methodName;
+    this.selector = this.selector ? this.subjectPath : '';
+    this.type = 'function';
   }
 
   /**

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -1,3 +1,4 @@
+import deepcopy from 'deepcopy';
 import { expect } from 'chai';
 import 'mocha';
 
@@ -8,9 +9,11 @@ import * as cartRules from '../examples/rules/ceddl-cart-fullstory.json';
 import * as pageRules from '../examples/rules/ceddl-page-fullstory.json';
 import * as productRules from '../examples/rules/ceddl-product-fullstory.json';
 import * as transactionRules from '../examples/rules/ceddl-transaction-fullstory.json';
+import * as googleTagsRules from '../examples/rules/google-tags-fullstory.json';
 
 import { basicAppMeasurement, AppMeasurement } from './mocks/adobe';
 import { CEDDL, basicDigitalData } from './mocks/CEDDL';
+import { basicGoogleTags } from './mocks/google-tags';
 import Console from './mocks/console';
 import FullStory from './mocks/fullstory-recording';
 import { expectParams } from './utils/mocha';
@@ -25,7 +28,7 @@ interface GlobalMock {
 let globalMock: GlobalMock;
 
 const rules = [...adobeRules.rules, ...cartRules.rules, ...pageRules.rules, ...userRules.rules, ...productRules.rules,
-  ...transactionRules.rules];
+  ...transactionRules.rules, ...googleTagsRules.rules];
 
 function getRule(id: string) {
   const rule = rules.find((r: DataLayerRule) => r.id === id);
@@ -33,6 +36,29 @@ function getRule(id: string) {
 
   return rule!;
 }
+
+describe('Google Tags to FullStory rules', () => {
+  beforeEach(() => {
+    (globalThis as any).digitalData = deepcopy(basicGoogleTags);
+    (globalThis as any).FS = new FullStory();
+    globalMock = globalThis as any;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).digitalData;
+    delete (globalThis as any).FS;
+  });
+
+  it('should set the user', () => {
+    const observer = new DataLayerObserver({
+      rules: [
+        getRule('fs-ga-user-vars'),
+      ],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+  });
+});
 
 describe('FullStory example rules unit tests', () => {
   beforeEach(() => {

--- a/test/mocks/google-tags.ts
+++ b/test/mocks/google-tags.ts
@@ -1,0 +1,91 @@
+/* eslint-disable import/prefer-default-export */
+export const basicGoogleTags = [
+  {
+    pageType: 'Home',
+    pageName: 'Home: Fruit shoppe',
+  },
+  {
+    'gtm.start': 1598892794094,
+    event: 'gtm.js',
+    'gtm.uniqueEventId': 1,
+  },
+  {
+    userProfile: {
+      userId: '101',
+      userType: 'member',
+      loyaltyProgram: 'early-adopter',
+      hashedEmail: '555-12232-2332232-232332',
+    },
+  },
+  {
+    event: 'impressions_loaded',
+    ecommerce: {
+      promoView: {
+        promotions: [
+          {
+            id: '1004-Blueberries123321',
+            name: 'Fruits',
+            creative: 'Blueberries123321',
+            position: 'Feature',
+          },
+          {
+            id: '1001-Strawberries222333',
+            name: 'Fruits',
+            creative: 'Strawberries222333',
+            position: 'Sub1',
+          },
+        ],
+      },
+    },
+    'gtm.uniqueEventId': 6,
+  },
+  {
+    event: 'gtm.dom',
+    'gtm.uniqueEventId': 12,
+  },
+  {
+    event: 'Social-media Loaded',
+    'gtm.uniqueEventId': 27,
+  },
+  {
+    event: 'recs loaded',
+    ecommerce: {
+      impressions: [
+        {
+          name: 'Heritage Huckleberries',
+          id: 'P000525722',
+          price: '2.99',
+          category: 'homepage product recs',
+          variant: '',
+          list: 'homepage product recs',
+          position: 1,
+          dimension3: 4.7,
+        },
+        {
+          name: 'Classic Corn',
+          id: 'P000614444',
+          price: '4.00',
+          category: 'homepage product recs',
+          variant: '',
+          list: 'homepage product recs',
+          position: 2,
+          dimension3: 5,
+        },
+      ],
+    },
+    'gtm.uniqueEventId': 28,
+  },
+  {
+    event: 'gtm.load',
+    'gtm.uniqueEventId': 42,
+  },
+  {
+    event: 'gtm.click',
+    'gtm.element': {},
+    'gtm.elementClasses': 'x-icon',
+    'gtm.elementId': '',
+    'gtm.elementTarget': '',
+    'gtm.elementUrl': '',
+    'gtm.uniqueEventId': 45,
+  },
+];

--- a/test/operator-fan-out.spec.ts
+++ b/test/operator-fan-out.spec.ts
@@ -59,8 +59,9 @@ describe('fan out operator unit tests', () => {
     const observer = new DataLayerObserver({
       rules: [
         {
-          source: 'item.list',
+          source: 'item',
           operators: [
+            { name: 'query', select: '$[(list)]' },
             { name: 'fan-out' },
           ],
           destination: (...params: any[]) => {


### PR DESCRIPTION
In addition to the rules, tests, and example page for google tags, this PR has a couple of tweaks to how we handle rules that are both read-on-load and monitor of array sources.
The monitor also checks that a property is configurable before trying to monitor it. 