### PR TITLE
Ability to compare undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `source` property uses a custom selector syntax.  It’s most often seen as 
 | object[^(property, ...)] | `digitalData.cart.price[^(shipping)]` | Returns an object with properties whose names begin with `property`. |
 | object[$(property, ...)] | `digitalData.page.pageInfo[$(Date)]` | Returns an object with properties whose names end with `property`. |
 | object[?(property, ...)] | `digitalData.cart[?(cartID)]` | Returns the object or null if the object does not have property. |
-| object[?(property=value, ...)] | `digitalData.cart.price[?(basePrice>=10)]` | Returns the object or null if the object's `property` does not compare to `value`. Comparison can be `=`, `<=`, `>=`, `<`, `>`, `!=`, `!^`, and `=^`. |
+| object[?(property=value, ...)] | `digitalData.cart.price[?(basePrice>=10)]` | Returns the object or null if the object's `property` does not compare to `value`. Comparison can be `=`, `<=`, `>=`, `<`, `>`, `!=`, `!^`, and `=^`. Use the value `undefined` to query if a property `=` or `!=` undefined. |
 
 Selector syntax can be combined to create sophisticated queries to the data layer.  For example, `digitalData.products[-1].attributes.availability[?(pickup)]` can be read as, "From the products list, return the last product's availability if it has the `pickup` property."  This usage of selection can be helpful to record only significant events and disregard others.
 

--- a/examples/rules/google-tags-fullstory.json
+++ b/examples/rules/google-tags-fullstory.json
@@ -253,7 +253,8 @@
       "source": "dataLayer",
       "operators": [
         { "name": "query", "select": "$[?(event!^gtm)]" },
-        { "name": "query", "select": "$[!(ecommerce,gtm.uniqueEventId)]" },
+        { "name": "query", "select": "$[?(ecommerce=undefined)]" },
+        { "name": "query", "select": "$[!(gtm.uniqueEventId)]" },
         { "name": "insert", "select": "event" }
       ],
       "destination": "FS.event",

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -383,7 +383,8 @@ class PathElement {
 
     for (let i = 0; i < this.brackets.op.props.length; i += 1) {
       const opProp = this.brackets.op.props[i];
-      if (typeof prop[opProp.name] === 'undefined') return undefined;
+      // checking for opProp.value set to 'undefined' allows us to check if a property is missing
+      if (typeof prop[opProp.name] === 'undefined' && opProp.value !== 'undefined') return undefined;
       if (opProp.value === null) continue; // Existance is enough
       /*
       Values come in as strings so we use loose matching (== not ===) to take advantage of JS's built-in fast parsing and evaluation
@@ -409,6 +410,12 @@ class PathElement {
           if (opProp.operator === '<=' && prop[opProp.name] > opProp.value) return undefined;
           if (opProp.operator === '>' && prop[opProp.name] <= opProp.value) return undefined;
           if (opProp.operator === '<' && prop[opProp.name] >= opProp.value) return undefined;
+          break;
+        case 'undefined':
+          // eslint-disable-next-line eqeqeq
+          if (opProp.operator === '==' && prop[opProp.name] != undefined) return undefined;
+          // eslint-disable-next-line eqeqeq
+          if (opProp.operator === '!=' && prop[opProp.name] == undefined) return undefined;
           break;
         default:
           throw new Error(Logger.format(LogMessage.SelectorSyntaxUnsupported, opProp.raw));

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -200,6 +200,8 @@ describe('test selection paths', () => {
     expect(select('favorites[?(dot.prop=1.0)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(dot.prop=2.0)]', testData)).to.be.undefined;
     expect(select('favorites[?(bogus=totally)]', testData)).to.be.undefined;
+    expect(select('favorites[?(bogus=undefined)]', testData)).to.not.be.undefined;
+    expect(select('favorites[?(bogus!=undefined)]', testData)).to.be.undefined;
     expect(select('favorites[?(color, number)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(bogus, number)]', testData)).to.be.undefined;
     expect(select('favorites[?(color=red, number)]', testData)).to.eq(testData.favorites);


### PR DESCRIPTION
The Google Enhanced Ecommerce ruleset and Event Measurement rulesets are very similar.  When used together, I think there a definite possibility we might record an event for each if an Enhanced Ecommerce hit fires.  The reason is that EM is essentially a superset of EC.  To better ignore EC events when also using the EM ruleset, I added a check that allows us to see if a property is/is not undefined.  This way we can check if `ecommerce` is defined in the event and if so, ignore it assuming the EC ruleset is also deployed.