### PR TITLE
v1.3.0 release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.3.0
+
+- Added `defaultValue` option for insert operator
+
 ### 1.2.1
 
 - Addressed bug in convert operator where an undefined property is created and set to a value of `0`, `0.0`, or `false` depending on the conversion type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Updated changelog and package to reflect the new `defaultValue` option for insert.  This feature will be used in the next version of souq.