### PR TITLE
Array push and unshift checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.5.2
+
+- Check if `push` and `unshift` exist in older browsers
+
 ### 1.5.1
 
 - Fix `convert` operator to trim spaces if a space separated CSV is supplied

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.5.0.js
+- https://edge.fullstory.com/datalayer/v1/1.5.2.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -237,11 +237,11 @@ export class DataLayerObserver {
     let workingTarget = target;
     const targetValue = workingTarget.value;
 
-    /*
-    * We do a bit of magic when monitoring an Array target.
-    * We create separate targets for the `push` and `unshift` methods.
-    */
-    if (monitor && Array.isArray(targetValue)) {
+    /**
+     * When the target is an Array, we create separate targets for the `push` and `unshift` methods.
+     * Some older browsers may not have these methods, so check before trying to shim.
+     */
+    if (monitor && Array.isArray(targetValue) && targetValue.push && targetValue.unshift) {
       this.registerTarget(DataLayerTarget.find(`${target.path}.unshift`), options, destination, false, true, debug);
       workingTarget = DataLayerTarget.find(`${target.path}.push`);
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -241,9 +241,18 @@ export class DataLayerObserver {
      * When the target is an Array, we create separate targets for the `push` and `unshift` methods.
      * Some older browsers may not have these methods, so check before trying to shim.
      */
-    if (monitor && Array.isArray(targetValue) && targetValue.push && targetValue.unshift) {
-      this.registerTarget(DataLayerTarget.find(`${target.path}.unshift`), options, destination, false, true, debug);
-      workingTarget = DataLayerTarget.find(`${target.path}.push`);
+    if (monitor && Array.isArray(targetValue)) {
+      if (targetValue.push && targetValue.unshift) {
+        this.registerTarget(DataLayerTarget.find(`${target.path}.unshift`), options, destination, false, true, debug);
+        workingTarget = DataLayerTarget.find(`${target.path}.push`);
+      } else {
+        Logger.getInstance().warn(LogMessageType.MonitorCreateError, {
+          path: workingTarget.path,
+          property: workingTarget.property,
+          selector: workingTarget.selector,
+          reason: 'Browser does not support push and unshift',
+        });
+      }
     }
 
     const handler = this.addHandler(workingTarget, !!debug);

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -568,6 +568,8 @@ describe('DataLayerObserver unit tests', () => {
     expect(globalMock.dataLayer.length).to.eq(0);
     expect(globalMock.console.error.length).to.eq(0);
     expect(globalMock.console.warn.length).to.eq(0);
+    expect(observer.handlers.length).to.eq(1);
+
     ExpectObserver.getInstance().cleanup(observer);
   });
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -544,6 +544,33 @@ describe('DataLayerObserver unit tests', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
+  it('missing push and unshift in older browsers should not error', () => {
+    // @ts-ignore
+    globalMock.dataLayer.push = undefined;
+    // @ts-ignore
+    globalMock.dataLayer.unshift = undefined;
+
+    expect(globalMock.dataLayer.push).to.be.undefined;
+    expect(globalMock.dataLayer.unshift).to.be.undefined;
+
+    const observer = ExpectObserver.getInstance().create({
+      rules: [
+        {
+          source: 'dataLayer',
+          operators: [],
+          destination: 'console.log',
+          readOnLoad: false,
+        },
+      ],
+    }, true);
+
+    expect(globalMock.dataLayer).to.not.be.undefined;
+    expect(globalMock.dataLayer.length).to.eq(0);
+    expect(globalMock.console.error.length).to.eq(0);
+    expect(globalMock.console.warn.length).to.eq(0);
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
   it('a developer can programmatically observe an object by reference', (done) => {
     let changes: any[] = [];
 


### PR DESCRIPTION
This PR adds checks on `push` and `unshift` and closes #106.  Older browsers fail to have these functions. 