### PR TITLE
Add configurable debounce time

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -55,7 +55,7 @@ export default class DataHandler {
     const { path } = this.target;
 
     if (value === undefined && args === undefined) {
-      // NOTE it seems some data layers may "clear" values by setting a property to undefined or empty strings
+      // NOTE it seems some data layers may "clear" values by setting a property to undefined
       // in one case, thousands of these calls lead to performance impacts so debug was chosen versus warn
       Logger.getInstance().debug(LogMessageType.EventEmpty, { path });
     } else if (type === createEventType(path)) {

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -268,7 +268,7 @@ describe('DataHandler unit tests', () => {
     setTimeout(() => {
       expect((seen[0] as PageInfo).pageID).to.eq('changedPage');
       done();
-    }, DataHandler.debounceTime * 1.5);
+    }, DataHandler.DefaultDebounceTime * 1.5);
   });
 
   it('multiple data layer events should be debounced', (done) => {
@@ -290,7 +290,7 @@ describe('DataHandler unit tests', () => {
     setTimeout(() => {
       expect(seen.length).to.eq(1);
       done();
-    }, DataHandler.debounceTime * 1.5);
+    }, DataHandler.DefaultDebounceTime * 1.5);
   });
 
   it('an object with no properties selected from an event should not be handled', (done) => {
@@ -308,6 +308,6 @@ describe('DataHandler unit tests', () => {
     setTimeout(() => {
       expect(seen.length).to.eq(0);
       done();
-    }, DataHandler.debounceTime * 1.5);
+    }, DataHandler.DefaultDebounceTime * 1.5);
   });
 });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -488,6 +488,9 @@ describe('DataLayerObserver unit tests', () => {
       }],
     }, true);
 
+    // there are some technical nuances to when/why to use debouncing
+    // see https://github.com/fullstorydev/fullstory-data-layer-observer/pull/139#discussion_r667939622
+
     // #1 trigger the first change event
     expectGlobal('digitalData').cart.cartID = 'abc';
 

--- a/test/rules-tealium-fullstory.spec.ts
+++ b/test/rules-tealium-fullstory.spec.ts
@@ -50,7 +50,7 @@ describe('Tealium to FullStory rules', () => {
       const [id, payload] = expectFS('event');
       expectEqual(id, 'product_view');
       expectEqual(payload.product_id, 'PROD789');
-    }, DataHandler.debounceTime * 1.5);
+    }, DataHandler.DefaultDebounceTime * 1.5);
 
     // NOTE this is an invalid property to monitor because it is not picked
     expectGlobal('utag').data.outsideScope = true;
@@ -59,7 +59,7 @@ describe('Tealium to FullStory rules', () => {
     setTimeout(() => {
       expectNoCalls(expectGlobal('FS'), 'event');
       done();
-    }, DataHandler.debounceTime * 1.5);
+    }, DataHandler.DefaultDebounceTime * 1.5);
   });
 
   it('should identify user', () => {


### PR DESCRIPTION
Recently, I've found that very active data layers (object-based in particular) can over-emit events.  I found a few areas of improvement:
- adding a config option to set the debounce time allowing some rules more time for the data layer to cool down
- moving the `this.timeoutId = null;` to unset the debounce flag; I saw that for a really really data layer I saw code that had its timeout cleared still executed.  Maybe some issues with the scope?  Open to theories on this change.