### PR TITLE
Add enumerate feature to convert operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.6.0
+
+- `enumerate` option added to `convert` operator
+- Tealium sample updated to use `enumerate` option
+- Added `order_` property selector to Tealium sample
+
 ### 1.5.2
 
 - Check if `push` and `unshift` exist in older browsers

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.5.2.js
+- https://edge.fullstory.com/datalayer/v1/1.6.0.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/docs/operator_convert.md
+++ b/docs/operator_convert.md
@@ -6,10 +6,11 @@ Convert is most useful when paired with `FS.event` for cart and checkout events 
 
 ## Options
 
-Options with an asterisk are required.
+Options with an asterisk are required. Note that `enumerate` can be used by itself or with `properties`.
 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
+| `enumerate`* | `boolean` | `false` | Automatically converts all string values into their numeric equivalent. |
 | `force` | `boolean` | `false` | If the property is undefined or has value `null`, forcibly add the property with value `0`, `0.0`,`false` or empty string. |
 | `index` | `number` | `0` | Position of the object to convert in the operator input list. |
 | `preserveArray` | `boolean` | `false` | If the conversion value is a list, keep the array type even if the array has a single value. |
@@ -27,8 +28,11 @@ Options with an asterisk are required.
 ```javascript
 {
  source: 'digitalData.cart.price',
- operators: [ { name: 'convert', properties: 'basePrice,taxRate,shipping,priceWithTax,cartTotal', type: 'real' } ],
- destination: 'FS.identify'
+ operators: [
+   { name: 'convert', properties: 'basePrice,taxRate,shipping,priceWithTax,cartTotal', type: 'real' },
+   { name: 'insert', value: 'Product Viewed' },
+ ],
+ destination: 'FS.event'
 }
 ```
 
@@ -54,6 +58,7 @@ Options with an asterisk are required.
 
 ```javascript
 [
+ 'Product Viewed',
  {
   basePrice: 15.55,
   voucherCode: '',
@@ -68,15 +73,18 @@ Options with an asterisk are required.
 ]
 ```
 
-## Converting all cart prices
+## Automatically convert all "numeric" strings
 
 ### Rule
 
 ```javascript
 {
- source: 'digitalData.cart.price[(basePrice,cartTotal,priceWithTax)]',
- operators: [ { name: 'convert', properties: '*', type: 'real' } ],
- destination: 'FS.identify'
+ source: 'digitalData.cart.price[(available,basePrice,cartTotal,priceWithTax)]',
+ operators: [
+   { name: 'convert', enumerate: true },
+   { name: 'insert', value: 'Product Viewed' },
+ ],
+ destination: 'FS.event'
 }
 ```
 
