### PR TITLE
Fix data layer side effect from flatten operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.6.3
+
+- Fix `flatten` operator bug related to mutating objects in list-based data layers
+
 ### 1.6.2
 
 - Fix `console.error` messages related to logging appender

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.6.2.js
+- https://edge.fullstory.com/datalayer/v1/1.6.3.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -157,3 +157,20 @@ export interface Operator {
    */
   validate(): void;
 }
+
+/**
+ * Some Operators transform the content or shape of data. To prevent side effects (i.e. changes) to the data layer,
+ * additional care is needed. This function performs safe insertion of an object in a list. This allows you to take
+ * an existing list of data passed to an operator and insert a new object at a given index, which prevents overwriting
+ * or changing the original object in the list. Note that all objects at other indexes will still reference their
+ * original counterparts. (This is not a deep copy.)
+ * @param list Array of data objects passed to an Operator
+ * @param index Numeric index in the `list` array to update
+ * @param object Object to insert at the given index (the original object at the index will be unchanged)
+ * @returns A copy of the list with the new object inserted
+ */
+export function safeUpdate(list: any[], index: number, object: any): any[] {
+  const clone = list.slice();
+  clone.splice(index, 1, object);
+  return clone;
+}

--- a/src/operators/flatten.ts
+++ b/src/operators/flatten.ts
@@ -49,10 +49,11 @@ export class FlattenOperator implements Operator {
   }
 
   handleData(data: any[]): any[] | null {
-    const flattenedData = data;
-    flattenedData[this.index] = this.flattenHelper(flattenedData[this.index]);
+    const flattened = this.flattenHelper(data[this.index]);
 
-    return flattenedData;
+    const clone = data.slice();
+    clone.splice(this.index, 1, flattened);
+    return clone;
   }
 
   validate() {

--- a/src/operators/flatten.ts
+++ b/src/operators/flatten.ts
@@ -1,4 +1,7 @@
-import { Operator, OperatorOptions, OperatorValidator } from '../operator';
+/* eslint no-param-reassign: ["error", { "props": false }] */
+import {
+  Operator, OperatorOptions, OperatorValidator, safeUpdate,
+} from '../operator';
 
 export interface FlattenOperatorOptions extends OperatorOptions {
 
@@ -22,38 +25,33 @@ export class FlattenOperator implements Operator {
   }
 
   /**
-   * Recursively flattens all properties into an object.
-   * @param root the root object to contain all properties
-   * @param node a child node to flatten
+   * Recursively flattens (copies) all properties into an object at a single level.
+   * @param target Object to copy properties into
+   * @param source Object that is the source containing properties (during recursive calls these are child objects under a root object)
    */
-  flattenHelper(root: any, depth = 0, node?: any) {
-    let targetNode = node;
-    let targetRoot = root;
-
-    if (!targetNode) {
-      // first time execution
-      targetNode = root;
-      targetRoot = {};
-    }
-
-    Object.getOwnPropertyNames(targetNode).forEach((prop) => {
-      if (typeof targetNode[prop] === 'object' && targetNode[prop] != null
-        && !Array.isArray(targetNode[prop]) && depth < this.maxDepth + 1) {
-        this.flattenHelper(targetRoot, depth + 1, targetNode[prop]);
+  flattenHelper(target: any, source: any, depth = 0) {
+    Object.getOwnPropertyNames(source).forEach((prop) => {
+      if (typeof source[prop] === 'object' && source[prop] != null
+        && !Array.isArray(source[prop]) && depth < this.maxDepth + 1) {
+        this.flattenHelper(target, source[prop], depth + 1);
       } else {
-        targetRoot[prop] = targetNode[prop];
+        target[prop] = source[prop];
       }
     });
-
-    return targetRoot;
   }
 
   handleData(data: any[]): any[] | null {
-    const flattened = this.flattenHelper(data[this.index]);
+    // NOTE this operator transforms data - be absolutely sure there are no side effects to the data layer!
 
-    const clone = data.slice();
-    clone.splice(this.index, 1, flattened);
-    return clone;
+    // flattening copies key value pairs from the source to the target
+    // the target is a new empty object so that the flattening process does not affect the data layer
+    const target = {};
+    const source = data[this.index];
+    this.flattenHelper(target, source);
+
+    // a copy of the incoming data layer needs to be returned
+    // if you modify/update the `data` parameter directly, you may modify the data layer!
+    return safeUpdate(data, this.index, target);
   }
 
   validate() {

--- a/src/operators/insert.ts
+++ b/src/operators/insert.ts
@@ -52,6 +52,8 @@ export class InsertOperator implements Operator {
       throw new Error('Failed to find a value to insert');
     }
 
+    // a copy of the incoming data layer needs to be returned
+    // if you modify/update the `data` parameter directly, you may modify the data layer!
     const clone = data.slice();
     clone.splice(this.position >= 0 ? this.position : clone.length - this.position, 0, insertedValue);
 

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -1,4 +1,6 @@
-import { OperatorValidator, OperatorOptions, Operator } from '../operator';
+import {
+  OperatorValidator, OperatorOptions, Operator, safeUpdate,
+} from '../operator';
 
 /**
  * A SuffixedObject is an object that has had FS types appended to properties.
@@ -160,6 +162,8 @@ export class SuffixOperator implements Operator {
   }
 
   handleData(data: any[]): any[] | null {
+    // NOTE this operator transforms data - be absolutely sure there are no side effects to the data layer!
+
     let index = this.index >= 0 ? this.index : data.length + this.index;
 
     // check if the `source` param was included and if so decrement the index
@@ -167,10 +171,11 @@ export class SuffixOperator implements Operator {
       index -= 1;
     }
 
-    const suffixedData = data;
-    suffixedData[index] = this.mapToSuffix(suffixedData[index]);
+    const suffixed = this.mapToSuffix(data[index]);
 
-    return suffixedData;
+    // a copy of the incoming data layer needs to be returned
+    // if you modify/update the `data` parameter directly, you may modify the data layer!
+    return safeUpdate(data, index, suffixed);
   }
 
   validate() {

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -51,6 +51,16 @@ describe('convert operator unit tests', () => {
     }, 'force not supported on date');
   });
 
+  it('it should not change the original object', () => {
+    const list = [item];
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'int' });
+    const [int] = operator.handleData(list)!;
+
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+  });
+
   it('it should convert to int', () => {
     const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'int' });
     const [int] = operator.handleData([item])!;

--- a/test/operator-flatten.spec.ts
+++ b/test/operator-flatten.spec.ts
@@ -19,6 +19,26 @@ describe('flatten operator unit tests', () => {
     }).validate()).to.not.throw();
   });
 
+  it('it should not change the original object', () => {
+    const userProfile = basicDigitalData.user.profile[0];
+    const originalJson = JSON.stringify(userProfile);
+
+    const operator = new FlattenOperator({ name: 'flatten' });
+    const [flatUser] = operator.handleData([userProfile])!;
+
+    expect(flatUser).to.not.be.null;
+    expect(originalJson).to.eq(JSON.stringify(userProfile));
+
+    const [flatListUser] = operator.handleData(basicDigitalData.user.profile)!;
+    expect(basicDigitalData.user.profile[0].address).to.not.be.undefined;
+    expect(flatListUser.address).to.be.undefined;
+
+    const customList = [{ event: 'test', data: { foo: 'bar' } }];
+    const [flatData] = operator.handleData(customList)!;
+    expect(customList[0].data).to.not.be.undefined;
+    expect(flatData.data).to.be.undefined;
+  });
+
   it('it should flatten an object', () => {
     const userProfile = basicDigitalData.user.profile[0];
     const operator = new FlattenOperator({ name: 'flatten' });

--- a/test/operator-rename.spec.ts
+++ b/test/operator-rename.spec.ts
@@ -39,6 +39,24 @@ describe('rename operator unit tests', () => {
     ).validate()).to.throw();
   });
 
+  it('it should not change the original object', () => {
+    const operator = OperatorFactory.create(
+      'rename',
+      {
+        name: 'rename-test',
+        properties: {
+          data: 'datum',
+        },
+      },
+    );
+
+    const customList = [{ event: 'test', data: { foo: 'bar' } }];
+    const [flatData] = operator.handleData(customList)!;
+    expect(customList[0].data).to.not.be.undefined;
+    expect(flatData.data).to.be.undefined;
+    expect(flatData.datum).to.be.not.undefined;
+  });
+
   it('should rename properties', () => {
     const operator = OperatorFactory.create(
       'rename',

--- a/test/operator-rename.spec.ts
+++ b/test/operator-rename.spec.ts
@@ -51,10 +51,10 @@ describe('rename operator unit tests', () => {
     );
 
     const customList = [{ event: 'test', data: { foo: 'bar' } }];
-    const [flatData] = operator.handleData(customList)!;
+    const [renamedData] = operator.handleData(customList)!;
     expect(customList[0].data).to.not.be.undefined;
-    expect(flatData.data).to.be.undefined;
-    expect(flatData.datum).to.be.not.undefined;
+    expect(renamedData.data).to.be.undefined;
+    expect(renamedData.datum).to.be.not.undefined;
   });
 
   it('should rename properties', () => {

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -55,6 +55,20 @@ describe('suffix operator unit test', () => {
     }).validate()).to.not.throw();
   });
 
+  it('it should not change the original object', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    const customList = [{ event: 'test', data: { foo: 'bar' } }];
+    const [suffixedData] = operator.handleData(customList)!;
+    expect(suffixedData.event_str).to.not.be.undefined;
+    expect(suffixedData.data_obj.foo_str).to.not.be.undefined;
+    expect(customList[0].event).to.not.be.undefined;
+    expect(customList[0].data.foo).to.not.be.undefined;
+    // @ts-ignore
+    expect(customList[0].event_str).to.be.undefined;
+    // @ts-ignore
+    expect(customList[0].data_obj).to.be.undefined;
+  });
+
   it('it should not suffix undefineds', () => {
     const operator = new SuffixOperator({ name: 'suffix' });
     expect(operator).to.not.be.undefined;


### PR DESCRIPTION
This PR fixes an issue where the flatten operator unintentionally updates the data layer.  The issue was due to assignment of new data to a shallow reference.  Flatten is an older operator, and it did not have the convention seen in more recent operators:

```
const clone = data.slice();
clone.splice(this.index, 1, flattened);
return clone;
``` 

I added additional test cases to the `flatten.spec.ts` and carried over the same test to two other specs (`convert.spec.ts` and `rename.spec.ts`) just to confirm they also did not have a similar bug.  No problems were found with these operators, and the convert operator has numerous checks for data layer side effects.