### PR TITLE
add fix for undefined comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.4.5
+
+- Fix `undefined` comparisons for properties with defined values
+
+### 1.4.4
+
+- Bug fix in string `!=` comparison
+- Added `undefined` comparison
+
 ### 1.4.3
 
 - Expose logging level as config option `_dlo_logLevel`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,13 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
-### 1.4.5
+### 1.5.0
 
-- Fix `undefined` comparisons for properties with defined values
+- Added `=` and `!=` `undefined` comparison for object properties
 
 ### 1.4.4
 
 - Bug fix in string `!=` comparison
-- Added `undefined` comparison
 
 ### 1.4.3
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.4.5.js
+- https://edge.fullstory.com/datalayer/v1/1.5.0.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.4.3.js
+- https://edge.fullstory.com/datalayer/v1/1.4.5.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -417,6 +417,12 @@ class PathElement {
           // eslint-disable-next-line eqeqeq
           if (opProp.operator === '!=' && prop[opProp.name] == undefined) return undefined;
           break;
+        case 'object':
+          // eslint-disable-next-line eqeqeq
+          if (opProp.operator === '==' && prop[opProp.name] != undefined) return undefined;
+          // eslint-disable-next-line eqeqeq
+          if (opProp.operator === '!=' && prop[opProp.name] == undefined) return undefined;
+          break;
         default:
           throw new Error(Logger.format(LogMessage.SelectorSyntaxUnsupported, opProp.raw));
       }

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -264,7 +264,7 @@ describe('Google Tags to FullStory rules', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
-  it('should read any event but remove ecommerce and event ID', () => {
+  it('should read any event not containing ecommerce and remove event ID', () => {
     const observer = ExpectObserver.getInstance().create({
       rules: [
         getRule('fs-ga-event'),

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -202,6 +202,8 @@ describe('test selection paths', () => {
     expect(select('favorites[?(bogus=totally)]', testData)).to.be.undefined;
     expect(select('favorites[?(bogus=undefined)]', testData)).to.not.be.undefined;
     expect(select('favorites[?(bogus!=undefined)]', testData)).to.be.undefined;
+    expect(select('favorites[?(films=undefined)]', testData)).to.be.undefined;
+    expect(select('favorites[?(films!=undefined)]', testData)).to.not.be.undefined;
     expect(select('favorites[?(color, number)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(bogus, number)]', testData)).to.be.undefined;
     expect(select('favorites[?(color=red, number)]', testData)).to.eq(testData.favorites);


### PR DESCRIPTION
I found an issue with #109.  Originally the goal allowed you to check that a non-existent property is `undefined`.  There's, however, the possibility that you also need to check that a defined property is `undefined`.  I bumped the versions to do a new deploy too.

I think there's also some found work in the selector code related to error checking which comparison operators are valid.  For example, you could compare using `!^` with a number, which I *think* falls through the switch statements and passes.  I'll add a card to track, but I bring it up because the new `undefined` behavior expects you to use `!=` and `=` but doesn't enforce it.