### PR TITLE
Add google analytics all purpose rule support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The `source` property uses a custom selector syntax.  It’s most often seen as 
 | object[^(property, ...)] | `digitalData.cart.price[^(shipping)]` | Returns an object with properties whose names begin with `property`. |
 | object[$(property, ...)] | `digitalData.page.pageInfo[$(Date)]` | Returns an object with properties whose names end with `property`. |
 | object[?(property, ...)] | `digitalData.cart[?(cartID)]` | Returns the object or null if the object does not have property. |
-| object[?(property=value, ...)] | `digitalData.cart.price[?(basePrice>=10)]` | Returns the object or null if the object's `property` does not compare to `value`. Comparison can be `=`, `<=`, `>=`, `<`, `>`, and `!=`. |
+| object[?(property=value, ...)] | `digitalData.cart.price[?(basePrice>=10)]` | Returns the object or null if the object's `property` does not compare to `value`. Comparison can be `=`, `<=`, `>=`, `<`, `>`, `!=`, `!^`, and `=^`. |
 
 Selector syntax can be combined to create sophisticated queries to the data layer.  For example, `digitalData.products[-1].attributes.availability[?(pickup)]` can be read as, "From the products list, return the last product's availability if it has the `pickup` property."  This usage of selection can be helpful to record only significant events and disregard others.
 

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -253,7 +253,7 @@
       "source": "dataLayer",
       "operators": [
         { "name": "query", "select": "$[?(event!^gtm)]" },
-        { "name": "query", "select": "$[!(gtm.uniqueEventId)]" },
+        { "name": "query", "select": "$[!(ecommerce,gtm.uniqueEventId)]" },
         { "name": "insert", "select": "event" }
       ],
       "destination": "FS.event",

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -12,6 +12,21 @@
       "monitor": true
     },
     {
+      "id": "fs-gtg-event",
+      "source": "dataLayer",
+      "operators": [
+        { "name": "query", "select": "$[(0,1,2)]" },
+        { "name": "query", "select": "$[?(0=event)]" },
+        { "name": "flatten" },
+        { "name": "query", "select": "$[?(0=event)]" },
+        { "name": "rename", "properties": { "0": "gtgCommand", "1": "gtgAction" } },
+        { "name": "insert", "select": "gtgAction" }
+      ],
+      "destination": "FS.event",
+      "readOnLoad": true,
+      "monitor": true
+    },
+    {
       "id": "fs-ga-e-commerce-detail-action",
       "source": "dataLayer",
       "operators": [
@@ -237,9 +252,9 @@
       "id": "fs-ga-event",
       "source": "dataLayer",
       "operators": [
-        { "name": "query", "select": "$[?(event)]" },
-        { "name": "query", "select": "$[!(ecommerce,gtm.uniqueEventId)]" },
-        { "name": "insert","select": "event" }
+        { "name": "query", "select": "$[?(event!^gtm)]" },
+        { "name": "query", "select": "$[!(gtm.uniqueEventId)]" },
+        { "name": "insert", "select": "event" }
       ],
       "destination": "FS.event",
       "readOnLoad": true,

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -56,7 +56,7 @@ class OpProp {
     for (let i = 0; i < raw.length; i += 1) {
       const codePoint = raw.charCodeAt(i);
       // the codePoint appears to be some form of comparison operator we support
-      if (codePoint === 33 || (codePoint >= 60 && codePoint <= 62)) {
+      if (codePoint === 33 || (codePoint >= 60 && codePoint <= 62) || codePoint === 94) {
         // mark the start pos of the operator
         if (start === 0) {
           start = i;
@@ -397,6 +397,8 @@ class PathElement {
           if (opProp.operator === '==' && prop[opProp.name] != opProp.value) return undefined;
           // eslint-disable-next-line eqeqeq
           if (opProp.operator != '==' && prop[opProp.name] == opProp.value) return undefined;
+          if (opProp.operator === '=^' && !prop[opProp.name].startsWith(opProp.value)) return undefined;
+          if (opProp.operator === '!^' && prop[opProp.name].startsWith(opProp.value)) return undefined;
           break;
         case 'number':
           // eslint-disable-next-line eqeqeq

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -18,6 +18,8 @@ const testData = {
     'dot.prop': '1.0',
   },
   cities: ['Seattle', 'Atlanta', 'San Francisco', 'New York City'],
+  gtmEvent: { event: 'gtm.dom' },
+  myEvent: { event: 'myEvent' },
 };
 
 describe('test selection paths', () => {
@@ -89,6 +91,7 @@ describe('test selection paths', () => {
     expect(() => { new Path('films[?(dot.prop=1.0)]'); }).to.not.throw();
     expect(() => { new Path('films[?()]'); }).to.throw(Error);
     expect(() => { new Path('films[?]'); }).to.throw(Error);
+    expect(() => { new Path('myEvent[?(event!^gtm.)]'); }).to.not.throw();
 
     expect(validate('favorites.films.action')).to.be.true;
     expect(validate('.')).to.be.false;
@@ -220,6 +223,12 @@ describe('test selection paths', () => {
     expect(select('favorites[?(number!=25)]', testData)).to.be.undefined;
     expect(select('favorites[?(number!=12)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(number+=25)]', testData)).to.be.undefined;
+    expect(select('gtmEvent[?(event!^gtm.)]', testData)).to.be.undefined;
+    expect(select('gtmEvent[?(event=^gtm.)]', testData)).to.not.be.undefined;
+    expect(select('myEvent[?(event!^gtm.)]', testData)).to.not.be.undefined;
+    expect(select('myEvent[?(event=^gtm.)]', testData)).to.be.undefined;
+    expect(select('myEvent[?(event=^my)]', testData)).to.not.be.undefined;
+    expect(select('favorites[?(missing=^my)]', testData)).to.be.undefined;
   });
 
   it('filter notation should return a reference to the object', () => {


### PR DESCRIPTION
This PR adds a bit more all-purpose support to Google Analytics.  While we have Enhanced Ecommerce rules, the basic Google Analytics usage in `ga.js`, `analytics.js`, and `gtg.js` needs to also be supported.  To that end, the rules were updated and a new comparison syntax to support "does not start with" was added.  This allows us to ignore noisy GA events like `gtm.dom` and `gtm.js`.

Google's newer `gtg.js` actually behaves a little differently.  Rather than inserting an object into the data layer, it adds `Arguments`.  This required a bit of creativity to leverage our existing operators.  It's worth documenting as an advanced operator tutorial, but I'll get to that at a later date.  I want to PR the support so that we can add GA as a souq ruleset.