### PR TITLE
Limit maxProps to FullStory 5000 cardinality

### DIFF
--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -12,7 +12,7 @@ Options with an asterisk are required.
 | ------ | ---- | ------- | ----------- |
 | `index` | `number` | `0` | Position of the object to suffix in the operator input list. |
 | `maxDepth` | `number` | `10` | Maximum depth to search for properties to be suffixed. |
-| `mapProps` | `number` | `100` | Maximum number of properties allowed in a suffixed object. This value may not exceed `5000`.|
+| `maxProps` | `number` | `100` | Maximum number of properties allowed in a suffixed object. This value may not exceed `5000`.|
 
 ## Usage
 

--- a/docs/operator_suffix.md
+++ b/docs/operator_suffix.md
@@ -12,7 +12,7 @@ Options with an asterisk are required.
 | ------ | ---- | ------- | ----------- |
 | `index` | `number` | `0` | Position of the object to suffix in the operator input list. |
 | `maxDepth` | `number` | `10` | Maximum depth to search for properties to be suffixed. |
-| `mapProps` | `number` | `100` | Maximum number of properties allowed in a suffixed object. |
+| `mapProps` | `number` | `100` | Maximum number of properties allowed in a suffixed object. This value may not exceed `5000`.|
 
 ## Usage
 

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -53,6 +53,10 @@ describe('suffix operator unit test', () => {
     expect(() => new SuffixOperator({
       name: 'suffix', maxDepth: 3,
     }).validate()).to.not.throw();
+
+    expect(() => new SuffixOperator({
+      name: 'suffix', maxProps: SuffixOperator.MaxPropsCeiling + 1,
+    }).validate()).to.throw();
   });
 
   it('it should not change the original object', () => {
@@ -351,5 +355,9 @@ describe('suffix operator unit test', () => {
     obj['5'] = '5';
 
     expect(() => operator.handleData([obj])).to.throw();
+  });
+
+  it('it should not allow maxProps to be above the hard coded ceiling', () => {
+    expect(() => new SuffixOperator({ name: 'suffix', maxProps: SuffixOperator.MaxPropsCeiling + 1 })).to.throw();
   });
 });


### PR DESCRIPTION
Put a ceiling on the suffix operator's `maxProps` feature.  No rush on reviewing this one, just a nice to have and will go out whenever we push a new release.