### PR TITLE
Allow more than one operator for beforeDestination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ### 1.7.0
 
-- Update `beforeDestination` to accept a list allowing multiple operators to execute
+- Updated `beforeDestination` to accept a list allowing multiple operators to execute
+- Updated `convert` operator to accept negative `index` (read from end of a data list)
 
 ### 1.6.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.7.0
+
+- Update `beforeDestination` to accept a list allowing multiple operators to execute
+
 ### 1.6.5
 
 - Adjusted suffixing behavior for `pageName`, `displayName`, and `email` to support FS APIs

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.6.5.js
+- https://edge.fullstory.com/datalayer/v1/1.7.0.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add Data Layer Observer to your web site or web app by including the following s
 ```html
 <script>
  window['_dlo_appender'] = 'fullstory';
- window['_dlo_beforeDestination'] = { name: 'suffix' };
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;     // set to false in production to send data to the destination
  window['_dlo_readOnLoad'] = true;      // see docs on usage
  window['_dlo_validateRules'] = true;
@@ -72,7 +72,7 @@ DLO is configurable by adding relevant options as `window` properties to the pag
 
 ```html
 <script>
- window['_dlo_beforeDestination'] = { name: 'suffix' };
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;
  window['_dlo_readOnLoad'] = true;
  window['_dlo_validateRules'] = true;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add Data Layer Observer to your web site or web app by including the following s
 ```html
 <script>
  window['_dlo_appender'] = 'fullstory';
- window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true },{ name: 'suffix' }];
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, index: -1 },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;     // set to false in production to send data to the destination
  window['_dlo_readOnLoad'] = true;      // see docs on usage
  window['_dlo_validateRules'] = true;
@@ -72,7 +72,7 @@ DLO is configurable by adding relevant options as `window` properties to the pag
 
 ```html
 <script>
- window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true },{ name: 'suffix' }];
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, index: -1 },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;
  window['_dlo_readOnLoad'] = true;
  window['_dlo_validateRules'] = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -26,7 +26,7 @@ import MonitorFactory from './monitor-factory';
  */
 export interface DataLayerConfig {
   appender?: string | LogAppender;
-  beforeDestination?: OperatorOptions;
+  beforeDestination?: OperatorOptions | OperatorOptions[];
   logLevel?: LogLevel;
   previewDestination?: string;
   previewMode?: boolean;
@@ -173,7 +173,8 @@ export class DataLayerObserver {
       // optionally perform a final transformation
       // useful if every rule needs the same operator run before the destination
       if (beforeDestination) {
-        handler.push(this.getOperator(beforeDestination));
+        const beforeOptions = Array.isArray(beforeDestination) ? beforeDestination : [beforeDestination];
+        beforeOptions.forEach((operator) => handler.push(this.getOperator(operator)));
       }
 
       // end with destination

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -210,14 +210,17 @@ export class ConvertOperator implements Operator {
         : !Number.isNaN((newValue as Date).getTime());
     }
 
-    // log warning and reset to the original value
+    // Note `debug` level is used because `enumerate` may always be done `beforeDestination`, which could generate
+    // a lot of false positives
+    // log debug and reset to the original value
     if (!verified) {
-      Logger.getInstance().warn(LogMessageType.OperatorError, {
+      newMap[property] = oldValue; // eslint-disable-line no-param-reassign
+
+      Logger.getInstance().debug(LogMessageType.OperatorError, {
         operator: 'convert',
         property: property.toString(),
         reason: `Failed to convert to ${type} for value ${oldValue}`,
       });
-      newMap[property] = oldValue; // eslint-disable-line no-param-reassign
     }
   }
 }

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -319,8 +319,7 @@ describe('DataLayerObserver unit tests', () => {
   it('it should register and call an operator before the destination', () => {
     expectNoCalls(globalMock.console, 'log');
 
-    // backwards compatibility test of a single operator
-    let observer = ExpectObserver.getInstance().create({ beforeDestination: { name: 'toUpper' }, rules: [] });
+    const observer = ExpectObserver.getInstance().create({ beforeDestination: { name: 'toUpper' }, rules: [] });
 
     observer.registerOperator('toUpper', new UppercaseOperator());
     observer.registerRule({
@@ -334,17 +333,16 @@ describe('DataLayerObserver unit tests', () => {
 
     observer.handlers[0].fireEvent();
 
-    let [category] = expectParams(globalMock.console, 'log');
+    const [category] = expectParams(globalMock.console, 'log');
     expect((category as PageCategory).primaryCategory).to.eq(
       globalMock.digitalData.page.category.primaryCategory.toUpperCase(),
     );
 
     ExpectObserver.getInstance().cleanup(observer);
+  });
 
-    expectNoCalls(globalMock.console, 'log');
-
-    // test multiple operators
-    observer = ExpectObserver.getInstance().create({
+  it('it should register and call multiple operators before the destination', () => {
+    const observer = ExpectObserver.getInstance().create({
       beforeDestination: [
         { name: 'toUpper' },
         { name: 'suffix' }, // NOTE suffix is a built-in operator
@@ -364,7 +362,7 @@ describe('DataLayerObserver unit tests', () => {
 
     observer.handlers[0].fireEvent();
 
-    [category] = expectParams(globalMock.console, 'log');
+    const [category] = expectParams(globalMock.console, 'log');
     expect(category.primaryCategory_str).to.eq(
       globalMock.digitalData.page.category.primaryCategory.toUpperCase(),
     );

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -365,8 +365,7 @@ describe('DataLayerObserver unit tests', () => {
     observer.handlers[0].fireEvent();
 
     [category] = expectParams(globalMock.console, 'log');
-    // @ts-ignore suffixed non-standard property name
-    expect((category as PageCategory).primaryCategory_str).to.eq(
+    expect(category.primaryCategory_str).to.eq(
       globalMock.digitalData.page.category.primaryCategory.toUpperCase(),
     );
 

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -355,4 +355,17 @@ describe('convert operator unit tests', () => {
     expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
     expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
   });
+
+  it('it should convert from the end of a list', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'quantity', type: 'int', index: -1,
+    });
+    const [eventName, int] = operator.handleData(['track', item])!;
+
+    expect(eventName).to.eql('track');
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(int.size).to.eq(5); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+  });
 });


### PR DESCRIPTION
This feature has been on the backlog for a while re: #108 .  It's become more clear that there's a need for multiple, required operators to support FullStory use cases: suffixing, adding the `source` param, and now auto-converting strings to numbers using the `enumerate: true` feature of the `convert` function.

So what I've done is updated the `beforeDestination` feature to take a list of always-executed operators prior to calling the `destination` function.  This change will support more concise configuration such as `{window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true }, { name: 'suffix' },  { name: 'insert', value: 'dlo', index: -1 }]`.

For completeness, it's worth doing some level of performance analysis to see what an "always on" auto-conversion yields.  I'll do that prior to merging but wanted to show where things are headed.