### PR TITLE
v1.1.0 doc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.1.0
+
+- Monitor property changes on data layer objects
+- Monitor function calls (e.g. dataLayer.push)
+- Two new operators added: Rename and Fan-Out
+- Google Analytics examples
+- Updated packaging to support NPM and programmatic usage
+
 ### 1.0.0
 
 - Initial release supporting static data layers

--- a/docs/operator_fan-out.md
+++ b/docs/operator_fan-out.md
@@ -1,0 +1,79 @@
+# Fan-Out Operator
+
+The fan-out operator can be used to execute the remaining operator chain on each element in a list.  The fan-out operator supports operating on elements within a traditional array or a list of properties within an object.
+
+## Options
+
+Options with an asterisk are required.
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `index` | `number` | `0` | Position of the object with properties in the operator input list. |
+| `properties`* | `object` | `undefined` | Dictionary of existing property to renamed property pairs. |
+
+## Usage
+
+## Sending multiple events from a list
+
+### Rule
+
+```javascript
+{
+  source: 'dataLayer[0].ecommerce.promoView.promotions',
+  operators: [{ name: 'fan-out' }, { name: 'insert', value: 'Viewed Promotion' }],
+  destination: 'FS.event',
+}
+```
+
+### Input
+
+```javascript
+[{
+  event: 'impressions_loaded',
+  ecommerce: {
+   promoView: {
+    promotions: [
+     {
+      id: '1004-Blueberries123321',
+      name: 'Fruits',
+      creative: 'Blueberries123321',
+      position: 'Feature'
+     },
+     {
+      id: '1001-Strawberries222333',
+      name: 'Fruits',
+      creative: 'Strawberries222333',
+      position: 'Sub1'
+     },
+    ]
+   }
+  },
+  'gtm.uniqueEventId': 6
+}]
+```
+
+### Output
+
+```javascript
+[
+  'Viewed Promotion',
+  {
+   id: '1004-Blueberries123321',
+   name: 'Fruits',
+   creative: 'Blueberries123321',
+   position: 'Feature'
+   }
+]
+```
+
+```javascript
+[
+  'Viewed Promotion',
+  {
+   id: '1001-Strawberries222333',
+   name: 'Fruits',
+   creative: 'Strawberries222333',
+   position: 'Sub1'
+   }
+]
+```

--- a/docs/operator_fan-out.md
+++ b/docs/operator_fan-out.md
@@ -13,14 +13,14 @@ Options with an asterisk are required.
 
 ## Usage
 
-## Sending multiple events from a list
+## Sending multiple events from a list (automatic)
 
 ### Rule
 
 ```javascript
 {
   source: 'dataLayer[0].ecommerce.promoView.promotions',
-  operators: [{ name: 'fan-out' }, { name: 'insert', value: 'Viewed Promotion' }],
+  operators: [{ name: 'insert', value: 'Viewed Promotion' }],
   destination: 'FS.event',
 }
 ```
@@ -46,6 +46,69 @@ Options with an asterisk are required.
       position: 'Sub1'
      },
     ]
