### PR TITLE
Convert when spaces are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
-### 1.5.0
+### 1.5.1
 
 - Fix `convert` operator to trim spaces if a space separated CSV is supplied
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ### 1.5.0
 
+- Fix `convert` operator to trim spaces if a space separated CSV is supplied
+
+### 1.5.0
+
 - Added `=` and `!=` `undefined` comparison for object properties
 
 ### 1.4.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -68,7 +68,7 @@ export class ConvertOperator implements Operator {
     const { force, preserveArray, type } = this.options;
 
     if (typeof properties === 'string') {
-      properties = properties.split(',');
+      properties = properties.split(',').map((property) => property.trim()); // auto-correct if the CSV has spaces
     }
 
     // NOTE if * is supplied, convert all properties

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -47,7 +47,7 @@ describe('convert operator unit tests', () => {
     expect(() => new ConvertOperator({ name: 'convert', properties: 'quantity' }).validate())
       .to.throw();
     expect(() => new ConvertOperator({
-    // @ts-ignore
+      // @ts-ignore
       name: 'convert', properties: ['price', 'tax'], type: 'real', force: 1,
     }).validate())
       .to.throw();
@@ -139,6 +139,18 @@ describe('convert operator unit tests', () => {
     expect(int!.stock).to.eq(10);
     expect(quantity).to.eq('10'); // don't mutate the actual data layer
     expect(stock).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert space separated props', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity, stock', type: 'int' });
+    const { quantity, stock } = item;
+    const [int] = operator.handleData([{ quantity, stock }])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(quantity).to.eq('10');
+    expect(stock).to.eq('10');
   });
 
   it('it should not convert unsupported types', () => {


### PR DESCRIPTION
Quick fix for an issue found with `convert` operator and spaces in the property list.