### PR TITLE
Add CEDDL Event Rule and Insert defaultValue

### DIFF
--- a/docs/operator_insert.md
+++ b/docs/operator_insert.md
@@ -15,6 +15,7 @@ Options with an asterisk are required.
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
+| `defaultValue`  | `any` | `undefined` | The value used if `select` fails to find a value. |
 | `index`  | `number` | `0` | Index of the object from the operator input list to apply `select` on. |
 | `position` | `number` | `0` | Where to insert in the output list, negative position will insert from the end. |
 | `select`* | `string` |  `undefined` | Value inserted, which is found using selector syntax. |

--- a/examples/rules/ceddl-fullstory.json
+++ b/examples/rules/ceddl-fullstory.json
@@ -97,6 +97,22 @@
       "destination": "FS.event"
     },
     {
+      "id": "fs-event-ceddl-event",
+      "description": "send CEDDL event to FS.event",
+      "source": "digitalData.event",
+      "operators": [
+        {
+          "name": "flatten"
+        },
+
+        {
+          "name": "insert",
+          "value": "event"
+        }
+      ],
+      "destination": "FS.event"
+    },
+    {
       "id": "fs-uservars-ceddl-user-all",
       "description": "send all CEDDL user properties to FS.setUserVars",
       "source": "digitalData.user.profile[0]",

--- a/examples/rules/ceddl-fullstory.json
+++ b/examples/rules/ceddl-fullstory.json
@@ -107,7 +107,8 @@
 
         {
           "name": "insert",
-          "value": "event"
+          "select": "eventName",
+          "defaultValue": "event"
         }
       ],
       "destination": "FS.event"

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -2,6 +2,7 @@ import { Operator, OperatorOptions, OperatorValidator } from '../operator';
 import { select } from '../selector';
 
 export interface InsertOperatorOptions extends OperatorOptions {
+  defaultValue?: boolean | string | number | object; // a default value if the select fails
   select?: string; // a value found using selection syntax
   value?: boolean | string | number | object; // a given value to insert
   position?: number; // the location where the value will be inserted
@@ -26,6 +27,7 @@ export class InsertOperator implements Operator {
   }
 
   static specification = {
+    defaultValue: { required: false, type: ['boolean,string,number,object'] },
     index: { required: false, type: ['number'] },
     select: { required: false, type: ['string'] },
     value: { required: false, type: ['boolean,string,number,object'] },
@@ -33,13 +35,22 @@ export class InsertOperator implements Operator {
   };
 
   handleData(data: any[]): any[] | null {
-    const { select: selection, value } = this.options;
+    const { defaultValue, select: selection, value } = this.options;
 
     if (selection && value !== undefined) {
-      throw new Error('function operator has both \'select\' and \'value\' options set');
+      throw new Error('insert operator has both \'select\' and \'value\' options set');
     }
 
-    const insertedValue = value || select(selection!, data[this.index]);
+    let insertedValue = value || select(selection!, data[this.index]);
+
+    if (insertedValue === undefined && defaultValue) {
+      insertedValue = defaultValue;
+    }
+
+    // if it's still undefined, don't proceed with the operator chain
+    if (insertedValue === undefined) {
+      throw new Error('insert operator failed to find a value to insert');
+    }
 
     const clone = data.slice();
     clone.splice(this.position >= 0 ? this.position : clone.length - this.position, 0, insertedValue);

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -43,7 +43,7 @@ export class InsertOperator implements Operator {
 
     let insertedValue = value || select(selection!, data[this.index]);
 
-    if (insertedValue === undefined && defaultValue) {
+    if (insertedValue === undefined && defaultValue !== undefined) {
       insertedValue = defaultValue;
     }
 

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -461,7 +461,7 @@ describe('CEDDL to FullStory rules', () => {
     expect(observer).to.not.be.undefined;
 
     let [eventName, payload] = expectParams(globalMock.FS, 'event');
-    expect(eventName).to.eq('event');
+    expect(eventName).to.eq('event'); // NOTE this tests non-compliant data layers that do not defined eventName
     expect(payload.eventAction).to.eq('cart-item-removed');
     expect(payload.primaryCategory).to.eq('cart');
 

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -466,7 +466,7 @@ describe('CEDDL to FullStory rules', () => {
     expect(payload.primaryCategory).to.eq('cart');
 
     [eventName, payload] = expectParams(globalMock.FS, 'event');
-    expect(eventName).to.eq('event');
+    expect(eventName).to.eq('Cart Item Added');
     expect(payload.eventAction).to.eq('cart-item-added');
     expect(payload.primaryCategory).to.eq('cart');
   });

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -452,6 +452,24 @@ describe('CEDDL to FullStory rules', () => {
     expect(payload.priceWithTax).to.eq(priceWithTax);
     expect(payload.transactionTotal).to.eq(transactionTotal);
   });
+
+  it('it should send CEDDL event to FS.event', () => {
+    const observer = new DataLayerObserver({
+      rules: [getRule('fs-event-ceddl-event')],
+      readOnLoad: true,
+    });
+    expect(observer).to.not.be.undefined;
+
+    let [eventName, payload] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('event');
+    expect(payload.eventAction).to.eq('cart-item-removed');
+    expect(payload.primaryCategory).to.eq('cart');
+
+    [eventName, payload] = expectParams(globalMock.FS, 'event');
+    expect(eventName).to.eq('event');
+    expect(payload.eventAction).to.eq('cart-item-added');
+    expect(payload.primaryCategory).to.eq('cart');
+  });
 });
 
 describe('Adobe to FullStory rules', () => {

--- a/test/mocks/CEDDL.ts
+++ b/test/mocks/CEDDL.ts
@@ -516,8 +516,8 @@ export const basicDigitalData: CEDDL = {
     },
   },
   {
+    // @ts-ignore NOTE this has no eventName to test non-compliant implementations
     eventInfo: {
-      eventName: 'Cart Item Removed',
       eventAction: 'cart-item-removed',
       eventPoints: 11,
       type: 'cart-modifier',

--- a/test/mocks/CEDDL.ts
+++ b/test/mocks/CEDDL.ts
@@ -514,6 +514,20 @@ export const basicDigitalData: CEDDL = {
       primaryCategory: 'cart',
       attributes: {},
     },
+  },
+  {
+    eventInfo: {
+      eventName: 'Cart Item Removed',
+      eventAction: 'cart-item-removed',
+      eventPoints: 11,
+      type: 'cart-modifier',
+      timeStamp: new Date(),
+      effect: 'cart has removed an item',
+    },
+    category: {
+      primaryCategory: 'cart',
+      attributes: {},
+    },
   }],
   component: [{
     componentInfo: {

--- a/test/operator-insert.spec.ts
+++ b/test/operator-insert.spec.ts
@@ -69,10 +69,28 @@ describe('insert operator unit tests', () => {
 
   it('it should insert using defaultValue if selection syntax fails', () => {
     const data: any[] = [{ foo: 'foo', bar: [{ baz: 'baz' }] }];
-    const operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: 'default' });
+    let operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: 'default' });
 
-    const [baz, obj] = operator.handleData(data)!;
+    let [baz, obj] = operator.handleData(data)!;
     expect(baz).to.eq('default');
+    expect(obj).to.eq(data[0]);
+
+    operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: false });
+
+    [baz, obj] = operator.handleData(data)!;
+    expect(baz).to.eq(false);
+    expect(obj).to.eq(data[0]);
+
+    operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: 1 });
+
+    [baz, obj] = operator.handleData(data)!;
+    expect(baz).to.eq(1);
+    expect(obj).to.eq(data[0]);
+
+    operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: { options: true } });
+
+    [baz, obj] = operator.handleData(data)!;
+    expect(baz).to.eql({ options: true });
     expect(obj).to.eq(data[0]);
   });
 

--- a/test/operator-insert.spec.ts
+++ b/test/operator-insert.spec.ts
@@ -6,7 +6,7 @@ import { InsertOperator } from '../src/operators';
 describe('insert operator unit tests', () => {
   it('it should validate options', () => {
     expect(() => new InsertOperator({
-      name: 'insert', select: 'user.profile[0].profileID',
+      name: 'insert', select: 'user.profile[0].profileID', defaultValue: 'user',
     }).validate()).to.not.throw();
 
     expect(() => new InsertOperator({
@@ -65,6 +65,22 @@ describe('insert operator unit tests', () => {
     const [baz, obj] = operator.handleData(data)!;
     expect(baz).to.eq('baz');
     expect(obj).to.eq(data[0]);
+  });
+
+  it('it should insert using defaultValue if selection syntax fails', () => {
+    const data: any[] = [{ foo: 'foo', bar: [{ baz: 'baz' }] }];
+    const operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz', defaultValue: 'default' });
+
+    const [baz, obj] = operator.handleData(data)!;
+    expect(baz).to.eq('default');
+    expect(obj).to.eq(data[0]);
+  });
+
+  it('it should throw an error if no value can be found', () => {
+    const data: any[] = [{ foo: 'foo', bar: [{ baz: 'baz' }] }];
+    const operator = new InsertOperator({ name: 'insert', select: 'bar[0].bazzz' });
+
+    expect(() => operator.handleData(data)).to.throw();
   });
 
   it('it should insert using selection syntax for an object at a specific index', () => {


### PR DESCRIPTION
Looks like I never had an `event` rule - probably because we didn't have fan-out at the time.  Adding a rule for it.  

The spec says that the `eventName` property must be present; however, I've already found a data layer that is not following that guidance.  To maximize using the real event's name with non-compliant data layers, I added a `defaultValue` fallback for the `insert` operator.