+   }
+  },
+  'gtm.uniqueEventId': 6
+}]
+```
+
+### Output
+
+```javascript
+[
+  'Viewed Promotion',
+  {
+   id: '1004-Blueberries123321',
+   name: 'Fruits',
+   creative: 'Blueberries123321',
+   position: 'Feature'
+   }
+]
+```
+
+```javascript
+[
+  'Viewed Promotion',
+  {
+   id: '1001-Strawberries222333',
+   name: 'Fruits',
+   creative: 'Strawberries222333',
+   position: 'Sub1'
+   }
+]
+```
+
+## Sending multiple events from an object's properties
+
+```javascript
+{
+  source: 'dataLayer[0].ecommerce.promoView.promotions',
+  operators: [{ name: 'fan-out' }, { name: 'insert', value: 'Viewed Promotion' }],
+  destination: 'FS.event',
+}
+```
+
+### Input
+
+```javascript
+[{
+  event: 'impressions_loaded',
+  ecommerce: {
+   promoView: {
+    promotions: {
+     0: {
+      id: '1004-Blueberries123321',
+      name: 'Fruits',
+      creative: 'Blueberries123321',
+      position: 'Feature'
+     },
+     1: {
+      id: '1001-Strawberries222333',
+      name: 'Fruits',
+      creative: 'Strawberries222333',
+      position: 'Sub1'
+     },
+    }
    }
   },
   'gtm.uniqueEventId': 6

--- a/docs/operator_fan-out.md
+++ b/docs/operator_fan-out.md
@@ -8,8 +8,8 @@ Options with an asterisk are required.
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
-| `index` | `number` | `0` | Position of the object with properties in the operator input list. |
-| `properties`* | `object` | `undefined` | Dictionary of existing property to renamed property pairs. |
+| `index` | `number` | `0` | Position of the object to fan-out in the operator input list. |
+| `properties`* | `string` or `string[]` | `undefined` | Desired list of properties to obtain the values and execute the remaining operators. |
 
 ## Usage
 

--- a/docs/operator_rename.md
+++ b/docs/operator_rename.md
@@ -1,0 +1,51 @@
+# Rename Operator
+
+The rename operator can be used to rename properties.  Values will remain unchanged.
+
+Rename is most useful when paired with `FS.identify`, which has specific naming conventions.  For example, you can rename an existing property `emailAddress` to the required property `email`.
+
+## Options
+
+Options with an asterisk are required.
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `index` | `number` | `0` | Position of the object with properties in the operator input list. |
+| `properties`* | `object` | `undefined` | Dictionary of existing property to renamed property pairs. |
+
+## Usage
+
+## Renaming userName to displayName
+
+### Rule
+
+```javascript
+{
+ source: 'digitalData.user.profile[0]',
+ operators: [ { name: 'rename', properties: { userName: 'displayName' } ],
+ destination: 'FS.identify'
+}
+```
+
+### Input
+
+```javascript
+[{
+ profile: [{
+  profileInfo: {
+   profileID: 'pr-12333211',
+   userName: 'JohnyAppleseed',
+  }
+ }]
+}]
+```
+
+### Output
+
+```javascript
+[{
+  profileID: 'pr-12333211',
+  displayName: 'JohnyAppleseed',
+  }
+]
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updated docs to reflect V1.1.0.  @TrevorFSmith can you check the fan-out doc?  I'm trying it in an integration test, and this is the debug output:

```
dataLayer[0].ecommerce.promoView.promotions handleData entry
[{"id":"1004-Blueberries123321","name":"Fruits","creative":"Blueberries123321","position":"Feature"}] 1.1.0.js:1:18535
dataLayer[0].ecommerce.promoView.promotions handleData exit
[] 1.1.0.js:1:18535
dataLayer[0].ecommerce.promoView.promotions handleData entry
[{"id":"1001-Strawberries222333","name":"Fruits","creative":"Strawberries222333","position":"Sub1"}] 1.1.0.js:1:18535
dataLayer[0].ecommerce.promoView.promotions handleData exit
[]
```

It doesn't seem like it executes the handler chain.  Here's the data layer 

```html
  <script>
    dataLayer = [
      {
        event: 'impressions_loaded',
        ecommerce: {
          promoView: {
            promotions: [
              {
                id: '1004-Blueberries123321',
                name: 'Fruits',
                creative: 'Blueberries123321',
                position: 'Feature',
              },
              {
                id: '1001-Strawberries222333',
                name: 'Fruits',
                creative: 'Strawberries222333',
                position: 'Sub1',
              },
            ]
          }
        },
        'gtm.uniqueEventId': 6
      },
    ];
  </script>
```

with the rule

```javascript
      {
        source: 'dataLayer[0].ecommerce.promoView.promotions',
        operators: [{ name: 'fan-out' }, { name: 'insert', value: 'Viewed Promotion' }],
        destination: 'FS.event',
        debug: true
      }
```

I'm doing something wrong I suppose.