### PR TITLE
Change logger source name

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -84,7 +84,7 @@ export class FullStoryAppender implements LogAppender {
     const fs = (window as any)[(window as any)._fs_namespace]; // eslint-disable-line no-underscore-dangle
 
     const customEventName = 'Data Layer Observer';
-    const customEventSource = 'dlo_log';
+    const customEventSource = 'dlo-log';
 
     if (fs) {
       /* eslint-disable camelcase */

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -84,7 +84,7 @@ export class FullStoryAppender implements LogAppender {
     const fs = (window as any)[(window as any)._fs_namespace]; // eslint-disable-line no-underscore-dangle
 
     const customEventName = 'Data Layer Observer';
-    const customEventSource = 'dlo';
+    const customEventSource = 'dlo_log';
 
     if (fs) {
       /* eslint-disable camelcase */

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -65,7 +65,7 @@ describe('logger unit tests', () => {
     expect(event.context.path).to.eq(context.path);
     expect(event.context.selector).to.eq(context.selector);
     expect(event.context.source).to.eq(context.source);
-    expect(source).to.eq('dlo');
+    expect(source).to.eq('dlo-log');
 
     logger.info('Data layer rules loaded', context);
     expectNoCalls((window as any).FS, 'event');


### PR DESCRIPTION
I have an in-flight PR that adds `dlo` as the source param to souq rules.  I'm changing the `FullStoryAppender`'s source name to be `dlo_log` to better differentiate between "real" data layer events and log-generated events.