### PR TITLE
Add Google Tag eCommerce rules

### DIFF
--- a/examples/google-tags-fs/index.html
+++ b/examples/google-tags-fs/index.html
@@ -1,97 +1,191 @@
 <!DOCTYPE html>
-<html lang='en'>
+<html lang="en">
   <head>
     <title>Data Layer Observer Example: Google Tags</title>
-    <meta charset='utf-8' />
+    <meta charset="utf-8" />
     <script>
       window.dataLayer = [
         {
-          'pageType': 'Home',
-          'pageName': 'Home: Fruit shoppe'
+          "pageType": "Home",
+          "pageName": "Home: Fruit shoppe"
         },
         {
-          'gtm.start': 1598892794094,
-          'event': 'gtm.js',
-          'gtm.uniqueEventId': 1
+          "gtm.start": 1598892794094,
+          "event": "gtm.js",
+          "gtm.uniqueEventId": 1
         },
         {
-          'userProfile': {
-            'userId': '101',
-            'userType': 'member',
-            'loyaltyProgram': 'early-adopter',
-            'hashedEmail': '555-12232-2332232-232332'
+          "userProfile": {
+            "userId": "101",
+            "userType": "member",
+            "loyaltyProgram": "early-adopter",
+            "hashedEmail": "555-12232-2332232-232332"
           }
         },
         {
-          'event': 'impressions_loaded',
-          'ecommerce': {
-            'promoView': {
-              'promotions': [
+          "ecommerce": {
+            "impressions": [
+              {
+                "name": "Heritage Huckleberries",
+                "id": "P000525722",
+                "price": "2.99",
+                "category": "homepage product recs",
+                "variant": "",
+                "list": "homepage product recs",
+                "position": 1,
+                "dimension3": 4.7
+              },
+              {
+                "name": "Classic Corn",
+                "id": "P000614444",
+                "price": "4.00",
+                "category": "homepage product recs",
+                "variant": "",
+                "list": "homepage product recs",
+                "position": 2,
+                "dimension3": 5
+              },
+            ]
+          },
+          "gtm.uniqueEventId": 28
+        },
+        {
+          "event": "productClick",
+          "ecommerce": {
+            "click": {
+              "actionField": {"list": "Search Results"},
+              "products": [
                 {
-                  'id': '1004-Blueberries123321',
-                  'name': 'Fruits',
-                  'creative': 'Blueberries123321',
-                  'position': 'Feature'
-                },
-                {
-                  'id': '1001-Strawberries222333',
-                  'name': 'Fruits',
-                  'creative': 'Strawberries222333',
-                  'position': 'Sub1'
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "homepage product recs",
+                  "variant": "",
+                  "position": 1
                 }
               ]
             }
           },
-          'gtm.uniqueEventId': 6
+          "eventCallback": function() {
+            console.log("Callback called");
+          }
         },
         {
-          'event': 'gtm.dom',
-          'gtm.uniqueEventId': 12
+          "ecommerce": {
+            "detail": {
+              "actionField": {"list": "Product Gallery"},
+              "products": [
+                {
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "product gallery",
+                  "variant": ""
+                }
+              ]
+            }
+          }
         },
         {
-          'event': 'Social-media Loaded',
-          'gtm.uniqueEventId': 27
+          "event": "addToCart",
+          "ecommerce": {
+            "currencyCode": "USD",
+            "add": {
+              "products": [
+                {
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "product",
+                  "variant": "",
+                  "quantity": 2
+                }
+              ]
+            }
+          }
         },
         {
-          'event': 'recs loaded',
-          'ecommerce': {
-            'impressions': [
-              {
-                'name': 'Heritage Huckleberries',
-                'id': 'P000525722',
-                'price': '2.99',
-                'category': 'homepage product recs',
-                'variant': '',
-                'list': 'homepage product recs',
-                'position': 1,
-                'dimension3': 4.7
-              },
-              {
-                'name': 'Classic Corn',
-                'id': 'P000614444',
-                'price': '4.00',
-                'category': 'homepage product recs',
-                'variant': '',
-                'list': 'homepage product recs',
-                'position': 2,
-                'dimension3': 5
-              },
-            ]
+          "event": "removeFromCart",
+          "ecommerce": {
+            "currencyCode": "USD",
+            "remove": {
+              "products": [
+                {
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "product",
+                  "variant": "",
+                  "quantity": 1
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ecommerce": {
+            "promoView": {
+              "promotions": [
+                {
+                  "id": "1004-Blueberries123321",
+                  "name": "Fruits",
+                  "creative": "Blueberries123321",
+                  "position": "Feature"
+                },
+                {
+                  "id": "1001-Strawberries222333",
+                  "name": "Fruits",
+                  "creative": "Strawberries222333",
+                  "position": "Sub1"
+                }
+              ]
+            }
           },
-          'gtm.uniqueEventId': 28
+          "gtm.uniqueEventId": 6
         },
         {
-          'event': 'gtm.load',
-          'gtm.uniqueEventId': 42
+          "event": "promotionClick",
+          "ecommerce": {
+            "promoClick": {
+              "promotions": [
+                {
+                  "id": "1004-Blueberries123321",
+                  "name": "Fruits",
+                  "creative": "Blueberries123321",
+                  "position": "Feature"
+                }
+              ]
+            }
+          },
+          "eventCallback": function() {
+            console.log("Callback called");
+          },
+          "gtm.uniqueEventId": 6
         },
         {
-          'event': 'gtm.click',
-          'gtm.element': {},
-          'gtm.elementClasses': 'x-icon',
-          'gtm.elementId': '',
-          'gtm.elementTarget': '',
-          'gtm.elementUrl': '',
-          'gtm.uniqueEventId': 45
+          "event": "gtm.dom",
+          "gtm.uniqueEventId": 12
+        },
+        {
+          "event": "Social-media Loaded",
+          "gtm.uniqueEventId": 27
+        },
+        {
+          "event": "gtm.load",
+          "gtm.uniqueEventId": 42
+        },
+        {
+          "event": "gtm.click",
+          "gtm.element": {},
+          "gtm.elementClasses": "x-icon",
+          "gtm.elementId": "",
+          "gtm.elementTarget": "",
+          "gtm.elementUrl": "",
+          "gtm.uniqueEventId": 45
         }
       ];
     </script>
@@ -108,12 +202,12 @@
 
     <script>
       /*
-        Look at the 'basic-embed' example for more configuration options
+        Look at the "basic-embed" example for more configuration options
       */
-      window['_dlo_previewMode'] = true;
-      window['_dlo_validateRules'] = true;
+      window["_dlo_previewMode"] = true;
+      window["_dlo_validateRules"] = true;
 
-      window['_dlo_rules'] = [
+      window["_dlo_rules"] = [
     {
       "id": "fs-ga-page-type",
       "source": "dataLayer",
@@ -131,19 +225,84 @@
       "operators": [
         { "name": "query", "select": "$.ecommerce.impressions" },
         { "name": "fan-out" },
-        { "name": "insert", "value": "Commerce impressions" }
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce impression" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
       "monitor": true
     },
     {
-      "id": "fs-ga-e-commerce-promotions",
+      "id": "fs-ga-e-commerce-product-detail",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.detail.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce product detail" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-product-click",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.click.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce product click" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-cart-add",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.add.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce cart add" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-cart-remove",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.remove.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce cart remove" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotion-impressions",
       "source": "dataLayer",
       "operators": [
         { "name": "query", "select": "$.ecommerce.promoView.promotions" },
         { "name": "fan-out" },
-        { "name": "insert", "value": "Commerce promotions" }
+        { "name": "insert", "value": "Commerce promotion impression" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotion-clicks",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.promoClick.promotions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce promotion click" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
@@ -164,6 +323,6 @@
     }
       ];
     </script>
-    <script async='true' src='../../build/dlo.js'></script>
+    <script async="true" src="../../build/dlo.js"></script>
   </body>
 </html>

--- a/examples/google-tags-fs/index.html
+++ b/examples/google-tags-fs/index.html
@@ -167,6 +167,72 @@
           "gtm.uniqueEventId": 6
         },
         {
+          "event": "checkout",
+          "ecommerce": {
+            "checkout": {
+              "actionField": {
+                "step": 1,
+                "option": "Visa"
+              },
+              "products": [
+                {
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "fruit",
+                  "variant": "",
+                  "quantity": 1
+                }
+              ]
+            }
+          },
+          "eventCallback": function() {
+            console.log("Callback called");
+          }
+        },
+        {
+          "ecommerce": {
+            "purchase": {
+              "actionField": {
+                "id": "T12345",
+                "affiliation": "Online Store",
+                "revenue": "35.43",
+                "tax":"4.90",
+                "shipping": "5.99",
+                "coupon": ""
+              },
+              "products": [
+                {
+                  "name": "Heritage Huckleberries",
+                  "id": "P000525722",
+                  "price": "2.99",
+                  "brand": "Heritage",
+                  "category": "fruit",
+                  "variant": "",
+                  "quantity": 1,
+                  "coupon": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ecommerce": {
+            "refund": {
+              "actionField": {
+                "id": "T12345"
+              },
+              "products": [
+                {
+                  "id": "P000525722",
+                  "quantity": 1
+                }
+              ]
+            }
+          }
+        },
+        {
           "event": "gtm.dom",
           "gtm.uniqueEventId": 12
         },
@@ -303,6 +369,40 @@
         { "name": "query", "select": "$.ecommerce.promoClick.promotions" },
         { "name": "fan-out" },
         { "name": "insert", "value": "Commerce promotion click" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-checkout",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.checkout.actionField" },
+        { "name": "insert", "value": "Commerce checkout" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-purchase",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.purchase.actionField" },
+        { "name": "convert", "properties": "revenue,tax,shipping", "type": "real" },
+        { "name": "insert", "value": "Commerce purchase" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-refund",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.refund.actionField" },
+        { "name": "insert", "value": "Commerce refund" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -101,6 +101,40 @@
       "monitor": true
     },
     {
+      "id": "fs-ga-e-commerce-checkout",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.checkout.actionField" },
+        { "name": "insert", "value": "Commerce checkout" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-purchase",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.purchase.actionField" },
+        { "name": "convert", "properties": "revenue,tax,shipping", "type": "real" },
+        { "name": "insert", "value": "Commerce purchase" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-refund",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.refund.actionField" },
+        { "name": "insert", "value": "Commerce refund" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
       "id": "fs-ga-user-vars",
       "source": "dataLayer",
       "operators": [

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -4,14 +4,8 @@
       "id": "fs-ga-page-type",
       "source": "dataLayer",
       "operators": [
-        {
-          "name": "query",
-          "select": "$[?(pageType, pageName)]"
-        },
-        {
-          "name": "insert",
-          "value": "View Page Type"
-        }
+        { "name": "query", "select": "$[?(pageType, pageName)]" },
+        { "name": "insert", "value": "View Page Type" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
@@ -21,37 +15,86 @@
       "id": "fs-ga-e-commerce-impressions",
       "source": "dataLayer",
       "operators": [
-        {
-          "name": "query",
-          "select": "$.ecommerce.impressions"
-        },
-        {
-          "name": "fan-out"
-        },
-        {
-          "name": "insert",
-          "value": "Commerce impression"
-        }
+        { "name": "query", "select": "$.ecommerce.impressions" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce impression" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
       "monitor": true
     },
     {
-      "id": "fs-ga-e-commerce-promotions",
+      "id": "fs-ga-e-commerce-product-detail",
       "source": "dataLayer",
       "operators": [
-        {
-          "name": "query",
-          "select": "$.ecommerce.promoView.promotions"
-        },
-        {
-          "name": "fan-out"
-        },
-        {
-          "name": "insert",
-          "value": "Commerce promotion"
-        }
+        { "name": "query", "select": "$.ecommerce.detail.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce product detail" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-product-click",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.click.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce product click" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-cart-add",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.add.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce cart add" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-cart-remove",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.remove.products" },
+        { "name": "fan-out" },
+        { "name": "convert", "properties": "price", "type": "real" },
+        { "name": "insert", "value": "Commerce cart remove" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotion-impressions",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.promoView.promotions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce promotion impression" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
+      "id": "fs-ga-e-commerce-promotion-clicks",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$.ecommerce.promoClick.promotions" },
+        { "name": "fan-out" },
+        { "name": "insert", "value": "Commerce promotion click" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,
@@ -61,21 +104,10 @@
       "id": "fs-ga-user-vars",
       "source": "dataLayer",
       "operators": [
-        {
-          "name": "query",
-          "select": "$[?(userProfile)]"
-        },
-        {
-          "name": "flatten"
-        },
-        {
-          "name": "query",
-          "select": "$[?(userId!=-1)]"
-        },
-        {
-          "name": "insert",
-          "select": "userId"
-        }
+        { "name": "query", "select": "$[?(userProfile)]" },
+        { "name": "flatten"},
+        { "name": "query", "select": "$[?(userId!=-1)]" },
+        { "name": "insert", "select": "userId" }
       ],
       "destination": "FS.setUserVars",
       "readOnLoad": true,

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -105,6 +105,90 @@ describe('Google Tags to FullStory rules', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
+  it('should read commerce product detail', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-product-detail'),
+      ],
+    });
+
+    const [id2, payload2] = expectParams(globalMock.FS, 'event');
+    expect(id2).to.eq('Commerce product detail');
+    expect(payload2.id).to.eq('P000525722');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce product click', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-product-click'),
+      ],
+    });
+
+    const [id2, payload2] = expectParams(globalMock.FS, 'event');
+    expect(id2).to.eq('Commerce product click');
+    expect(payload2.id).to.eq('P000525722');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce cart add', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-cart-add'),
+      ],
+    });
+
+    const [id2, payload2] = expectParams(globalMock.FS, 'event');
+    expect(id2).to.eq('Commerce cart add');
+    expect(payload2.id).to.eq('P000525722');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce cart remove', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-cart-remove'),
+      ],
+    });
+
+    const [id2, payload2] = expectParams(globalMock.FS, 'event');
+    expect(id2).to.eq('Commerce cart remove');
+    expect(payload2.id).to.eq('P000525722');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce promotion impressions', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-promotion-impressions'),
+      ],
+    });
+    expect(observer).to.not.be.undefined;
+    const [id, payload] = expectParams(globalMock.FS, 'event');
+    expect(id).to.eq('Commerce promotion impression');
+    expect(payload.id).to.eq('1001-Strawberries222333');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce promotion clicks', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-promotion-clicks'),
+      ],
+    });
+    expect(observer).to.not.be.undefined;
+    const [id, payload] = expectParams(globalMock.FS, 'event');
+    expect(id).to.eq('Commerce promotion click');
+    expect(payload.id).to.eq('1004-Blueberries123321');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
   it('should set the user', () => {
     const observer = ExpectObserver.getInstance().create({
       rules: [
@@ -127,37 +211,6 @@ describe('Google Tags to FullStory rules', () => {
     const [id2, payload2] = expectParams(globalMock.FS, 'setUserVars');
     expect(id2).to.eq('201');
     expect(payload2.userType).to.eq('admin');
-
-    ExpectObserver.getInstance().cleanup(observer);
-  });
-
-  it('should read commerce promotions', () => {
-    const observer = ExpectObserver.getInstance().create({
-      rules: [
-        getRule('fs-ga-e-commerce-promotions'),
-      ],
-    });
-    expect(observer).to.not.be.undefined;
-    const [id, payload] = expectParams(globalMock.FS, 'event');
-    expect(id).to.eq('Commerce promotion');
-    expect(payload.id).to.eq('1001-Strawberries222333');
-
-    (globalThis as any).dataLayer.push({
-      event: 'impressions_loaded',
-      ecommerce: {
-        promoView: {
-          promotions: [
-            {
-              id: 'test',
-              name: 'Test',
-            },
-          ],
-        },
-      },
-    });
-    const [id2, payload2] = expectParams(globalMock.FS, 'event');
-    expect(id2).to.eq('Commerce promotion');
-    expect(payload2.id).to.eq('test');
 
     ExpectObserver.getInstance().cleanup(observer);
   });

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -189,6 +189,48 @@ describe('Google Tags to FullStory rules', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
+  it('should read purchases', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-purchase'),
+      ],
+    });
+    expect(observer).to.not.be.undefined;
+    const [id, payload] = expectParams(globalMock.FS, 'event');
+    expect(id).to.eq('Commerce purchase');
+    expect(payload.shipping).to.eq(5.99);
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce checkout', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-checkout'),
+      ],
+    });
+    expect(observer).to.not.be.undefined;
+    const [id, payload] = expectParams(globalMock.FS, 'event');
+    expect(id).to.eq('Commerce checkout');
+    expect(payload.step).to.eq(1);
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('should read commerce refund', () => {
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        getRule('fs-ga-e-commerce-refund'),
+      ],
+    });
+    expect(observer).to.not.be.undefined;
+    const [id, payload] = expectParams(globalMock.FS, 'event');
+    expect(id).to.eq('Commerce refund');
+    expect(payload.id).to.eq('T12345');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
   it('should set the user', () => {
     const observer = ExpectObserver.getInstance().create({
       rules: [

--- a/test/mocks/google-tags.ts
+++ b/test/mocks/google-tags.ts
@@ -162,6 +162,72 @@ export const basicGoogleTags = [
     'gtm.uniqueEventId': 6,
   },
   {
+    event: 'checkout',
+    ecommerce: {
+      checkout: {
+        actionField: {
+          step: 1,
+          option: 'Visa',
+        },
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'fruit',
+            variant: '',
+            quantity: 1,
+          },
+        ],
+      },
+    },
+    eventCallback() {
+      console.log('Callback called');
+    },
+  },
+  {
+    ecommerce: {
+      purchase: {
+        actionField: {
+          id: 'T12345',
+          affiliation: 'Online Store',
+          revenue: '35.43',
+          tax: '4.90',
+          shipping: '5.99',
+          coupon: '',
+        },
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'fruit',
+            variant: '',
+            quantity: 1,
+            coupon: '',
+          },
+        ],
+      },
+    },
+  },
+  {
+    ecommerce: {
+      refund: {
+        actionField: {
+          id: 'T12345',
+        },
+        products: [
+          {
+            id: 'P000525722',
+            quantity: 1,
+          },
+        ],
+      },
+    },
+  },
+  {
     event: 'gtm.dom',
     'gtm.uniqueEventId': 12,
   },

--- a/test/mocks/google-tags.ts
+++ b/test/mocks/google-tags.ts
@@ -18,37 +18,6 @@ export const basicGoogleTags = [
     },
   },
   {
-    event: 'impressions_loaded',
-    ecommerce: {
-      promoView: {
-        promotions: [
-          {
-            id: '1004-Blueberries123321',
-            name: 'Fruits',
-            creative: 'Blueberries123321',
-            position: 'Feature',
-          },
-          {
-            id: '1001-Strawberries222333',
-            name: 'Fruits',
-            creative: 'Strawberries222333',
-            position: 'Sub1',
-          },
-        ],
-      },
-    },
-    'gtm.uniqueEventId': 6,
-  },
-  {
-    event: 'gtm.dom',
-    'gtm.uniqueEventId': 12,
-  },
-  {
-    event: 'Social-media Loaded',
-    'gtm.uniqueEventId': 27,
-  },
-  {
-    event: 'recs loaded',
     ecommerce: {
       impressions: [
         {
@@ -74,6 +43,131 @@ export const basicGoogleTags = [
       ],
     },
     'gtm.uniqueEventId': 28,
+  },
+  {
+    event: 'productClick',
+    ecommerce: {
+      click: {
+        actionField: { list: 'Search Results' },
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'homepage product recs',
+            variant: '',
+            position: 1,
+          },
+        ],
+      },
+    },
+    eventCallback() {
+      console.log('Callback called');
+    },
+  },
+  {
+    ecommerce: {
+      detail: {
+        actionField: { list: 'Product Gallery' },
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'product gallery',
+            variant: '',
+          },
+        ],
+      },
+    },
+  },
+  {
+    event: 'addToCart',
+    ecommerce: {
+      currencyCode: 'USD',
+      add: {
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'product',
+            variant: '',
+            quantity: 2,
+          },
+        ],
+      },
+    },
+  },
+  {
+    event: 'removeFromCart',
+    ecommerce: {
+      currencyCode: 'USD',
+      remove: {
+        products: [
+          {
+            name: 'Heritage Huckleberries',
+            id: 'P000525722',
+            price: '2.99',
+            brand: 'Heritage',
+            category: 'product',
+            variant: '',
+            quantity: 1,
+          },
+        ],
+      },
+    },
+  },
+  {
+    ecommerce: {
+      promoView: {
+        promotions: [
+          {
+            id: '1004-Blueberries123321',
+            name: 'Fruits',
+            creative: 'Blueberries123321',
+            position: 'Feature',
+          },
+          {
+            id: '1001-Strawberries222333',
+            name: 'Fruits',
+            creative: 'Strawberries222333',
+            position: 'Sub1',
+          },
+        ],
+      },
+    },
+    'gtm.uniqueEventId': 6,
+  },
+  {
+    event: 'promotionClick',
+    ecommerce: {
+      promoClick: {
+        promotions: [
+          {
+            id: '1004-Blueberries123321',
+            name: 'Fruits',
+            creative: 'Blueberries123321',
+            position: 'Feature',
+          },
+        ],
+      },
+    },
+    eventCallback() {
+      console.log('Callback called');
+    },
+    'gtm.uniqueEventId': 6,
+  },
+  {
+    event: 'gtm.dom',
+    'gtm.uniqueEventId': 12,
+  },
+  {
+    event: 'Social-media Loaded',
+    'gtm.uniqueEventId': 27,
   },
   {
     event: 'gtm.load',


### PR DESCRIPTION
Added rules (with example page and tests) that hand the [Google Tag eCommerce](https://developers.google.com/tag-manager/enhanced-ecommerce) data layer objects to Fullstory.