### PR TITLE
Limit number of suffixed props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.9.0
+
+- `suffix` operator limits number of properties in an object to `100` (configurable with `maxProps`)
+
 ### 1.8.0
 
 - Performance improvement to prevent emitting change events for the same value

--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -2,7 +2,7 @@
 
 The suffix operator can be used to automatically apply the appropriate type suffix to properties in an object.  Since the suffix operator is useful for every `FS` API, it is included as the default `window['_dlo_beforeDestination']` configuration option and is not needed in the `operators` list.
 
-To support FullStory-specific APIs, the properties `displayName`, `pageName`, and `email` are not suffixed in a root object.
+To support FullStory-specific APIs, the properties `displayName`, `pageName`, and `email` are not suffixed in a root object. Additionally, the number of properties in a suffixed object is limited to `100` by default. This prevents unintentional, large objects from being sent to the destination, which can result in performance issues or exceeding cardinality quotas. Increase the limit using the `maxProps` option.
 
 ## Options
 
@@ -12,6 +12,7 @@ Options with an asterisk are required.
 | ------ | ---- | ------- | ----------- |
 | `index` | `number` | `0` | Position of the object to suffix in the operator input list. |
 | `maxDepth` | `number` | `10` | Maximum depth to search for properties to be suffixed. |
+| `mapProps` | `number` | `100` | Maximum number of properties allowed in a suffixed object. |
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/operators/suffix.ts
+++ b/src/operators/suffix.ts
@@ -54,7 +54,7 @@ export class SuffixOperator implements Operator {
 
   constructor(public options: SuffixOperatorOptions) {
     // NOTE the index is -1 because payloads to FS.event or FS.setUserVars are the last in the list of args
-    const { index = -1, maxDepth = 10, maxProps = 100 } = options;
+    const { index = -1, maxDepth = 10, maxProps = SuffixOperator.DefaultMaxProps } = options;
 
     this.index = index;
     this.maxDepth = maxDepth;

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -317,4 +317,39 @@ describe('suffix operator unit test', () => {
     expect(source).to.eq('mocha');
     expect(suffixedObject.id_str).to.not.be.undefined;
   });
+
+  it('it should throw an error when an object has more props than allowed', () => {
+    const obj: any = {};
+
+    for (let i = 0; i < SuffixOperator.DefaultMaxProps + 1; i += 1) {
+      obj[i] = i;
+    }
+
+    const operator = new SuffixOperator({ name: 'suffix' });
+    expect(operator).to.not.be.undefined;
+
+    expect(() => operator.handleData([obj])).to.throw();
+  });
+
+  it('it should allow maxProps to be configured', () => {
+    const obj: any = {
+      1: '1',
+      2: '2',
+      3: {
+        4: '4',
+      },
+    };
+
+    const operator = new SuffixOperator({ name: 'suffix', maxProps: 4 });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([obj])!;
+    expect(Object.getOwnPropertyNames(suffixedObject).length
+      + Object.getOwnPropertyNames(suffixedObject['3_obj']).length).to.eql(4);
+
+    // go over the limit
+    obj['5'] = '5';
+
+    expect(() => operator.handleData([obj])).to.throw();
+  });
 });


### PR DESCRIPTION
There was a Clubhouse ticket where a customer had long delays on their site.  This was tracked back to a super-size (120MB) object being added to the data layer.  The object had a reference to the React app, which is why it was so big.  In order to guard against wayward objects in the data layer either impacting site performance or simply overrunning our cardinality quota on `FS.event`, I've put a cap on the `suffix` operator's total property count at `100`.  This was done through an informed analysis of DLO events and is not arbitrary.

The rationale for doing this in the `suffix` operator is because it is always used in `beforeDestination` and has FullStory specific behavior already.  Thus it makes for a good candidate to put a guard that benefits FullStory.