@@ -85,6 +93,7 @@ Options with an asterisk are required.
 ```javascript
 [
  {
+  available: 'false',
   basePrice: '15.55',
   priceWithTax: '16.95',
   cartTotal: '21.95',
@@ -96,7 +105,51 @@ Options with an asterisk are required.
 
 ```javascript
 [
+ 'Product Viewed',
  {
+  available: 'false',
+  basePrice: 15.55,
+  priceWithTax: 16.95,
+  cartTotal: 21.95,
+ }
+]
+```
+
+## Convert "numeric" strings with specific property conversions
+
+### Rule
+
+```javascript
+{
+ source: 'digitalData.cart.price[(basePrice,cartTotal,priceWithTax,available)]',
+ operators: [
+   { name: 'convert', enumerate: true, properties: 'available', type: 'bool' },
+   { name: 'insert', value: 'Product Viewed' },
+ ],
+ destination: 'FS.event'
+}
+```
+
+### Input
+
+```javascript
+[
+ {
+  available: 'false',
+  basePrice: '15.55',
+  priceWithTax: '16.95',
+  cartTotal: '21.95',
+ }
+]
+```
+
+### Output
+
+```javascript
+[
+ 'Product Viewed',
+ {
+   available: false,
   basePrice: 15.55,
   priceWithTax: 16.95,
   cartTotal: 21.95,

--- a/examples/rules/tealium-fullstory.json
+++ b/examples/rules/tealium-fullstory.json
@@ -3,7 +3,7 @@
     {
       "id": "fs-tealium-event",
       "description": "Send Tealium data (except for customer personal details) for FS.event. See https://community.tealiumiq.com/t5/Data-Layer/Data-Layer-Definition-Retail/ta-p/17227.",
-      "source": "utag.data[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,search_,site_,tealium_event)]",
+      "source": "utag.data[^(brand_,browse_,cart_,category_,customer_,language_,order_,page_,product_,search_,site_,tealium_event)]",
       "operators": [
         {
           "name": "query",
@@ -15,13 +15,7 @@
         },
         {
           "name": "convert",
-          "properties": "cart_product_quantity,cart_total_items,product_quantity,search_results",
-          "type": "int"
-        },
-        {
-          "name": "convert",
-          "properties": "cart_product_price,cart_total_value,order_discount_amount,order_merchandise_total,order_shipping_amount,order_subtotal,order_tax_amount,order_total,product_discount_amount,product_original_price,product_price",
-          "type": "real"
+          "enumerate": true
         },
         {
           "name": "insert",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -26,7 +26,7 @@ export class ConvertOperator implements Operator {
     force: { required: false, type: ['boolean'] },
     index: { required: false, type: ['number'] },
     preserveArray: { required: false, type: ['boolean'] },
-    properties: { required: false, type: ['string,object'] }, // NOTE an typeof array is object
+    properties: { required: false, type: ['string,object'] }, // NOTE typeof array is object
     type: { required: false, type: ['string'] },
   };
 

--- a/test/fullstory.spec.ts
+++ b/test/fullstory.spec.ts
@@ -559,6 +559,8 @@ describe('Tealium to FullStory rules', () => {
     const [id, payload] = expectParams(globalMock.FS, 'event');
     expect(id).to.eq('product_view');
     expect(payload.product_id).to.eql(tealiumRetail.product_id);
+    expect(payload.order_total).to.eql(54.47);
+    expect(payload.product_discount_amount).to.eql(2.98); // NOTE list reduced to single value
     expect(payload.customer_first_name).to.be.undefined;
     expect(payload.customer_last_name).to.be.undefined;
     expect(payload.customer_email).to.be.undefined;
@@ -582,7 +584,7 @@ describe('Tealium to FullStory rules', () => {
     setTimeout(() => {
       const [id, payload] = expectParams(globalMock.FS, 'event');
       expect(id).to.eq('product_view');
-      expect(payload.product_id).to.eql(['PROD789']);
+      expect(payload.product_id).to.eql('PROD789');
     }, DataHandler.debounceTime * 1.5);
 
     // NOTE this is an invalid property to monitor because it is not picked

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -4,6 +4,7 @@ import { MockClass, Call } from '../mocks/mock';
 import { DataLayerDetail } from '../../src/event';
 import { DataLayerObserver, DataLayerConfig } from '../../src/observer';
 import MonitorFactory from '../../src/monitor-factory';
+import { BuiltinOptions, OperatorFactory } from '../../src/factory';
 
 /**
  * Tests whether a call queue has one Call and returns it.
@@ -165,4 +166,25 @@ export class ExpectObserver {
 
     return ExpectObserver.instance;
   }
+}
+
+/**
+ * Expects an Operator's options to be valid.
+ * @param options The OperatorOptions passed to the Operator
+ * @param message An optional message that describes the use case of options
+ */
+export function expectValid(options: BuiltinOptions, message?: string) {
+  const { name } = options;
+  expect(() => OperatorFactory.create(name, options).validate(), message).to.not.throw();
+}
+
+/**
+ * Expects an Operator's options to be invalid.
+ * @param operatorName The Operator's name
+ * @param options The OperatorOptions passed to the Operator
+ * @param message An optional message that describes the use case of options
+ */
+export function expectInvalid(options: BuiltinOptions, message?: string) {
+  const { name } = options;
+  expect(() => OperatorFactory.create(name, options).validate(), message).to.throw();
 }


### PR DESCRIPTION
This PR addresses a few issues seen with Tealium users.
- The sample rule needs frequent updates to convert strings to numbers
- `order_` information was not included in the original sample
- The `convert` operator could do a better job of intelligently converting to numbers

An `enumerate` option was added to `convert`.  The intent is that if specified, `convert` will try to automatically convert strings to numbers.  There was a fair amount of cleanup needed in convert, and I broke the handler into stages:
- Enumerate any strings if desired
- Convert any additional properties specifically
- Reduce any single item arrays to a single value if needed

Two test utility methods `expectValid` and `expectInvalid` were added to make the validate tests more legible.  (We should refactor other tests later).