### PR TITLE
String not equal bug

### DIFF
--- a/src/selector.ts
+++ b/src/selector.ts
@@ -396,7 +396,7 @@ class PathElement {
           // eslint-disable-next-line eqeqeq
           if (opProp.operator === '==' && prop[opProp.name] != opProp.value) return undefined;
           // eslint-disable-next-line eqeqeq
-          if (opProp.operator != '==' && prop[opProp.name] == opProp.value) return undefined;
+          if (opProp.operator == '!=' && prop[opProp.name] == opProp.value) return undefined;
           if (opProp.operator === '=^' && !prop[opProp.name].startsWith(opProp.value)) return undefined;
           if (opProp.operator === '!^' && prop[opProp.name].startsWith(opProp.value)) return undefined;
           break;

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -195,7 +195,7 @@ describe('test selection paths', () => {
     expect(select('favorites[?(color)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(bogus)]', testData)).to.be.undefined;
     expect(select('favorites[?(color=red)]', testData)).to.eq(testData.favorites);
-    expect(select('favorites[?(color=red)]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(color!=red)]', testData)).to.be.undefined;
     expect(select('favorites[?(dot.prop)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(dot.prop=1.0)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(dot.prop=2.0)]', testData)).to.be.undefined;


### PR DESCRIPTION
While doing #109 I happened to notice there was no `!=` for strings in `select`.  I also saw line 198 in the test looked like a copy/paste.  Wondering if `!=` has gone unnoticed as a bug.  @TrevorFSmith , does the previous line 399 jog any memory of why it doesn't conform to all the other if blocks.  This is the only one that used a `!=` comparison.  Feels out of place. 