### PR TITLE
Initialize the logger early in the embed script 

### DIFF
--- a/src/embed/init.ts
+++ b/src/embed/init.ts
@@ -83,6 +83,12 @@ function _dlo_initializeFromWindow() {
     const startTime = Date.now();
     const win = (window as { [key: string]: any });
 
+    /*
+    This is called so that custom appenders (e.g. 'fullstory') are initialized early enough
+    to correctly log initialization errors and recorded stats
+    */
+    Logger.getInstance(win._dlo_appender);
+
     if (win._dlo_observer) {
       Logger.getInstance().warn(LogMessageType.ObserverMultipleLoad);
       return;


### PR DESCRIPTION
In embed, the Logger needs to be initialized with the custom appended (`fullstory`) so that stats and early failures are correctly appended.