### PR TITLE
Replace String.prototype.startsWith usage with internal implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.10.2
+
+- Fixed `Object doesn't support property or method 'startsWith'` error in IE11
+
 ### 1.10.1
 
 - `suffix` operator `maxProps` should not count properties with undefined values

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/v1.10.1.js
+- https://edge.fullstory.com/datalayer/v1/v1.10.2.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/embed/init.ts
+++ b/src/embed/init.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle, camelcase */
 import { Logger, LogMessageType } from '../utils/logger';
+import { startsWith } from '../utils/object';
 import { DataLayerObserver } from '../observer';
 
 /*
@@ -57,7 +58,7 @@ function _dlo_collectRules(): any[] {
     const startTime = Date.now();
     const results: any[] = [];
     Object.getOwnPropertyNames(window).forEach((propName) => {
-      if (propName.startsWith('_dlo_rules') === false) return;
+      if (startsWith(propName, '_dlo_rules') === false) return;
 
       const prop = (window as { [key: string]: any })[propName];
       if (Array.isArray(prop) === false) {

--- a/src/monitor-factory.ts
+++ b/src/monitor-factory.ts
@@ -1,5 +1,6 @@
 import Monitor from './monitor';
 import ShimMonitor from './monitor-shim';
+import { startsWith } from './utils/object';
 
 /**
  * Because only a single Monitor can exist on an object's property and various DataHandlers
@@ -48,7 +49,7 @@ export default class MonitorFactory {
    * @param fuzzy when true removes all Monitors that start with the path
    */
   remove(path: string, fuzzy = false) {
-    const paths = fuzzy ? Object.getOwnPropertyNames(this.monitors).filter((key) => key.startsWith(path)) : [path];
+    const paths = fuzzy ? Object.getOwnPropertyNames(this.monitors).filter((key) => startsWith(key, path)) : [path];
 
     paths.forEach((monitorPath) => {
       const monitor = this.monitors[monitorPath];

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-classes-per-file */
 /* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: false}}] */
 
-import { getGlobal } from './utils/object';
+import { getGlobal, startsWith } from './utils/object';
 import { Logger, LogMessage } from './utils/logger';
 
 // Memoized Paths or false if the path cannot be parsed
@@ -335,7 +335,7 @@ class PathElement {
     for (let i = 0; i < propNames.length; i += 1) {
       const key = propNames[i];
       for (let j = 0; j < this.brackets.op.propNames.length; j += 1) {
-        if (key.startsWith(this.brackets.op.propNames[j])) {
+        if (startsWith(key, this.brackets.op.propNames[j])) {
           results[key] = prop[key];
           atLeastOne = true;
           break;
@@ -398,8 +398,8 @@ class PathElement {
           if (opProp.operator === '==' && prop[opProp.name] != opProp.value) return undefined;
           // eslint-disable-next-line eqeqeq
           if (opProp.operator == '!=' && prop[opProp.name] == opProp.value) return undefined;
-          if (opProp.operator === '=^' && !prop[opProp.name].startsWith(opProp.value)) return undefined;
-          if (opProp.operator === '!^' && prop[opProp.name].startsWith(opProp.value)) return undefined;
+          if (opProp.operator === '=^' && !startsWith(prop[opProp.name], opProp.value)) return undefined;
+          if (opProp.operator === '!^' && startsWith(prop[opProp.name], opProp.value)) return undefined;
           break;
         case 'number':
           // eslint-disable-next-line eqeqeq

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -33,3 +33,23 @@ export function fromPath(path: string): [object, string] {
 
   return [target, property];
 }
+
+/**
+ * Returns true if the searchString sequence is the same as the corresponding target sequence
+ * starting at the given target position (defaulting to 0); otherwise returns false.
+ * @param target The string to search within.
+ * @param searchString The string to search for.
+ * @param position The position to start searching witin the target.
+ */
+export function startsWith(target: string, searchString: string, position?: number): boolean {
+  // We provide our own startsWith implementation matching the ES2015 String.prototype.startsWith
+  // function behavior since IE11 doesn't support String.prototype.startsWith
+  let effectivePosition = 0;
+
+  // 'foo'.startsWith('foo', -100) will return true
+  if (position && position > 0) {
+    effectivePosition = position;
+  }
+
+  return target.indexOf(searchString, effectivePosition) === effectivePosition;
+}

--- a/test/object-utils.spec.ts
+++ b/test/object-utils.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { startsWith } from '../src/utils/object';
+
+const testCase = (target: string, searchString: string, position?: number) => ({
+  target,
+  searchString,
+  position,
+});
+
+describe('startsWith', () => {
+  const testCases = [
+    testCase('foo', 'fo'),
+    testCase('foo', 'foo'),
+    testCase('fo', 'foo'),
+    testCase('foo', 'bar'),
+    testCase('foo', 'fo', -100),
+    testCase('foo', 'fo', -1),
+    testCase('foo', 'fo', 0),
+    testCase('foo', 'fo', 1),
+    testCase('foo', 'fo', 100),
+    testCase('fo', 'foo', -100),
+    testCase('fo', 'foo', -1),
+    testCase('fo', 'foo', 0),
+    testCase('fo', 'foo', 1),
+    testCase('fo', 'foo', 100),
+    testCase('foo', 'foo', -100),
+    testCase('foo', 'foo', -1),
+    testCase('foo', 'foo', 0),
+    testCase('foo', 'foo', 1),
+    testCase('foo', 'foo', 100),
+    testCase('foo', 'bar', -100),
+    testCase('foo', 'bar', -1),
+    testCase('foo', 'bar', 0),
+    testCase('foo', 'bar', 1),
+    testCase('foo', 'bar', 100),
+  ];
+
+  testCases.forEach((tc) => {
+    it(`matches String.prototype.startsWith behavior with args: ${JSON.stringify(tc)}`, () => {
+      const expected = tc.target.startsWith(tc.searchString, tc.position);
+      const actual = startsWith(tc.target, tc.searchString, tc.position);
+      expect(actual).to.eq(expected);
+    });
+  });
+});


### PR DESCRIPTION
IE11 doesn't support the ES2015 `String.prototype.startsWith` function.

I opted for an internal `startsWith` implementation for a couple reasons:
- I think `startsWith` reads clearer than introducing `indexOf('target', 'searchString') === 0` or `indexOf('target', 'searchString') !== 0` at the current call sites
- I don't think it makes sense for DLO to poly-fill by adding onto `String.prototype` which could impact other JavaScript on the page

Suggestions for alternative approaches definitely welcome.