### PR TITLE
Magical unshift

### DIFF
--- a/examples/basic-embed/index.html
+++ b/examples/basic-embed/index.html
@@ -11,7 +11,8 @@
           pageInfo: {
             pageID: '1234'
           }
-        }
+        },
+        list: [1, 2, 3, 4, 5]
       }
       window.adInformation = {
         accountID: 'abcd'
@@ -24,8 +25,8 @@
       }
 
       /* This function will receive information as the DLO rules find it */
-      function ruleDestination(info) {
-        console.log('ruleDestination received:', info);
+      function ruleDestination(...info) {
+        console.log('ruleDestination received:', ...info);
       }
     </script>
   </head>
@@ -64,7 +65,14 @@
       window['_dlo_rules'] = [
         { source: 'exampleData.page.pageInfo', operators: [], destination: 'ruleDestination' },
         /* The following rule has a bogus source so an error will appear in the console */
-        { source: 'exampleData.cart.cartInfo', operators: [], destination: 'ruleDestination' }
+        { source: 'exampleData.cart.cartInfo', operators: [], destination: 'ruleDestination' },
+        { source:
+          'exampleData.list',
+          operators: [
+            { name: 'insert', value: 'First parameter' }
+          ],
+          destination: 'ruleDestination'
+        }
       ];
       window['_dlo_rulesFromAdTeam'] = [
         { source: 'adInformation', operators: [], destination: 'ruleDestination' }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -17,7 +17,7 @@ export default abstract class Monitor {
     if (!object) {
       throw new Error('Monitor could not find target');
     } else {
-      if (path.endsWith(property)) {
+      if (path.endsWith(property) && typeof object[property] !== 'function') {
         // this could be an error or just a poorly structured data layer object
         Logger.getInstance().warn(`Monitor path appears to include property ${property}`, path);
       }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -219,13 +219,14 @@ export class DataLayerObserver {
   registerTarget(target: DataLayerTarget, options: OperatorOptions[], destination: string | Function,
     read = false, monitor = true, debug = false): DataHandler {
     const targetValue = target.value;
-
     /*
     We do a bit of magic when monitor is set and the target is an Array.
     We convert the target to the `push` method and then monitor it below.
     */
+    let shouldShimUnshift = false;
     if (monitor && Array.isArray(targetValue)) {
       target.convertToPropertyMethod('push');
+      shouldShimUnshift = true;
     }
 
     const handler = this.addHandler(target, !!debug);
@@ -258,6 +259,18 @@ export class DataLayerObserver {
       } catch (err) {
         Logger.getInstance().warn('Monitor creation failed');
       }
+    }
+
+    if (shouldShimUnshift) {
+      const unshiftTarget = target.copyToDifferentPropertyMethod('unshift');
+      this.registerTarget(
+        unshiftTarget,
+        options,
+        destination,
+        read,
+        monitor,
+        debug,
+      );
     }
 
     return handler;

--- a/src/target.ts
+++ b/src/target.ts
@@ -85,11 +85,23 @@ export default class DataLayerTarget {
     if (this.type !== 'object') {
       throw new Error('Can only convert targets of type object to a property method target');
     }
-    this.subject = this.value;
-    // this.path stays as-is because we're setting a new property
+    this.subject = (this.subject as any)[this.property];
     this.property = methodName;
-    this.selector = this.selector ? this.subjectPath : '';
+    this.selector = this.path;
+    this.path = `${this.path}.${methodName}`;
     this.type = 'function';
+  }
+
+  /**
+   * Creates a new DataLayerTarget from a function type target but with a new method name
+   * This is mainly used by the observer to add `unshift` monitoring to an array target
+   */
+  copyToDifferentPropertyMethod(methodName: string) {
+    if (this.type !== 'function') {
+      throw new Error('Can only copy targets of type function to a new property method target');
+    }
+    const path = `${this.path.substring(0, this.path.lastIndexOf('.'))}.${methodName}`;
+    return new DataLayerTarget(this.subject, methodName, path, this.selector);
   }
 
   /**

--- a/src/target.ts
+++ b/src/target.ts
@@ -78,33 +78,6 @@ export default class DataLayerTarget {
   }
 
   /**
-   * Converts an Object instance to one that targets a method of the current target
-   * This is mainly used by the observer to convert from targeting an array to targeting array.push
-   */
-  convertToPropertyMethod(methodName: string) {
-    if (this.type !== 'object') {
-      throw new Error('Can only convert targets of type object to a property method target');
-    }
-    this.subject = (this.subject as any)[this.property];
-    this.property = methodName;
-    this.selector = this.path;
-    this.path = `${this.path}.${methodName}`;
-    this.type = 'function';
-  }
-
-  /**
-   * Creates a new DataLayerTarget from a function type target but with a new method name
-   * This is mainly used by the observer to add `unshift` monitoring to an array target
-   */
-  copyToDifferentPropertyMethod(methodName: string) {
-    if (this.type !== 'function') {
-      throw new Error('Can only copy targets of type function to a new property method target');
-    }
-    const path = `${this.path.substring(0, this.path.lastIndexOf('.'))}.${methodName}`;
-    return new DataLayerTarget(this.subject, methodName, path, this.selector);
-  }
-
-  /**
    * Finds a target in the data layer and constructs a DataLayerTarget.
    * @param selector used to build the target
    */

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -104,7 +104,8 @@ export class ExpectObserver {
     expect(observer).to.not.be.null;
 
     if (expectHandlers) {
-      expect(observer.handlers.length).to.eq(config.rules.length);
+      // We can end up with multiple rules for a single array target
+      expect(observer.handlers.length >= config.rules.length);
     }
 
     this.observers.push(observer);


### PR DESCRIPTION
Make the magical monitoring of arrays include `unshift` in addition to `push`.

This is the first time that a single input rule can result in multiple running rules. Instead of converting a rule that watches an array into a rule that watches that array's `push` we now do that and *in addition* add a rule to watch `unshift`.