### PR TITLE
Expose logging level config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.4.3
+
+- Expose logging level as config option `_dlo_logLevel`
+
 ### 1.4.2
 
 - Debouncing added to limit the number of log events for similar error messages

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Additional configuration can be added using the below options.
 | ------ | ---- | ------- | ----------- |
 | _dlo_appender | LogAppender or string | `console` | Defines a custom log appender to redirect log messages. |
 | _dlo_beforeDestination | OperatorOptions | `undefined` | An optional operator that is always used just before before the destination. |
+| _dlo_logLevel | number | `1` | Log messages at this level and below will be logged by the LogAppender. Defaults to WARN. |
 | _dlo_previewDestination | string | `'console.log'` | Output destination using rule selector syntax for use with previewMode. |
 | _dlo_previewMode | boolean | `true` | Redirects output from a destination to previewDestination when testing rules. |
 | _dlo_readOnLoad | boolean | `false` | When true reads data layer target(s) and emits the initial value(s). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/embed/init.ts
+++ b/src/embed/init.ts
@@ -9,6 +9,10 @@ This is where we initialize the DataLayerObserver from this info:
 // Default is null
 window['_dlo_appender'] = null;
 
+// Log message level, NONE = -1, ERROR = 0, WARN = 1, INFO = 2, DEBUG = 3
+// Default is null
+window['_dlo_logLevel'] = 1;
+
 // OperatorOptions that is always used just before before the destination
 // Default is null
 window['_dlo_beforeDestination'] = null;
@@ -84,6 +88,7 @@ function _dlo_initializeFromWindow() {
   win._dlo_observer = new DataLayerObserver({
     appender: win._dlo_appender || undefined,
     beforeDestination: win._dlo_beforeDestination || undefined,
+    logLevel: win._dlo_logLevel || undefined,
     previewMode: win._dlo_previewMode === true,
     previewDestination: win._dlo_previewDestination || undefined,
     readOnLoad: win._dlo_readOnLoad === true,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -3,7 +3,7 @@ import { OperatorOptions, Operator } from './operator';
 import { BuiltinOptions, OperatorFactory } from './factory';
 import DataHandler from './handler';
 import {
-  Logger, LogAppender, LogMessageType, LogMessage,
+  Logger, LogAppender, LogMessageType, LogMessage, LogLevel,
 } from './utils/logger';
 import { FunctionOperator } from './operators';
 import DataLayerTarget from './target';
@@ -17,6 +17,7 @@ import MonitorFactory from './monitor-factory';
  * Optional
  *  appender: a custom log appender or string alias (e.g. fullstory or console)
  *  beforeDestination: OperatorOptions that is always used just before before the destination
+ *  logLevel: LogLevel for debugging; levels at this value and below will be logged
  *  previewMode: redirects output from a destination to previewDestination when testing rules
  *  previewDestination: output destination using selection syntax for with previewMode
  *  readOnLoad: when true reads data layer target(s) and emit the initial value(s)
@@ -26,6 +27,7 @@ import MonitorFactory from './monitor-factory';
 export interface DataLayerConfig {
   appender?: string | LogAppender;
   beforeDestination?: OperatorOptions;
+  logLevel?: LogLevel;
   previewDestination?: string;
   previewMode?: boolean;
   readOnLoad?: boolean;
@@ -89,13 +91,19 @@ export class DataLayerObserver {
     readOnLoad: false,
     validateRules: true,
   }) {
-    const { appender, rules } = config;
+    const { appender, logLevel, rules } = config;
     if (appender) {
       if (typeof appender === 'string') {
         Logger.getInstance(appender);
       } else {
         Logger.getInstance().appender = appender;
       }
+    }
+
+    // set the level after the appender is assigned since the first call to getInstance()
+    // inits the Logger; else the Logger will use the default appender (e.g. console)
+    if (logLevel) {
+      Logger.getInstance().level = logLevel;
     }
 
     if (rules) {


### PR DESCRIPTION
We've always had the ability to set and leverage `LogLevel` to control debug messages.  This PR exposes that ability as a config option.  External configurability allows souq to turn off logging if desired.