### PR TITLE
Add CEDDL out-of-the-box ruleset; test against this ruleset

### DIFF
--- a/rulesets/README.md
+++ b/rulesets/README.md
@@ -15,3 +15,9 @@ Rulesets provide out of the box rules that are compatible with common data layer
 - [Ruleset](./google-ua-enhanced-ecommerce.js)
 - [Vendor Guidelines](https://developers.google.com/tag-manager/enhanced-ecommerce)
 - [Tests](../test/rules-google-fullstory.spec.ts)
+
+## Customer Experience Digital Data Layer 1.0 (CEDDL)
+
+- [Ruleset](./ceddl.js)
+- [Vendor Guidelines](https://www.w3.org/2013/12/ceddl-201312.pdf)
+- [Tests](../test/rules-ceddl-fullstory.spec.ts)

--- a/rulesets/ceddl.js
+++ b/rulesets/ceddl.js
@@ -1,0 +1,47 @@
+window['_dlo_rules_ceddl'] = [
+  {
+    "id": "fs-event-ceddl-cart", "source": "digitalData.cart",
+    "operators": [
+      { "name": "query", "select": "$[!(item)]" },
+      { "name": "flatten" },
+      { "name": "insert", "value": "cart" }
+    ],
+    "destination": "FS.event"
+  },
+  {
+    "id": "fs-event-ceddl-page", "source": "digitalData.page",
+    "operators": [
+      { "name": "flatten" },
+      { "name": "query", "select": "$[!(destinationURL,referringURL)]" },
+      { "name": "convert","properties": "issueDate,effectiveDate,expiryDate", "type": "date" },
+      { "name": "insert", "value": "page" }
+    ],
+    "destination": "FS.event"
+  },
+  {
+    "id": "fs-event-ceddl-product", "source": "digitalData.product[0]",
+    "operators": [
+      { "name": "query", "select": "$[!(linkedProduct)]" },
+      { "name": "flatten" },
+      { "name": "insert", "value": "product" }
+    ],
+    "destination": "FS.event"
+  },
+  {
+    "id": "fs-event-ceddl-transaction", "source": "digitalData.transaction",
+    "operators": [
+      { "name": "query", "select": "$[!(profile,item)]" },
+      { "name": "flatten" },
+      { "name": "insert", "value": "transaction" }
+    ],
+    "destination": "FS.event"
+  },
+  {
+    "id": "fs-event-ceddl-event", "source": "digitalData.event",
+    "operators": [
+      { "name": "flatten" },
+      { "name": "insert", "select": "eventName", "defaultValue": "event" }
+    ],
+    "destination": "FS.event"
+  }
+];


### PR DESCRIPTION
Previously, CEDDL tests were against an example ruleset that didn't match the out-of-the-box ruleset provided for organizations which enabled the Data Layer Observer integration and toggled on the Customer Experience Digital Data Layer: 1.0 option. Now, we test against the default ruleset. This required removing and updating a number of tests since some expectations were no longer valid.

There are no behavior changes in this PR, so the package version hasn't been bumped.

/cc @patrick-fs @van-fs 