### PR TITLE
Adjust suffixing undefined values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.10.1
+
+- `suffix` operator `maxProps` should not count properties with undefined values
+- `suffix` operator explicitly stops processing if provided an undefined or null object to be suffixed
+
+### 1.10.0
+
+- Added rule options `waitUntil` and `maxRetry` related to scheduling rule registration
+- Updated default behavior of rule registration: waiting for both a defined data layer object and at least one property defined
+- Adjusted rule registration logic to schedule using exponential backoff times
+
 ### 1.9.0
 
 - `suffix` operator limits number of properties in an object to `100` (configurable with `maxProps`)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/v1.10.0.js
+- https://edge.fullstory.com/datalayer/v1/v1.10.1.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/operator-suffix.spec.ts
+++ b/test/operator-suffix.spec.ts
@@ -77,10 +77,14 @@ describe('suffix operator unit test', () => {
     const operator = new SuffixOperator({ name: 'suffix' });
     expect(operator).to.not.be.undefined;
 
-    const [suffixedObject] = operator.handleData([undefined])!;
+    // undefined objects themselves have no data so return null to halt the operator chain
+    let suffixedObject = operator.handleData([undefined])!;
+    expect(suffixedObject).to.be.null;
 
+    // undefined values will be pruned from the resulting object
+    [suffixedObject] = operator.handleData([{ a: undefined, b: 'b' }])!;
     expect(suffixedObject).to.not.be.undefined;
-    expect(Object.getOwnPropertyNames(suffixedObject).length).to.eq(0);
+    expect(Object.getOwnPropertyNames(suffixedObject).length).to.eq(1);
   });
 
   it('it should not suffix required FullStory naming conventions', () => {
@@ -359,5 +363,16 @@ describe('suffix operator unit test', () => {
 
   it('it should not allow maxProps to be above the hard coded ceiling', () => {
     expect(() => new SuffixOperator({ name: 'suffix', maxProps: SuffixOperator.MaxPropsCeiling + 1 })).to.throw();
+  });
+
+  it('it should not count undefined values in the property total', () => {
+    const operator = new SuffixOperator({ name: 'suffix', maxProps: 1 });
+    expect(operator).to.not.be.undefined;
+
+    const [suffixedObject] = operator.handleData([{ a: undefined, b: undefined, c: 'c' }])!;
+    expect(Object.getOwnPropertyNames(suffixedObject).length).to.eql(1);
+
+    // go over the limit
+    expect(() => operator.handleData([{ c: 'c', d: 'd' }])).to.throw();
   });
 });


### PR DESCRIPTION
I'm finding the suffix operator's handling of undefined needs tuning:
- The large object fix is counting all properties in an object. It appears Adobe for example may have a long list of undefined values (e.g. eVars).  So we're including them in the total count; however, they'll never be sent to the destination because suffix prunes undefined values.
- I added some quick guards for conditions where we just shouldn't process at all. For example, if a property is undefined, just return null so we don't perform needless work.  Same for someone giving us a null/undefined object.

@patrick-fs WDYT