### PR TITLE
replace registerRuleWithDelay with a more generic sleep function

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -349,27 +349,28 @@ export class DataLayerObserver {
    *
    * @param snooze Function to test whether to wait again
    * @param awake Function to execute once the wait is over
-   * @param didTimeout Function that gets called in the event of a timeout
+   * @param timeout Function that gets called in the event of a timeout
    * @param attempt The current attempt to test the snooze function
    * @param wait Wait time in milliseconds before testing whether to wait some more
    */
   private sleep(
     snooze: () => boolean,
     awake: () => void,
-    didTimeout: () => void,
+    timeout: () => void,
     maxRetry = 5,
     attempt = 1,
     wait = 250,
   ) {
+    if (attempt > maxRetry) {
+      timeout();
+      return;
+    }
+
     const delay = (2 ** (attempt - 1) * wait) + Math.random();
     if (snooze()) {
-      if (attempt > maxRetry) {
-        didTimeout();
-      } else {
-        setTimeout(() => {
-          this.sleep(snooze, awake, didTimeout, maxRetry, attempt + 1);
-        }, delay);
-      }
+      setTimeout(() => {
+        this.sleep(snooze, awake, timeout, maxRetry, attempt + 1);
+      }, delay);
     } else {
       awake();
     }

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -351,7 +351,7 @@ export class DataLayerObserver {
    * @param awake Function to execute once the wait is over
    * @param timeout Function that gets called in the event of a timeout
    * @param attempt The current attempt to test the snooze function
-   * @param wait Wait time in milliseconds before testing whether to wait some more
+   * @param wait Time in milliseconds before invoking the awake function or snoozing again
    */
   private sleep(
     snooze: () => boolean,
@@ -366,6 +366,8 @@ export class DataLayerObserver {
       return;
     }
 
+    // exponentially back-off with a slight offset to prevent tight grouping of re-registration
+    // NOTE, use `attempt - 1` because the first attempt should be equal to `Math.pow(2, 0)`
     const delay = (2 ** (attempt - 1) * wait) + Math.random();
     if (snooze()) {
       setTimeout(() => {

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -346,11 +346,12 @@ export class DataLayerObserver {
   }
 
   /**
-   *
+   * Will test whether the `awake` function is ready to be called, and if not,
+   * will sleep according to an exponential delay up to `maxRetry` attempts.
    * @param shouldWake Function to test whether to wait again
    * @param awake Function to execute once the wait is over
    * @param timeout Function that gets called in the event of a timeout
-   * @param attempt The current attempt to test the snooze function
+   * @param attempt The current attempt to test the `shouldWake` function
    * @param wait Time in milliseconds before invoking the awake function or snoozing again
    */
   private sleep(

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -366,16 +366,17 @@ export class DataLayerObserver {
       return;
     }
 
+    if (shouldWake()) {
+      awake();
+      return;
+    }
+
     // exponentially back-off with a slight offset to prevent tight grouping of re-registration
     // NOTE, use `attempt - 1` because the first attempt should be equal to `Math.pow(2, 0)`
     const delay = (2 ** (attempt - 1) * wait) + Math.random();
-    if (shouldWake()) {
-      awake();
-    } else {
-      setTimeout(() => {
-        this.sleep(shouldWake, awake, timeout, maxRetry, attempt + 1, wait);
-      }, delay);
-    }
+    setTimeout(() => {
+      this.sleep(shouldWake, awake, timeout, maxRetry, attempt + 1, wait);
+    }, delay);
   }
 
   /**

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -414,8 +414,10 @@ export class DataLayerObserver {
     }
 
     try {
-      const target = DataLayerTarget.find(source);
-      const register = () => this.registerTarget(target, operators, destination, readOnLoad, monitor, debug, debounce);
+      const register = () => {
+        const target = DataLayerTarget.find(source);
+        this.registerTarget(target, operators, destination, readOnLoad, monitor, debug, debounce);
+      };
       const timeout = () => Logger.getInstance().warn(LogMessageType.RuleRegistrationError, {
         rule: id, source, reason: 'Max Retries Attempted',
       });
@@ -429,12 +431,7 @@ export class DataLayerObserver {
           }, waitUntil > -1 ? waitUntil : 0); // negative values will schedule immediately
           break;
         case 'function':
-          if (!waitUntil(target)) {
-            this.sleep(() => !waitUntil(target), register, timeout, maxRetry);
-            // this.registerRuleWithDelay(rule, attempt);
-          } else {
-            register();
-          }
+          this.sleep(() => !waitUntil(DataLayerTarget.find(source)), register, timeout, maxRetry);
           break;
         default:
           Logger.getInstance().warn(Logger.format(LogMessage.UnsupportedType, typeof waitUntil));

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -371,7 +371,7 @@ export class DataLayerObserver {
     const delay = (2 ** (attempt - 1) * wait) + Math.random();
     if (snooze()) {
       setTimeout(() => {
-        this.sleep(snooze, awake, timeout, maxRetry, attempt + 1);
+        this.sleep(snooze, awake, timeout, maxRetry, attempt + 1, wait);
       }, delay);
     } else {
       awake();


### PR DESCRIPTION
This PR removes the need to carry the `attempt` parameter around with `registerRule` and the circular dependency between `registerRule` and `registerRuleWithDelay`

@van-fs please check it out and let me know what you think.