### PR TITLE
Undefined empty events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.6.4
+
+- Move `EmptyEvent` scenario from log level `warn` to `debug`
+
 ### 1.6.3
 
 - Fix `flatten` operator bug related to mutating objects in list-based data layers

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.6.3.js
+- https://edge.fullstory.com/datalayer/v1/1.6.4.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -53,7 +53,9 @@ export default class DataHandler {
     const { path } = this.target;
 
     if (value === undefined && args === undefined) {
-      Logger.getInstance().warn(LogMessageType.EventEmpty, { path });
+      // NOTE it seems some data layers may "clear" values by setting a property to undefined
+      // in one case, thousands of these calls lead to performance impacts so debug was chosen versus warn
+      Logger.getInstance().debug(LogMessageType.EventEmpty, { path });
     } else if (type === createEventType(path)) {
       if (value) {
         // debounce events so multiple, related property assignments don't create multiple events


### PR DESCRIPTION
Normally, a data layer event where the observed changed was `undefined` triggered a warning log message.  This was designed to signal that a possible DLO bug was present.  It appears that there may be data layers where `undefined` is assigned to an observed property as a way to "clear" variables in the data layer.  This may be done at a high volume in which case, `warn` is undesirable because it could cause rate limiting.  This PR moves the log level from `warn` to `debug` to allow this scenario while still retaining the ability to know when an undefined assignment is occurring.