### PR TITLE
Normalize numbers as real

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.4.1
+
+- Normalized numbers as `real` by default to prevent ambiguous `int` for numbers like `200.00`
+
 ### 1.4.0
 
 - Monitoring properties is limited to only the properties in the object returned from the `source` selector, which may be a subset of all properties

--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -10,7 +10,6 @@ Options with an asterisk are required.
 | ------ | ---- | ------- | ----------- |
 | `index` | `number` | `0` | Position of the object to suffix in the operator input list. |
 | `maxDepth` | `number` | `10` | Maximum depth to search for properties to be suffixed. |
-| `preferReal` | `boolean` | `true` | When false whole numbers like `200.00` will be suffixed `int` and not `real`. |
 
 ## Usage
 

--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -10,6 +10,7 @@ Options with an asterisk are required.
 | ------ | ---- | ------- | ----------- |
 | `index` | `number` | `0` | Position of the object to suffix in the operator input list. |
 | `maxDepth` | `number` | `10` | Maximum depth to search for properties to be suffixed. |
+| `preferReal` | `boolean` | `true` | When false whole numbers like `200.00` will be suffixed `int` and not `real`. |
 
 ## Usage
 
@@ -50,7 +51,7 @@ Options with an asterisk are required.
  {
   basePrice_real: 15.55,
   voucherCode_str: '',
-  voucherDiscount_int: 0,
+  voucherDiscount_real: 0,
   currency_str: 'USD',
   taxRate_real: 0.09,
   shipping_real: 5.0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -39,26 +39,38 @@ export class SuffixOperator implements Operator {
   static specification = {
     index: { required: false, type: ['number'] },
     maxDepth: { required: false, type: ['number'] },
+    preferReal: { required: false, type: ['boolean'] },
   };
 
   readonly index: number;
 
   readonly maxDepth: number;
 
+  readonly preferReal: boolean;
+
   constructor(public options: SuffixOperatorOptions) {
     // NOTE the index is -1 because payloads to FS.event or FS.setUserVars are the last in the list of args
-    const { index = -1, maxDepth = 10 } = options;
+    const { index = -1, maxDepth = 10, preferReal = true } = options;
 
     this.index = index;
     this.maxDepth = maxDepth;
+    this.preferReal = preferReal;
   }
 
   /**
    * Infers the type suffix for a numeric value (i.e. Int or Real).
    * @param value value property value used to infer type and return suffix
+   * @param preferReal when true will treat whole numbers as a Real and not Int (default is true)
    */
-  static coerceNumSuffix(value: number): string {
-    // NOTE 1.00 will return _int but you might expect 1.00 as a _real suffix
+  static coerceNumSuffix(value: number, preferReal = true): string {
+    // NOTE numbers are a Real by default
+    // this addresses a more difficult historical problem where
+    // 1.00 will return _int but you might expect 1.00 as a _real suffix
+    // this dual type situation makes searching difficult
+    if (preferReal) {
+      return Suffixes.Real;
+    }
+
     return value % 1 === 0 ? Suffixes.Int : Suffixes.Real;
   }
 
@@ -67,8 +79,9 @@ export class SuffixOperator implements Operator {
    * There are 10 valid type suffixes:
    * _bool, _date, _int, _real, _str, _bools, _dates, _ints, _reals, and _strs.
    * @param value the object to inspect and return suffix
+   * @param preferReal when true will treat whole numbers as a Real and not Int (default is true)
    */
-  static coerceSuffix(value: SuffixableValue): string {
+  static coerceSuffix(value: SuffixableValue, preferReal = true): string {
     // arrays are pluralized
     if (Array.isArray(value)) {
       if (value.every((v: any) => typeof v === 'string')) {
@@ -82,7 +95,8 @@ export class SuffixOperator implements Operator {
       if (value.every((v: any) => typeof v === 'number')) {
         // NOTE [1.00, 1.99] is actually _int, _real types respectively
         // so favor _reals over _ints if the list is mixed
-        return (value as number[]).filter((v: number) => SuffixOperator.coerceNumSuffix(v) === '_real').length === 0
+        return (value as number[]).filter((v: number) => SuffixOperator.coerceNumSuffix(v,
+          preferReal) === '_real').length === 0
           ? Suffixes.Ints : Suffixes.Reals;
       }
 
@@ -109,7 +123,7 @@ export class SuffixOperator implements Operator {
       case 'boolean':
         return Suffixes.Bool;
       case 'number':
-        return SuffixOperator.coerceNumSuffix(value);
+        return SuffixOperator.coerceNumSuffix(value, preferReal);
       case 'object':
         return Suffixes.Obj;
       default:
@@ -135,7 +149,7 @@ export class SuffixOperator implements Operator {
 
     Object.getOwnPropertyNames(obj).forEach((prop: string) => {
       const value = obj[prop];
-      const suffix = SuffixOperator.coerceSuffix(value);
+      const suffix = SuffixOperator.coerceSuffix(value, this.preferReal);
       const suffixedProp = `${prop}${suffix}`;
 
       // if a suffix exists, it means we support the value

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -82,11 +82,11 @@ describe('suffix operator unit test', () => {
     });
   });
 
-  it('it should prefer real versus int', () => {
-    let operator = new SuffixOperator({ name: 'suffix' });
+  it('all numbers are suffixed as a real', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
     expect(operator).to.not.be.undefined;
 
-    let [suffixedObject] = operator.handleData([testData])!;
+    const [suffixedObject] = operator.handleData([testData])!;
 
     expect(suffixedObject.quantity_real).to.not.be.undefined;
     expect(suffixedObject.quantity_real).to.eql(testData.quantity);
@@ -96,20 +96,6 @@ describe('suffix operator unit test', () => {
 
     expect(suffixedObject.region_real).to.not.be.undefined;
     expect(suffixedObject.region_real).to.eql(testData.region);
-
-    operator = new SuffixOperator({ name: 'suffix', preferReal: false });
-    expect(operator).to.not.be.undefined;
-
-    [suffixedObject] = operator.handleData([testData])!;
-
-    expect(suffixedObject.quantity_int).to.not.be.undefined;
-    expect(suffixedObject.quantity_int).to.eql(testData.quantity);
-
-    expect(suffixedObject.discountTiers_ints).to.not.be.undefined;
-    expect(suffixedObject.discountTiers_ints).to.eql(testData.discountTiers);
-
-    expect(suffixedObject.region_int).to.not.be.undefined;
-    expect(suffixedObject.region_int).to.eql(testData.region);
   });
 
   it('it should suffix child properties in object', () => {

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -13,6 +13,7 @@ const testData: any = {
   last_name: 'Falco',
   price: 49.99,
   quantity: 1,
+  region: 0,
   isFeatured: true,
   listedPages: [true, false, false],
   created: date,
@@ -79,6 +80,36 @@ describe('suffix operator unit test', () => {
     Object.getOwnPropertyNames(suffixedObject).forEach((prop) => {
       expect(prop).to.not.contain('fn');
     });
+  });
+
+  it('it should prefer real versus int', () => {
+    let operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    let [suffixedObject] = operator.handleData([testData])!;
+
+    expect(suffixedObject.quantity_real).to.not.be.undefined;
+    expect(suffixedObject.quantity_real).to.eql(testData.quantity);
+
+    expect(suffixedObject.discountTiers_reals).to.not.be.undefined;
+    expect(suffixedObject.discountTiers_reals).to.eql(testData.discountTiers);
+
+    expect(suffixedObject.region_real).to.not.be.undefined;
+    expect(suffixedObject.region_real).to.eql(testData.region);
+
+    operator = new SuffixOperator({ name: 'suffix', preferReal: false });
+    expect(operator).to.not.be.undefined;
+
+    [suffixedObject] = operator.handleData([testData])!;
+
+    expect(suffixedObject.quantity_int).to.not.be.undefined;
+    expect(suffixedObject.quantity_int).to.eql(testData.quantity);
+
+    expect(suffixedObject.discountTiers_ints).to.not.be.undefined;
+    expect(suffixedObject.discountTiers_ints).to.eql(testData.discountTiers);
+
+    expect(suffixedObject.region_int).to.not.be.undefined;
+    expect(suffixedObject.region_int).to.eql(testData.region);
   });
 
   it('it should suffix child properties in object', () => {
@@ -154,12 +185,12 @@ describe('suffix operator unit test', () => {
 
     expect(suffixedObject).to.haveOwnProperty('id_str');
     expect(suffixedObject).to.haveOwnProperty('price_real');
-    expect(suffixedObject).to.haveOwnProperty('quantity_int');
+    expect(suffixedObject).to.haveOwnProperty('quantity_real');
     expect(suffixedObject).to.haveOwnProperty('isFeatured_bool');
     expect(suffixedObject).to.haveOwnProperty('listedPages_bools');
     expect(suffixedObject).to.haveOwnProperty('created_date');
     expect(suffixedObject).to.haveOwnProperty('shippingDates_dates');
-    expect(suffixedObject).to.haveOwnProperty('discountTiers_ints');
+    expect(suffixedObject).to.haveOwnProperty('discountTiers_reals');
     expect(suffixedObject).to.haveOwnProperty('discountPrices_reals');
     expect(suffixedObject).to.haveOwnProperty('variants_strs');
   });


### PR DESCRIPTION
This PR skews suffixing numeric values as `real`.  For example, whole numbers such as `200.00` are considered as a `real` rather than `int`.  The issue is that a property related to price might be interpreted as an `int` because it is a whole number but should ideally be a `real` for consistency purposes.  Doing this groups it with other price values such as `200.01` that already exist. 