### PR TITLE
Enumerate shoudn't convert empty strings

### DIFF
--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -46,6 +46,9 @@ export class ConvertOperator implements Operator {
       case 'date': return new Date(value);
       case 'int':
       case 'real':
+        // NOTE be careful of trying to convert an empty string, which will become 0
+        // a guard exists in `enumerate` but `convert` assumes you intend the conversion
+        // and the ternary allows converting a boolean for example to 0
         return !value ? 0 : ConvertOperator.enumerate(value);
       case 'string':
         switch (typeof value) {
@@ -104,8 +107,11 @@ export class ConvertOperator implements Operator {
       const enumerableProps = ConvertOperator.enumerableProperties(data[index]);
       enumerableProps.forEach((property) => {
         if (typeof data[index][property] === 'string') {
-          converted[property] = ConvertOperator.convert('real', data[index][property]);
-          ConvertOperator.verifyConversion('real', property, converted, data[index]);
+          // it seems best to leave an empty string as-is rather than have it converted to 0
+          if (data[index][property] !== '') {
+            converted[property] = ConvertOperator.convert('real', data[index][property]);
+            ConvertOperator.verifyConversion('real', property, converted, data[index]);
+          }
         } else {
           converted[property] = []; // this prevents mutating the actual data layer
           for (let i = 0; i < (data[index][property] as string[]).length; i += 1) {

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -324,7 +324,7 @@ describe('convert operator unit tests', () => {
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
     const [enumerated] = operator.handleData([item])!;
     const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers,
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty,
     } = enumerated;
 
     expect(quantity).to.eq(10);
@@ -335,6 +335,7 @@ describe('convert operator unit tests', () => {
     expect(type).to.eq(true);
     expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
     expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
   });
 
   it('strings can be converted automatically to numbers while converting specific properties', () => {

--- a/test/operator-convert.spec.ts
+++ b/test/operator-convert.spec.ts
@@ -18,6 +18,7 @@ const item = {
   vat: null,
   salePrice: ['24.99'],
   discountTiers: ['24.99', '19.99', '12.99'],
+  promoCodes: ['', 'bogo', 'july4th'],
 };
 
 describe('convert operator unit tests', () => {
@@ -324,7 +325,7 @@ describe('convert operator unit tests', () => {
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
     const [enumerated] = operator.handleData([item])!;
     const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty,
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
     } = enumerated;
 
     expect(quantity).to.eq(10);
@@ -336,6 +337,7 @@ describe('convert operator unit tests', () => {
     expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
     expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
     expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
   });
 
   it('strings can be converted automatically to numbers while converting specific properties', () => {


### PR DESCRIPTION
Historically the `ConvertOperator` allowed you (end-user) to specify what to convert.  The default behavior of `convert` on an empty string to a `real` is that the resulting value is `0`.  After introducing `enumerate` where `convert` tries to auto-convert for convenience, this has what appears to be an unwanted side effect.  If the properties selected from an object in the data layer are broad (e.g. all eVars), many times those get "cleared" by setting the existing value to empty string.  DLO then converts it to a 0, which is probably unexpected and has the second drawback of creating `eVarN_str` and `eVarN_real` in custom event properties.  So it feels best to just leave empty strings as-is for enumeration specifically.

Obscure technical detail: while the code change now checks if a single value is an empty string, the code to enumerate strings in a list is unchanged (i.e. we don't have any check for empty strings in a list).  The thinking is this, `verifyConversion` already checks to see if every element in a list is the same type.  If they don't, we assume conversion didn't work and reset the list to its original value.  Because FullStory doesn't allow mixed lists (what suffix would that be?), the conversion is all or none.  So a list of `['', '1.99']` would expectedly become `[0, 1.99]` but `['', 'foo']` gets converted to `[0, 'foo']` and then we `verifyConversion` which fails so its set back to `['', 'foo']`.