### PR TITLE
Fix read on load for rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.7.2
+
+- Fix to allow rule-specific `readOnLoad` to override global `readOnLoad`
+
 ### 1.7.1
 
 - Additional log messages when adding operators

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/1.7.1.js
+- https://edge.fullstory.com/datalayer/v1/1.7.2.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -339,7 +339,7 @@ export class DataLayerObserver {
     } = rule;
 
     // rule properties override global ones
-    const readOnLoad = ruleReadOnLoad || globalReadOnLoad;
+    const readOnLoad = ruleReadOnLoad === undefined ? globalReadOnLoad : ruleReadOnLoad;
 
     if (!source || !destination) {
       Logger.getInstance().error(LogMessageType.RuleInvalid,

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -173,6 +173,26 @@ describe('DataLayerObserver unit tests', () => {
     ExpectObserver.getInstance().cleanup(observer);
   });
 
+  it('rule-specific readOnLoad overrides global readOnLoad', () => {
+    expectNoCalls(globalMock.console, 'log');
+
+    const observer = ExpectObserver.getInstance().create({
+      readOnLoad: true,
+      rules: [
+        {
+          source: 'digitalData.page.pageInfo',
+          operators: [],
+          destination: 'console.log',
+          readOnLoad: false,
+        },
+      ],
+    });
+
+    expectNoCalls(globalMock.console, 'log');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
   it('it should allow custom operators to be registered', () => {
     const observer = ExpectObserver.getInstance().default();
     observer.registerOperator('echo', new EchoOperator());


### PR DESCRIPTION
Looks like the logic for overriding the global config for `readOnLoad` is incorrect.  If DLO is globally configured as `readOnLoad:true`, it's not possible to make a rule that had `readOnLoad:false`.  This now checks if a rule has `readOnLoad` defined and sets the behavior accordingly.