### PR TITLE
Suffix Corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.6.4.js
+- https://edge.fullstory.com/datalayer/v1/1.6.5.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -2,6 +2,8 @@
 
 The suffix operator can be used to automatically apply the appropriate type suffix to properties in an object.  Since the suffix operator is useful for every `FS` API, it is included as the default `window['_dlo_beforeDestination']` configuration option and is not needed in the `operators` list.
 
+To support FullStory-specific APIs, the properties `displayName`, `pageName`, and `email` are not suffixed in a root object.
+
 ## Options
 
 Options with an asterisk are required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -69,6 +69,7 @@ export class SuffixOperator implements Operator {
 
   /**
    * Infers the type suffix needed for FS API objects.
+   * Returns `null` if the value is not supported and thus unable to be suffixed.
    * There are 10 valid type suffixes:
    * _bool, _date, _int, _real, _str, _bools, _dates, _ints, _reals, and _strs.
    * @param value the object to inspect and return suffix

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -79,6 +79,37 @@ describe('suffix operator unit test', () => {
     expect(Object.getOwnPropertyNames(suffixedObject).length).to.eq(0);
   });
 
+  it('it should not suffix required FullStory naming conventions', () => {
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([{
+      pageName: 'homepage',
+      displayName: 'Data Layer Observer',
+      email: 'dlo@fullstory.com',
+      child: {
+        pageName: 'homepage',
+        displayName: 'Data Layer Observer',
+        email: 'dlo@fullstory.com',
+      },
+    }])!;
+
+    expect(suffixedObject).to.not.be.undefined;
+    expect(suffixedObject.pageName).to.not.be.undefined;
+    expect(suffixedObject.pageName_str).to.be.undefined;
+    expect(suffixedObject.displayName).to.not.be.undefined;
+    expect(suffixedObject.displayName_str).to.be.undefined;
+    expect(suffixedObject.email).to.not.be.undefined;
+    expect(suffixedObject.email_str).to.be.undefined;
+
+    expect(suffixedObject.child_obj.pageName).to.be.undefined;
+    expect(suffixedObject.child_obj.pageName_str).to.not.be.undefined;
+    expect(suffixedObject.child_obj.displayName).to.be.undefined;
+    expect(suffixedObject.child_obj.displayName_str).to.not.be.undefined;
+    expect(suffixedObject.child_obj.email).to.be.undefined;
+    expect(suffixedObject.child_obj.email_str).to.not.be.undefined;
+  });
+
   it('it should suffix all properties in object', () => {
     const operator = new SuffixOperator({ name: 'suffix' });
     expect(operator).to.not.be.undefined;


### PR DESCRIPTION
The new page vars API was not allowing us to set the `pageName` correctly because we by default auto-suffix all properties.  When the property was set to `pageName_str`, FullStory did not correctly infer the page name because it is specifically looking for `pageName`.  Adjustments were made to `displayName` and `email` as well.