### PR TITLE
WEL rule probe and separate test "site" 

### DIFF
--- a/examples/basic-embed/index.html
+++ b/examples/basic-embed/index.html
@@ -26,11 +26,7 @@
       /* This function will receive information as the DLO rules find it */
       function ruleDestination(info) {
         console.log('ruleDestination received:', info);
-        // We tuck the results into this array for easy debugging and testing
-        window._testRuleResults.push(info);
       }
-
-      window._testRuleResults = [];
     </script>
   </head>
   <body>

--- a/examples/basic-embed/index.html
+++ b/examples/basic-embed/index.html
@@ -26,7 +26,11 @@
       /* This function will receive information as the DLO rules find it */
       function ruleDestination(info) {
         console.log('ruleDestination received:', info);
+        // We tuck the results into this array for easy debugging and testing
+        window._testRuleResults.push(info);
       }
+
+      window._testRuleResults = [];
     </script>
   </head>
   <body>
@@ -42,7 +46,7 @@
 
       // Redirects output from a destination to previewDestination when testing rules
       // Default is false
-      window['_dlo_previewMode'] = true;
+      window['_dlo_previewMode'] = false;
 
       // The output destination using rule selection syntax for use with previewMode
       // Default is 'console.log'

--- a/test/web-embed-lab/auto-formulate.conf.json
+++ b/test/web-embed-lab/auto-formulate.conf.json
@@ -53,6 +53,9 @@
       "capture-name": "basic-embed",
       "formula-name": "basic-embed",
       "probe-basis": {
+        "dlo-rules": {
+          "count": 3
+        },
         "dom-shape": {
           "relative": {
             "depth": 0,

--- a/test/web-embed-lab/auto-formulate.conf.json
+++ b/test/web-embed-lab/auto-formulate.conf.json
@@ -12,15 +12,15 @@
       },
       "sites": [
         {
-          "name": "basic-embed",
-          "url": "https://dlowel.ngrok.io/examples/basic-embed/",
+          "name": "basics",
+          "url": "https://dlowel.ngrok.io/test/web-embed-lab/sites/basics/",
           "close-pause": 5,
           "modifiers": [
             {
               "mime-type-selectors": ["text/html"],
               "replacements": [
                 {
-                  "selector": "<script async=\"true\" src=\"../../build/dlo.js\">(?s:.*)</script>",
+                  "selector": "<script async=\"true\" src=\"../../../../build/dlo.js\">(?s:.*)</script>",
                   "replacement": "<!-- removed original script -->",
                   "all": true
                 }
@@ -50,11 +50,15 @@
   ],
   "formulations": [
     {
-      "capture-name": "basic-embed",
-      "formula-name": "basic-embed",
+      "capture-name": "basics",
+      "formula-name": "basics",
       "probe-basis": {
         "dlo-rules": {
-          "count": 3
+          "count": 3,
+          "parameters": [
+            [0, 0, "First"],
+            [2, 0, "Last"]
+          ]
         },
         "dom-shape": {
           "relative": {

--- a/test/web-embed-lab/auto-formulate.conf.json
+++ b/test/web-embed-lab/auto-formulate.conf.json
@@ -27,23 +27,6 @@
               ]
             }
           ]
-        },
-        {
-          "name": "ceddl-fs",
-          "url": "https://dlowel.ngrok.io/examples/ceddl-fs/",
-          "close-pause": 5,
-          "modifiers": [
-            {
-              "mime-type-selectors": ["text/html"],
-              "replacements": [
-                {
-                  "selector": "<script async=\"true\" src=\"../../build/dlo.js\">(?s:.*)</script>",
-                  "replacement": "<!-- removed original script -->",
-                  "all": true
-                }
-              ]
-            }
-          ]
         }
       ]
     }
@@ -70,23 +53,6 @@
           "relative": {
             "comment": "this is 1 because one of the rules is bogus",
             "count": 1
-          }
-        }
-      }
-    },
-    {
-      "capture-name": "ceddl-fs",
-      "formula-name": "ceddl-fs",
-      "probe-basis": {
-        "dom-shape": {
-          "relative": {
-            "depth": 0,
-            "width": 0
-          }
-        },
-        "exceptions": {
-          "relative": {
-            "count": 0
           }
         }
       }

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -1,8 +1,7 @@
 {
   "comment": "This experiment tests the example sites",
   "page-formulas": [
-    { "name": "basics" },
-    { "name": "ceddl-fs" }
+    { "name": "basics" }
   ],
   "browser-configurations": [
     {

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -17,8 +17,7 @@
   "test-runs": [
     {
       "page-formulas": [
-        "basics",
-        "ceddl-fs"
+        "basics"
       ],
       "test-probes": [
         "dlo-rules",

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -1,5 +1,5 @@
 {
-  "comment": "This experiment tests the sites of the largest users of FullStory",
+  "comment": "This experiment tests the example sites",
   "page-formulas": [
     { "name": "basic-embed" },
     { "name": "ceddl-fs" }
@@ -21,6 +21,7 @@
         "ceddl-fs"
       ],
       "test-probes": [
+        "dlo-rules",
         "dom-shape",
         "exceptions"
       ],

--- a/test/web-embed-lab/runner.conf.json
+++ b/test/web-embed-lab/runner.conf.json
@@ -1,7 +1,7 @@
 {
   "comment": "This experiment tests the example sites",
   "page-formulas": [
-    { "name": "basic-embed" },
+    { "name": "basics" },
     { "name": "ceddl-fs" }
   ],
   "browser-configurations": [
@@ -17,7 +17,7 @@
   "test-runs": [
     {
       "page-formulas": [
-        "basic-embed",
+        "basics",
         "ceddl-fs"
       ],
       "test-probes": [

--- a/test/web-embed-lab/sites/basics/index.html
+++ b/test/web-embed-lab/sites/basics/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Basic WEL DLO test</title>
+    <meta charset="utf-8" />
+    <script>
+      window._testRuleResults = []; // This will hold rule results for the test probe
+
+      window.exampleData = {
+        page: {
+          pageName: 'basic embed',
+          pageInfo: {
+            pageID: '1234'
+          }
+        }
+      }
+      window.adInformation = {
+        accountID: 'abcd'
+      }
+      window.ops = {
+        clusterInfo: {
+          id: '444-111-11231',
+          load: 0.4
+        }
+      }
+
+      /* This function will receive information as the DLO rules find it */
+      function ruleDestination(...info) {
+        console.log('ruleDestination received:', ...info);
+        // We tuck the results into this array for the DLO rules test probe
+        window._testRuleResults.push(info);
+      }
+    </script>
+  </head>
+  <body>
+    <h1>Basic WEL DLO test</h1>
+
+    <script>
+      window['_dlo_validateRules'] = true;
+      window['_dlo_readOnLoad'] = true;
+      window['_dlo_rules'] = [
+        {
+          source: 'exampleData.page',
+          operators: [
+            { name: 'flatten' },
+            { name: 'insert', value: 'First' }
+          ],
+          destination: 'ruleDestination'
+        },
+        {
+          source: 'adInformation',
+          operators: [],
+          destination: 'ruleDestination'
+        },
+        {
+          source: 'ops.clusterInfo',
+          operators: [
+            { name: 'insert', value: 'Last' }
+          ],
+          destination: 'ruleDestination'
+        },
+        /* The following rule has a bogus source */
+        {
+          source: 'exampleData.cart.cartInfo',
+          operators: [],
+          destination: 'ruleDestination'
+        }
+      ];
+    </script>
+    <script async="true" src="../../../../build/dlo.js"></script>
+  </body>
+</html>

--- a/test/web-embed-lab/test-probes/dlo-rules/test.js
+++ b/test/web-embed-lab/test-probes/dlo-rules/test.js
@@ -24,7 +24,7 @@ class DLORulesProbe {
     if(!basis) return { passed: true }
     const results = {
       passed: true,
-      results: window._testRuleResults || null, // List of rule results
+      results: window._testRuleResults, // List of rule results
       failures: []
     }
 
@@ -33,6 +33,22 @@ class DLORulesProbe {
       if (basis.count !== window._testRuleResults.length) {
         results.passed = false;
         results.failures.push('Count does not match results length');
+      }
+    }
+
+    if (Array.isArray(basis.parameters)) {
+      for (let i=0; i < basis.parameters.length; i += 1) {
+        const paramInfo = basis.parameters[i];
+        if (Array.isArray(paramInfo) && typeof paramInfo[0] === 'number' && typeof paramInfo[1] === 'number') {
+          if (results.results[paramInfo[0]][paramInfo[1]] != paramInfo[2]) {
+            results.passed = false;
+            results.failures.push('Parameter mismatch:', paramInfo);
+          }
+        } else {
+          console.error('The parameters array must contain arrays like [result index, parameter index, value]');
+          results.passed = false;
+          results.failures.push('The parameters array must contain arrays like [index, value]')
+        }
       }
     }
 

--- a/test/web-embed-lab/test-probes/dlo-rules/test.js
+++ b/test/web-embed-lab/test-probes/dlo-rules/test.js
@@ -1,0 +1,43 @@
+/**
+DLORulesProbe tests that a well known array contains expected rule results
+*/
+class DLORulesProbe {
+  /**
+  @return {Object} data collected when the target embed script *is not* loaded
+  @return {Object.success} always true
+  */
+  async gatherBaselineData(){
+    console.log('DLO rules baseline')
+    if (Array.isArray(window._testRuleResults) === false) {
+      console.error('No window._testRuleResults in the page');
+      return { success: false };
+    }
+
+    return { success: window._testRuleResults.length === 0 };
+  }
+
+  /**
+  @return {object} the results of the probe
+  */
+  async probe(basis, baseline){
+    console.log('Probing DLO rules ' + (basis ? 'with' : 'without') + ' basis');
+    if(!basis) return { passed: true }
+    const results = {
+      passed: true,
+      results: window._testRuleResults || null, // List of rule results
+      failures: []
+    }
+
+    if (typeof basis.count === 'number') {
+      console.log('Testing DLO rule result count: ' + basis.count + ': ' + window._testRuleResults.length);
+      if (basis.count !== window._testRuleResults.length) {
+        results.passed = false;
+        results.failures.push('Count does not match results length');
+      }
+    }
+
+    return results
+  }
+}
+
+window.__welProbes['dlo-rules'] = new DLORulesProbe()


### PR DESCRIPTION
I created a [WEL test probe](https://github.com/fullstorydev/web-embed-lab/blob/master/docs/TEST_PROBE_API.md) and a testing page that work together to ensure that the rules ran, that the right number of results were created, and that the results have expected parameters.

In the future we can flesh this out to test the intricacies of each operator but this satisfies the task which is to make sure that the DLO successfully evaluates rules.