### PR TITLE
Error message cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.3.3
+
+- Log message cleanup
+
 ### 1.3.2
 
 - Fix bug related to usage of `globalThis` in older browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/embed/init.ts
+++ b/src/embed/init.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle, camelcase */
-import { Logger } from '../utils/logger';
+import { Logger, LogMessages } from '../utils/logger';
 import { DataLayerObserver } from '../observer';
 
 /*
@@ -55,7 +55,8 @@ function _dlo_collectRules(): any[] {
 
     const prop = (window as { [key: string]: any })[propName];
     if (Array.isArray(prop) === false) {
-      Logger.getInstance().warn(`window[${propName}] is not an array of Data Layer Observer rules so will be ignored`);
+      Logger.getInstance().warn(LogMessages.RuleInvalid,
+        { property: prop, reason: 'Rules list must be an array' });
       return;
     }
 
@@ -70,14 +71,14 @@ function _dlo_initializeFromWindow() {
   const win = (window as { [key: string]: any });
 
   if (win._dlo_observer) {
-    Logger.getInstance().error('The Data Layer Observer script is loaded twice! Canceling the second load.');
+    Logger.getInstance().warn(LogMessages.ObserverMultipleLoad);
     return;
   }
 
   // Read rules
   const rules = _dlo_collectRules();
   if (rules.length === 0) {
-    Logger.getInstance().warn('No rules for the Data Layer Observer');
+    Logger.getInstance().warn(LogMessages.ObserverRulesNone);
   }
 
   win._dlo_observer = new DataLayerObserver({

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -9,6 +9,7 @@ import {
   FanOutOperator, FanOutOperatorOptions,
 } from './operators';
 import { Operator } from './operator';
+import { Logger, LogMessage } from './utils/logger';
 
 /**
  * Declares known, built-in Operators.
@@ -47,7 +48,7 @@ export class OperatorFactory {
    */
   static create(name: string, options: BuiltinOptions): Operator {
     if (!OperatorFactory.hasOperator(name)) {
-      throw new Error(`Operator ${name} is unknown`);
+      throw new Error(Logger.format(LogMessage.UnknownValue, name));
     }
 
     return new (this.operators[name] as any)(options);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,4 +1,4 @@
-import { Logger } from './utils/logger';
+import { Logger, LogMessageType } from './utils/logger';
 import { Operator } from './operator';
 import { DataLayerDetail, createEventType } from './event';
 import DataLayerTarget from './target';
@@ -53,7 +53,7 @@ export default class DataHandler {
     const { path } = this.target;
 
     if (value === undefined && args === undefined) {
-      Logger.getInstance().warn(`${path} emitted no data`, path);
+      Logger.getInstance().warn(LogMessageType.EventEmpty, { path });
     } else if (type === createEventType(path)) {
       if (value) {
         // debounce events so multiple, related property assignments don't create multiple events
@@ -75,7 +75,7 @@ export default class DataHandler {
         this.handleData(args || []);
       }
     } else {
-      Logger.getInstance().warn(`EventListener received unexpected event ${type}`, path);
+      Logger.getInstance().warn(LogMessageType.EventUnexpected, { path });
     }
   }
 
@@ -129,8 +129,7 @@ export default class DataHandler {
 
         this.runDebugger(`[${i}] ${name} output ${stats}`, handledData, '  ');
       } catch (err) {
-        Logger.getInstance().error(`Operator ${name} failed for ${path} at step ${i}`,
-          path);
+        Logger.getInstance().error(LogMessageType.OperatorError, { operator: name, path, reason: err.message });
         return null;
       }
     }

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -1,5 +1,5 @@
 import Monitor from './monitor';
-import { Logger } from './utils/logger';
+import { Logger, LogMessage, LogMessageType } from './utils/logger';
 
 /**
  * ShimMonitor watches for changes and function calls through a shim technique.
@@ -17,11 +17,11 @@ export default class ShimMonitor extends Monitor {
    */
   static checkShimAllowed(object: any) {
     if (Object.isFrozen(object)) {
-      throw new Error('Object is frozen');
+      throw new Error(Logger.format(LogMessage.ShimFail, 'frozen'));
     }
 
     if (Object.isSealed(object)) {
-      throw new Error('Object is sealed');
+      throw new Error(Logger.format(LogMessage.ShimFail, 'sealed'));
     }
   }
 
@@ -58,7 +58,8 @@ export default class ShimMonitor extends Monitor {
         writable: this.writable,
       });
     } catch (err) {
-      Logger.getInstance().error(`Failed to remove listener on ${this.property}`, this.path);
+      Logger.getInstance().error(LogMessageType.MonitorRemoveError,
+        { path: this.path, property: this.property, reason: err.message });
     }
   }
 
@@ -70,7 +71,8 @@ export default class ShimMonitor extends Monitor {
         this.emit(args);
         return this.state.apply(this.object, args);
       } catch (err) {
-        Logger.getInstance().error(`Function ${this.property} exception`);
+        Logger.getInstance().error(LogMessageType.MonitorCallError,
+          { path: this.property, property: this.property, reason: err.message });
         return null;
       }
     };

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -1,5 +1,5 @@
 import { Operator, OperatorOptions, OperatorValidator } from '../operator';
