### PR TITLE
add suffix bug fix and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.6.1
+
+- Fix incorrect suffix behavior when using FS.event source parameter
+- FullStoryAppender logger source updated to `dlo-log`
+
 ### 1.6.0
 
 - `enumerate` option added to `convert` operator

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.6.0.js
+- https://edge.fullstory.com/datalayer/v1/1.6.1.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -160,7 +160,13 @@ export class SuffixOperator implements Operator {
   }
 
   handleData(data: any[]): any[] | null {
-    const index = this.index >= 0 ? this.index : data.length + this.index;
+    let index = this.index >= 0 ? this.index : data.length + this.index;
+
+    // check if the `source` param was included and if so decrement the index
+    if (typeof data[index] === 'string') {
+      index -= 1;
+    }
+
     const suffixedData = data;
     suffixedData[index] = this.mapToSuffix(suffixedData[index]);
 

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -262,4 +262,14 @@ describe('suffix operator unit test', () => {
     expect(eventName).to.eq('Message Event');
     expect(suffixedObject.message_str).to.eq(message);
   });
+
+  it('it should account for FS.event source param usage', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [eventName, suffixedObject, source] = operator.handleData(['event', testData, 'mocha'])!;
+    expect(eventName).to.eq('event');
+    expect(source).to.eq('mocha');
+    expect(suffixedObject.id_str).to.not.be.undefined;
+  });
 });


### PR DESCRIPTION
This PR fixes a bug where an `FS` API includes the `source` param.  Previously, the suffix operator expected that the object to suffix was last in the list of args.  Adding the `source` param changes that assumption. The suffix operator succeeds but sends malformed data to FullStory.  This results in FullStory rejecting the event with [Expected Atom](https://help.fullstory.com/hc/en-us/articles/360020624394-Troubleshooting-Recording-Client-API-FS-event-FS-setUserVars-and-FS-identify-errors#expectedAtom) errors.