### PR TITLE
Guard emitting the same value

### DIFF
--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -43,8 +43,15 @@ export default class ShimMonitor extends Monitor {
       enumerable: this.enumerable,
       get: () => this.state,
       set: (value: any) => {
+        // checks if the incoming value matches the existing value
+        const hasChanged = this.state !== value;
+
         this.state = value;
-        this.emit(value);
+
+        // object-based data layers will often re-assign the same value, which causes over emitting
+        if (hasChanged) {
+          this.emit(value);
+        }
       },
     });
   }

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -66,6 +66,35 @@ describe('ShimMonitor unit tests', () => {
     globalMock.digitalData.cart.cartID = 'cart-5678';
   });
 
+  it('it should not emit an on change value if it matches the existing value', () => {
+    const path = 'digitalData.transaction';
+
+    // this test is a bit different because we have to create a listener where the
+    // Nth invocation is expected not to happen
+
+    // track the number of dispatched events with a simple counter
+    let counter = 0;
+    const listener = () => {
+      counter += 1;
+    };
+
+    // add the counter handler
+    window.addEventListener(createEventType(path), listener);
+
+    const cartMonitor = new ShimMonitor(globalMock.digitalData.transaction, 'transactionID', path);
+    expect(cartMonitor).to.not.be.undefined;
+
+    // trigger the first counter handler
+    globalMock.digitalData.transaction.transactionID = '123';
+    expect(counter).to.eql(1);
+
+    // re-assign the same value, which should not trigger the counter
+    globalMock.digitalData.transaction.transactionID = '123';
+    expect(counter).to.eql(1);
+
+    window.removeEventListener(createEventType(path), listener);
+  });
+
   it('it should emit args from function calls', (done) => {
     const path = 'dataLayer';
     const hit: any = {


### PR DESCRIPTION
Some object-based data layers appear to be re-assigning the same value to properties very frequently.  Conceptually that is problematic because it produces a change event that triggers the operator chain, which would send an event to the destination.  This scenario has been less noticed because property setters are debounced higher in the call stack by the `DataHandler`.  So a no-op, same-value reassignment occurs within the debounce window of a different property's assignment of a different value.  When the debounce time limit is reached, the two properties get collected, which looks like a valid change event because one property's did change.  As the list of properties under observation in the object grows, it appears the incidence of these "same value" assignments can occur.  For super active/messy? data layers, it increases the possibility that change events are emitted for data that's already been seen/processed.  I have another PR on allowing that debounce window to be extended to further reduce this scenario.

Also, it's probable that there's some legitimate scenario where you'd want to receive an event for a re-assignment, but I feel like that's a lesser problem to an over-active/messy data layer that's susceptible to rate limiting.  Open to hearing counter points.