### PR TITLE
Don't handle empty data in operators or send to configured rule destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.11.0
+
+- Empty objects are no longer passed to rule operators. This prevents empty objects from being sent to configured rule destinations. Empty objects are defined as empty arrays or objects where all first-level child keys have `undefined` values
+
 ### 1.10.2
 
 - Fixed `Object doesn't support property or method 'startsWith'` error in IE11

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -242,6 +242,8 @@ describe('DataHandler unit tests', () => {
 
       expect(seen.length).to.eq(1);
       expect(seen[0].definedChild).to.eq(val);
+      expect(Object.keys(seen[0])).to.include('undefinedChild');
+      expect(seen[0].undefinedChild).to.be.undefined;
     });
   });
 

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -63,14 +63,18 @@ class GetterOperator implements Operator {
   }
 }
 
-class NullOperator implements Operator {
+class StaticReturnOperator implements Operator {
   options: OperatorOptions = {
-    name: 'null',
+    name: 'static-return',
   };
+
+  constructor(private returnValue: any[] | null) {
+    // sets this.returnValue
+  }
 
   // eslint-disable-next-line class-methods-use-this
   handleData(): any[] | null {
-    return null;
+    return this.returnValue;
   }
 
   validate() {
@@ -122,7 +126,7 @@ describe('DataHandler unit tests', () => {
   it('data layer event data should pass to the first operator', () => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);
@@ -134,7 +138,7 @@ describe('DataHandler unit tests', () => {
   it('transformed data should pass from operator to operator', () => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     const getter = new GetterOperator('pageInfo', seen);
@@ -152,7 +156,7 @@ describe('DataHandler unit tests', () => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
     handler.debug = true;
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     const getter = new GetterOperator('pageInfo', seen);
@@ -194,24 +198,76 @@ describe('DataHandler unit tests', () => {
     expect(debugMessages.length).to.eq(3);
   });
 
-  it('returning null in an operator should halt data handling', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+  [null, []].forEach((val) => {
+    it(`returning ${JSON.stringify(val)} in an operator should halt data handling`, () => {
+      const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
 
-    const seen: any = [];
+      const seen: any[] = [];
 
-    const nullify = new NullOperator();
+      const staticReturn = new StaticReturnOperator(val);
+      const echo = new EchoOperator(seen);
+
+      handler.push(staticReturn, echo);
+      handler.fireEvent();
+
+      expect(seen.length).to.eq(0);
+    });
+  });
+
+  it('empty object should halt data handling', () => {
+    (globalThis as any).digitalData.emptyObject = { undefinedChild: undefined };
+    const handler = new DataHandler(DataLayerTarget.find('digitalData.emptyObject')!);
+
+    const seen: any[] = [];
+
     const echo = new EchoOperator(seen);
 
-    handler.push(nullify, echo);
+    handler.push(echo);
     handler.fireEvent();
 
     expect(seen.length).to.eq(0);
   });
 
+  [0, '', false, null, []].forEach((val) => {
+    it(`non-empty object with child property value ${JSON.stringify(val)} should not halt data handling`, () => {
+      (globalThis as any).digitalData.nonEmptyObject = { undefinedChild: undefined, definedChild: val };
+      const handler = new DataHandler(DataLayerTarget.find('digitalData.nonEmptyObject')!);
+
+      const seen: any[] = [];
+
+      const echo = new EchoOperator(seen);
+
+      handler.push(echo);
+      handler.fireEvent();
+
+      expect(seen.length).to.eq(1);
+      expect(seen[0].definedChild).to.eq(val);
+    });
+  });
+
+  [0, '', false].forEach((val) => {
+    it(`${typeof val} value should not halt data handling`, () => {
+      (globalThis as any).digitalData.nonEmptyObject = { val };
+      const handler = new DataHandler(DataLayerTarget.find('digitalData.nonEmptyObject'));
+
+      const seen: any[] = [];
+
+      // Returns the val property value directly instead of within an object e.g. { val: 0 }
+      const getter = new GetterOperator('val', []);
+      const echo = new EchoOperator(seen);
+
+      handler.push(getter, echo);
+      handler.fireEvent();
+
+      expect(seen.length).to.eq(1);
+      expect(seen[0]).to.eq(val);
+    });
+  });
+
   it('operator exceptions should fail gracefully', () => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const throws = new ThrowOperator();
     const echo = new EchoOperator(seen);
@@ -227,7 +283,7 @@ describe('DataHandler unit tests', () => {
     (globalThis as any).digitalData.fn = () => console.log('Hello World'); // eslint-disable-line no-console
     const handler = new DataHandler(DataLayerTarget.find('digitalData.fn')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);
@@ -238,7 +294,7 @@ describe('DataHandler unit tests', () => {
   it('events with unknown types should not be handled', () => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);
@@ -253,7 +309,7 @@ describe('DataHandler unit tests', () => {
   it('data layer events should be delayed to allow debouncing', (done) => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);
@@ -274,7 +330,7 @@ describe('DataHandler unit tests', () => {
   it('multiple data layer events should be debounced', (done) => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);
@@ -296,7 +352,7 @@ describe('DataHandler unit tests', () => {
   it('an object with no properties selected from an event should not be handled', (done) => {
     const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo[(missingProperty)]')!);
 
-    const seen: any = [];
+    const seen: any[] = [];
 
     const echo = new EchoOperator(seen);
     handler.push(echo);


### PR DESCRIPTION
Within `handleData` seemed to be the most optimal place to change this behavior for a couple reasons:
- If we added empty data checking in `handleEvent`, we also would've needed to add empty data checking in `fireEvent` for `readOnLoad: true` scenarios (and we would've needed to test both `fireEvent` and `handleEvent`)
- It's possible data received in `fireEvent` or `handleEvent` could start as non-empty but eventually become empty through operator data processing -- meaning we'd still have a seam to submit empty data to the configured rule destination (e.g. `FS.event`).

Definitely open to feedback about other ways to implement this.

I opted to unit test this pretty heavily and add more of an integration test within our Adobe ruleset tests since empty `eVar` objects sparked interest in this change.