-import { Logger } from '../utils/logger';
+import { Logger, LogMessageType } from '../utils/logger';
 
 type ConvertibleType = 'bool' | 'date' | 'int' | 'real' | 'string';
 
@@ -140,7 +140,11 @@ export class ConvertOperator implements Operator {
 
     // log error and reset to the original value
     if (!verified) {
-      Logger.getInstance().error(`Unable to convert ${property} to ${type} for value ${oldValue}`);
+      Logger.getInstance().error(LogMessageType.OperatorError, {
+        operator: 'convert',
+        property: property.toString(),
+        reason: `Failed to convert to ${type} for value ${oldValue}`,
+      });
       converted[property] = oldValue; // eslint-disable-line no-param-reassign
     }
   }

--- a/src/operators/function.ts
+++ b/src/operators/function.ts
@@ -34,12 +34,12 @@ export class FunctionOperator implements Operator {
           actualThisArg = select(thisArg);
           break;
         default:
-          throw new Error('FunctionOperator has unsupported this');
+          throw new Error('Unsupported this context used');
       }
     }
 
     if (!actualThisArg) {
-      throw new Error('FunctionOperator has no this');
+      throw new Error('No this context set');
     }
 
     let val = null;

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -38,7 +38,7 @@ export class InsertOperator implements Operator {
     const { defaultValue, select: selection, value } = this.options;
 
     if (selection && value !== undefined) {
-      throw new Error('insert operator has both \'select\' and \'value\' options set');
+      throw new Error('Both \'select\' and \'value\' options set');
     }
 
     let insertedValue = value || select(selection!, data[this.index]);
@@ -49,7 +49,7 @@ export class InsertOperator implements Operator {
 
     // if it's still undefined, don't proceed with the operator chain
     if (insertedValue === undefined) {
-      throw new Error('insert operator failed to find a value to insert');
+      throw new Error('Failed to find a value to insert');
     }
 
     const clone = data.slice();

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,4 +1,5 @@
 import { parsePath, ElementKind, select } from './selector';
+import { Logger, LogMessage } from './utils/logger';
 import { getGlobal } from './utils/object';
 
 /**
@@ -46,15 +47,15 @@ export default class DataLayerTarget {
   constructor(public subject: Object, public property: string, public path: string,
     public selector = '') {
     if (typeof subject !== 'object') {
-      throw new Error('Data layer subject must be an object');
+      throw new Error(LogMessage.TargetSubjectObject);
     }
 
     if (!property) {
-      throw new Error('Data layer target property is missing');
+      throw new Error(LogMessage.TargetPropertyMissing);
     }
 
     if (!path) {
-      throw new Error('Data layer subject must also have a path to broadcast changes or function calls');
+      throw new Error(LogMessage.TargetPathMissing);
     }
 
     // NOTE select using the path because a filter could not yet be valid
@@ -67,7 +68,7 @@ export default class DataLayerTarget {
         this.type = type;
         break;
       default:
-        throw new Error('Data layer not found');
+        throw new Error(LogMessage.DataLayerMissing);
     }
   }
 
@@ -86,7 +87,7 @@ export default class DataLayerTarget {
     const parsedPath = parsePath(selector);
 
     if (!parsedPath) {
-      throw new Error('Failed to parse selector');
+      throw new Error(Logger.format(LogMessage.SelectorMalformed, selector));
     }
 
     let subjectPath: string = '';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -109,7 +109,7 @@ export interface LogContext {
  * LogEvent defines a message to be sent to a sink for a given level.
  */
 export interface LogEvent {
-  context?: string | LogContext;
+  context?: LogContext;
   level: LogLevel;
   message: string;
 }
@@ -162,7 +162,7 @@ export class Logger {
    * @param message the informational message
    * @param context provides additional metadata related to the log event
    */
-  private log(level: LogLevel, message: string, context?: string | LogContext) {
+  private log(level: LogLevel, message: string, context?: LogContext) {
     if (level <= this.level) {
       this.appender.log({
         level,
@@ -172,19 +172,19 @@ export class Logger {
     }
   }
 
-  error(message: string, data?: string | LogContext) {
-    this.log(LogLevel.ERROR, message, data);
+  error(message: string, context?: LogContext) {
+    this.log(LogLevel.ERROR, message, context);
   }
 
-  warn(message: string, data?: string | LogContext) {
-    this.log(LogLevel.WARN, message, data);
+  warn(message: string, context?: LogContext) {
+    this.log(LogLevel.WARN, message, context);
   }
 
-  info(message: string, data?: string | LogContext) {
-    this.log(LogLevel.INFO, message, data);
+  info(message: string, context?: LogContext) {
+    this.log(LogLevel.INFO, message, context);
   }
 
-  debug(message: string, data?: string | LogContext) {
-    this.log(LogLevel.DEBUG, message, data);
+  debug(message: string, context?: LogContext) {
+    this.log(LogLevel.DEBUG, message, context);
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,6 +14,39 @@ export enum LogLevel {
   DEBUG
 }
 
+export enum LogMessageType {
+  EventEmpty = 'Empty Event',
+  EventUnexpected = 'Unexpected Event',
+  MonitorCallError = 'Monitor Call Error',
+  MonitorCreateError = 'Monitor Creation Error',
+  MonitorDuplicateProp = 'Monitor Duplicate Property',
+  MonitorEmitError = 'Monitor Emit Error',
+  MonitorRemoveError = 'Monitor Removal Error',
+  OperatorError = 'Operator Error',
+  ObserverMultipleLoad = 'Duplicate Observer',
+  ObserverReadError = 'Read Error',
+  ObserverRulesNone = 'No Rules Defined',
+  RuleInvalid = 'Invalid Rule',
+  RuleRegistrationError = 'Rule Registration Error',
+}
+
+export enum LogMessage {
+  DataLayerMissing = 'Data layer not found',
+  DuplicateValue = 'Value $0 already used',
+  ShimFail = 'Shim not allowed because object is $0',
+  SelectorInvalidIndex = 'Selector index $0 is not a number in $1',
+  SelectorIncorrectTokenCount = 'Selector has incorrect number ($0) of tokens in $1',
+  SelectorMalformed = 'Selector $0 is malformed',
+  SelectorMissingToken = 'Selector is missing $0 in $1',
+  SelectorNoProps = 'Selector is missing properties',
+  SelectorSyntaxUnsupported = 'Selector syntax $0 is unsupported',
+  TargetSubjectObject = 'Target subject must be an object',
+  TargetPropertyMissing = 'Target property is missing',
+  TargetPathMissing = 'Target path is missing',
+  UnknownValue = 'Unknown value $0',
+  UnsupportedType = 'Unsupported type $0',
+}
+
 /**
  * ConsoleAppender serializes LogEvents to the browser's console.
  */
@@ -65,7 +98,9 @@ export class FullStoryAppender implements LogAppender {
 export interface LogContext {
   rule?: string;
   source?: string;
+  operator?: string;
   path?: string;
+  property?: string;
   selector?: string;
   reason?: string;
 }
@@ -100,6 +135,16 @@ export class Logger {
       default:
         this.appender = new ConsoleAppender();
     }
+  }
+
+  static format(message: string, ...substitutions: string[]) {
+    let formatted = message;
+
+    for (let i = 0; i < substitutions.length; i += 1) {
+      formatted = formatted.replace(`$${i}`, substitutions[i]);
+    }
+
+    return formatted.trim();
   }
 
   static getInstance(appender?: string): Logger {

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -110,4 +110,11 @@ describe('logger unit tests', () => {
     expect(event.message).to.eq('Data layer not found');
     expect(event.context.source).to.eq(mockDatalayer);
   });
+
+  it('it should format using substitution', () => {
+    expect(Logger.format('Hello $0', 'World')).to.eql('Hello World');
+    expect(Logger.format('$0 $1', 'Hello', 'World')).to.eql('Hello World');
+    expect(Logger.format('$0 $1', 'Hello', 'World', '!')).to.eql('Hello World');
+    expect(Logger.format('$0 $1 $0', 'Hello', 'World')).to.eql('Hello World $0'); // NOTE re-use is unsupported
+  });
 });

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -25,23 +25,23 @@ describe('logger unit tests', () => {
   });
 
   it('a console logger with warn and error levels is configured by default', () => {
-    const mockDatalayer = 'digitalData.user';
+    const path = 'digitalData.user';
 
     const logger = Logger.getInstance();
 
-    logger.error('Data layer not found', mockDatalayer);
-    logger.warn('Data layer not ready', mockDatalayer);
+    logger.error('Data layer not found', { path });
+    logger.warn('Data layer not ready', { path });
 
     const [error] = expectParams(console, 'error');
-    expect(error).to.eq(`Data layer not found "${mockDatalayer}"`);
+    expect(error).to.eq(`Data layer not found {"path":"${path}"}`);
 
     const [warn] = expectParams(console, 'warn');
-    expect(warn).to.eq(`Data layer not ready "${mockDatalayer}"`);
+    expect(warn).to.eq(`Data layer not ready {"path":"${path}"}`);
 
-    logger.info('Data layer rules loaded', mockDatalayer);
+    logger.info('Data layer rules loaded', { path });
     expectNoCalls(console, 'info');
 
-    logger.debug('Operator output', mockDatalayer);
+    logger.debug('Operator output', { path });
     expectNoCalls(console, 'debug');
   });
 


### PR DESCRIPTION
This closes #56 and cleans up/bubbles up a lot of the error messages.  I took the approach:
- If DLO is calling a `log` event, a shorter `LogMessageType` was used (e.g. `Empty Event`).  It's a mix of trying to re-use error messages and mimic what's done in [FS API error kinds](https://help.fullstory.com/hc/en-us/articles/360020624394#API%20Error%20Kinds).
- The above lacks a bit of clarity, and when an `Error` is constructed, you can use `Logger.format` and `LogMessage` to create a more descriptive message.  Anything in `err.message` gets put into the context object as `reason_str: <message>`.  This was used heavily in `selector.ts` to be more granular with parsing related errors.