### PR TITLE
Increased logging visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.7.1
+
+- Additional log messages when adding operators
+
 ### 1.7.0
 
 - Updated `beforeDestination` to accept a list allowing multiple operators to execute

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.7.0.js
+- https://edge.fullstory.com/datalayer/v1/1.7.1.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -182,6 +182,7 @@ export class DataLayerObserver {
       handler.push(new FunctionOperator({ name: 'function', func }));
     } catch (err) {
       this.removeHandler(handler);
+      Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
       throw err;
     }
   }
@@ -192,15 +193,20 @@ export class DataLayerObserver {
    * @throws an Error if the `validateRules` setting is true and the `options` are invalid
    */
   private getOperator(options: OperatorOptions) {
-    const { name } = options;
-    const operator = this.customOperators[name] ? this.customOperators[name]
-      : OperatorFactory.create(name, options as BuiltinOptions);
+    try {
+      const { name } = options;
+      const operator = this.customOperators[name] ? this.customOperators[name]
+        : OperatorFactory.create(name, options as BuiltinOptions);
 
-    if (this.config.validateRules) {
-      operator.validate();
+      if (this.config.validateRules) {
+        operator.validate();
+      }
+
+      return operator;
+    } catch (err) {
+      Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
+      throw err;
     }
-
-    return operator;
   }
 
   /**


### PR DESCRIPTION
I've seen an uptick in error logs that indicate the `name` property is missing from operator options.  I can't understand how that's happening so I've added additional logging to print the raw operator that gets passed into configuration.