### PR TITLE
Limit monitoring scope

### DIFF
--- a/examples/rules/tealium-fullstory.json
+++ b/examples/rules/tealium-fullstory.json
@@ -35,10 +35,10 @@
     {
       "id": "fs-tealium-user-registration",
       "description": "See https://community.tealiumiq.com/t5/Data-Layer/Data-Layer-Definition-Retail/ta-p/17227#toc-hId-867970954.",
-      "source": "utag.data[?(tealium_event=user_registration)]",
+      "source": "utag.data[^(customer_,tealium_event)]",
       "operators": [
         {
-          "select": "$[^(customer_)]",
+          "select": "$[?(tealium_event=user_registration)]",
           "name": "query"
         },
         {
@@ -60,11 +60,11 @@
     {
       "id": "fs-tealium-user-update",
       "description": "See https://community.tealiumiq.com/t5/Data-Layer/Data-Layer-Definition-Retail/ta-p/17227#toc-hId-1755474635.",
-      "source": "utag.data[?(tealium_event=user_update)]",
+      "source": "utag.data[^(customer_,tealium_event)]",
       "operators": [
         {
           "name": "query",
-          "select": "$[^(customer_)]"
+          "select": "$[?(tealium_event=user_update)]"
         }
       ],
       "destination": "FS.setUserVars",

--- a/examples/rules/tealium-fullstory.json
+++ b/examples/rules/tealium-fullstory.json
@@ -3,11 +3,11 @@
     {
       "id": "fs-tealium-event",
       "description": "Send Tealium data (except for customer personal details) for FS.event. See https://community.tealiumiq.com/t5/Data-Layer/Data-Layer-Definition-Retail/ta-p/17227.",
-      "source": "utag.data[?(tealium_event)]",
+      "source": "utag.data[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]",
       "operators": [
         {
           "name": "query",
-          "select": "$[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]"
+          "select": "$[?(tealium_event)]"
         },
         {
           "name": "query",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -128,16 +128,16 @@ export class DataLayerObserver {
     if (type === 'function') {
       MonitorFactory.getInstance().create(subject, property, targetPath);
     } else {
-      // when a selector gets used, we know the full path through the data layer and can monitor note
+      // when a selector gets used, we know the full path through the data layer and can monitor
       if (selector) {
         MonitorFactory.getInstance().create(subject, property, subjectPath); // monitor the subject for re-assignments
       }
 
-      // monitor all child properties
-      // NOTE this results in all properties firing changes but the query result ensures that only desired events
-      // are sent to the destination
+      // NOTE only the properties that would be returned from a query
+      // else we'll create events for changed properties that are never included in the data
       const subjectRef = target.value;
-      Object.getOwnPropertyNames(subjectRef).forEach((childProperty: string) => {
+      const subjectProps = Object.getOwnPropertyNames(target.query());
+      subjectProps.forEach((childProperty: string) => {
         MonitorFactory.getInstance().create(subjectRef, childProperty, targetPath);
       });
     }

--- a/test/monitor-factory.spec.ts
+++ b/test/monitor-factory.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import deepcopy from 'deepcopy';
+import 'mocha';
+import MonitorFactory from '../src/monitor-factory';
+
+import { basicDigitalData, CEDDL } from './mocks/CEDDL';
+
+interface GlobalMock {
+  digitalData: CEDDL,
+}
+
+let globalMock: GlobalMock;
+
+describe('MonitorFactory unit tests', () => {
+  beforeEach(() => {
+    (globalThis as any).digitalData = deepcopy(basicDigitalData); // NOTE copy so mutations don't pollute tests
+    globalMock = globalThis as any;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).digitalData;
+  });
+
+  it('it should return a singleton', () => {
+    const factory = MonitorFactory.getInstance();
+    expect(factory).to.not.be.undefined;
+
+    const factory2 = MonitorFactory.getInstance();
+    expect(factory2).to.not.be.undefined;
+    expect(factory2).to.eq(factory);
+  });
+
+  it('it should return an existing Monitor if recreated', () => {
+    expect(globalMock.digitalData.cart).to.not.be.undefined;
+
+    const cartMonitor = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor).to.not.be.undefined;
+
+    const cartMonitor2 = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor2).to.not.be.undefined;
+    expect(cartMonitor2).to.eq(cartMonitor);
+  });
+
+  it('it should remove a Monitor', () => {
+    expect(globalMock.digitalData.cart).to.not.be.undefined;
+
+    const cartMonitor = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor).to.not.be.undefined;
+
+    MonitorFactory.getInstance().remove('digitalData.cart.cartID');
+
+    const cartMonitor2 = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    expect(cartMonitor2).to.not.be.undefined;
+    expect(cartMonitor2).to.not.eq(cartMonitor);
+  });
+});

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -419,6 +419,37 @@ describe('DataLayerObserver unit tests', () => {
     }, DataHandler.debounceTime * 1.5);
   });
 
+  it('updating properties not included in result should not trigger the data handler', (done) => {
+    let changes: any[] = [];
+
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        {
+          source: 'digitalData.cart[(cartID,price)]',
+          operators: [],
+          destination: (...data: any[]) => {
+            // NOTE use a local destination to prevent cross-test pollution
+            changes = data;
+          },
+          readOnLoad: false,
+          // monitor: true, // NOTE the default is true
+        },
+      ],
+    }, true);
+
+    expect(globalMock.digitalData.cart).to.not.be.undefined;
+
+    // NOTE this property is not part of the [(cartID,price)] selector
+    globalMock.digitalData.cart.attributes = { ignored: true };
+
+    // check the assignment
+    setTimeout(() => {
+      expect(changes.length).to.eq(0);
+      ExpectObserver.getInstance().cleanup(observer);
+      done();
+    }, DataHandler.debounceTime * 1.5);
+  });
+
   it('it should not add monitors for an invalid rule', () => {
     const observer = ExpectObserver.getInstance().create({
       rules: [


### PR DESCRIPTION
This PR limits when we add monitors to properties in a data layer.  Previously, we added monitors on all properties in the data layer.  The result was that a property change would fire and the data handler ran the appropriate selector to return the desired data.  I _think_ monitoring all properties may have just been a convenience approach rather than anything intentional.  @TrevorFSmith Do you recall any specific situation why monitoring all props was necessary?

When a data layer has ALOT of properties, the current implementation has the side effect that we are over eventing.  For example, the Tealium default rule is `utag.data[?(tealium_event)]`.  This means that we're monitoring all properties in `utag.data`, but the default rule's query operator has us only getting a subset of this data `[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]`.  Thus a change to a property outside our selector (e.g. `someCustomProp`) is triggering the data handler, but the pick selector discards the property that originally fired the event.  To the end user, it appears we're just sending the "same" data over and over again.  And this can happen a lot, I've seen where the link tracking extension in Tealium may cause the data layer to change on every click.

A solution is that we only monitor the properties that would eventually be contained in the final data sent to a destination.  This is subtly more difficult than it seems.  `Monitor`s are well separated from `DataHandler`s.  It's feels like a lot of code.  There's also questions about filtering scenarios when the property does not yet exist in the data layer.

What I've created is a more straightforward approach where we will dynamically get the properties from the `source` selector.  That way we don't have to process a full operator chain, but we can likely get the required properties to create intended monitors.  For example, this is the pre and post fix Tealium rule:

pre-fix
```
"id": "fs-tealium-event",
"source": "utag.data[?(tealium_event)]",
"operators": [
        {
          "name": "query",
          "select": "$[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]"
        },
```

post-fix
```
"id": "fs-tealium-event",
"source": "utag.data[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]",
"operators": [
        {
          "name": "query",
          "select": "$[?(tealium_event)]"
        },
```

Notice that all this really does is ensure that we can get a list of desired properties when we register the rule (because we can run the `select` on the `source` selector).  This approach I don't think changes the fundamental design choices in how to create rules other than adding the best practice of swapping picking and query.  This applies to Tealium and Adobe mainly.  An upside here is that we will monitor less, which hopefully reduces the possibility for unforeseen side effects and increases performance.

 The technical change is pretty small, but I wanted to carefully consider the adjustment since we have customers with Tealium rules deployed.  A coordinated change in the souq rule will need to occur and then the dlo.js fix would be deployed.