### PR TITLE
syncing package-lock.json version with package.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^5.0.1",


### PR DESCRIPTION
This PR updates the package-lock.json version to match the on in package.json