### PR TITLE
Prevent triggering rules with property changes that don't match selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.12.0
+
+- Rules can no longer be triggered by changes to properties which don't match a rule's selector
+
 ### 1.11.0
 
 - Empty objects are no longer passed to rule operators. This prevents empty objects from being sent to configured rule destinations. Empty objects are defined as empty arrays or objects where all first-level child keys have `undefined` values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/event.ts
+++ b/src/event.ts
@@ -33,21 +33,23 @@ export class PropertyDetail implements DataLayerDetail {
 /**
  * Defines CustomEvent types. Types will be prefixed with a DLO namespace.
  * See https://developer.mozilla.org/en-US/docs/Web/API/Event/type
+ * @param source source from the rule monitoring the data layer
  * @param path that identifies the data layer object that created the event
  */
-export function createEventType(path: string) {
-  return `datalayerobserver/${path}`;
+export function createEventType(source: string, path: string) {
+  return `datalayerobserver/${source}/${path}`;
 }
 
 /**
  * Builds a CustomEvent used to broadcast changes.
+ * @param source source from the rule monitoring the data layer
  * @param target that triggered the event (see https://developer.mozilla.org/en-US/docs/Web/API/Event/target)
  * @param property that triggered the event
  * @param value that was emitted by the target
  * @param path to the target
  */
-export function createEvent(target: any, property: string, value: any, path: string): CustomEvent<DataLayerDetail> {
-  return new CustomEvent<DataLayerDetail>(createEventType(path), {
+export function createEvent(source: string, target: any, property: string, value: any, path: string): CustomEvent<DataLayerDetail> {
+  return new CustomEvent<DataLayerDetail>(createEventType(source, path), {
     detail: typeof target[property] === 'function' ? new FunctionDetail(path, property, value)
       : new PropertyDetail(path, property, value),
   });

--- a/src/event.ts
+++ b/src/event.ts
@@ -33,7 +33,7 @@ export class PropertyDetail implements DataLayerDetail {
 /**
  * Defines CustomEvent types. Types will be prefixed with a DLO namespace.
  * See https://developer.mozilla.org/en-US/docs/Web/API/Event/type
- * @param source source from the rule monitoring the data layer
+ * @param source from the rule monitoring the data layer
  * @param path that identifies the data layer object that created the event
  */
 export function createEventType(source: string, path: string) {
@@ -42,7 +42,7 @@ export function createEventType(source: string, path: string) {
 
 /**
  * Builds a CustomEvent used to broadcast changes.
- * @param source source from the rule monitoring the data layer
+ * @param source from the rule monitoring the data layer
  * @param target that triggered the event (see https://developer.mozilla.org/en-US/docs/Web/API/Event/target)
  * @param property that triggered the event
  * @param value that was emitted by the target

--- a/src/event.ts
+++ b/src/event.ts
@@ -48,7 +48,13 @@ export function createEventType(source: string, path: string) {
  * @param value that was emitted by the target
  * @param path to the target
  */
-export function createEvent(source: string, target: any, property: string, value: any, path: string): CustomEvent<DataLayerDetail> {
+export function createEvent(
+  source: string,
+  target: any,
+  property: string,
+  value: any,
+  path: string,
+): CustomEvent<DataLayerDetail> {
   return new CustomEvent<DataLayerDetail>(createEventType(source, path), {
     detail: typeof target[property] === 'function' ? new FunctionDetail(path, property, value)
       : new PropertyDetail(path, property, value),

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -25,7 +25,7 @@ export default class DataHandler {
 
   /**
    * Creates a DataHandler.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param target in the data layer
    * @param debug true optionally enables debugging data transformation (defaults to console.debug)
    * @param debounce number of milliseconds to debounce property value assignments (defaults to 250ms)

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -25,12 +25,13 @@ export default class DataHandler {
 
   /**
    * Creates a DataHandler.
+   * @param source source from the rule monitoring the data layer
    * @param target in the data layer
    * @param debug true optionally enables debugging data transformation (defaults to console.debug)
    * @param debounce number of milliseconds to debounce property value assignments (defaults to 250ms)
    * @throws will throw an error if the data layer is not found (i.e. undefined or null)
    */
-  constructor(public readonly target: DataLayerTarget, public debug = false,
+  constructor(private readonly source: string, public readonly target: DataLayerTarget, public debug = false,
     public debounce = DataHandler.DefaultDebounceTime) {
     if (!target || !target.value) {
       throw new Error(LogMessage.DataLayerMissing);
@@ -62,7 +63,7 @@ export default class DataHandler {
       // NOTE it seems some data layers may "clear" values by setting a property to undefined
       // in one case, thousands of these calls lead to performance impacts so debug was chosen versus warn
       Logger.getInstance().debug(LogMessageType.EventEmpty, { path });
-    } else if (type === createEventType(path)) {
+    } else if (type === createEventType(this.source, path)) {
       // value could legitimately be an empty string
       if (value !== undefined) {
         // debounce events so multiple, related property assignments don't create multiple events
@@ -255,7 +256,7 @@ export default class DataHandler {
   start() {
     if (!this.listener) {
       this.listener = (e: Event) => this.handleEvent(e as CustomEvent);
-      window.addEventListener(createEventType(this.target.path), this.listener);
+      window.addEventListener(createEventType(this.source, this.target.path), this.listener);
     }
   }
 
@@ -263,7 +264,7 @@ export default class DataHandler {
    * Stops listening for data layer changes or function calls.
    */
   stop() {
-    window.removeEventListener(createEventType(this.target.path), this.listener as EventListener);
+    window.removeEventListener(createEventType(this.source, this.target.path), this.listener as EventListener);
     this.listener = null;
   }
 }

--- a/src/monitor-factory.ts
+++ b/src/monitor-factory.ts
@@ -25,19 +25,22 @@ export default class MonitorFactory {
 
   /**
    * Creates a Monitor. If a Monitor has already been created, it will be returned.
+   * @param source source from the rule monitoring the data layer
    * @param object that applies to the Monitor
    * @param property in the object to Monitor
    * @param path describing the object
    */
-  create(object: Object, property: string, path: string): Monitor {
+  create(source: string, object: Object, property: string, path: string): Monitor {
     const key = typeof (object as any)[property] === 'function' ? path : `${path}.${property}`;
 
     if (!this.monitors[key]) {
       const propDescriptor = Object.getOwnPropertyDescriptor(object, property) || null;
       // functions have no property descriptors but properties need to be configurable (e.g. Array.length is not)
       if (propDescriptor === null || propDescriptor.configurable) {
-        this.monitors[key] = new ShimMonitor(object, property, path);
+        this.monitors[key] = new ShimMonitor(source, object, property, path);
       }
+    } else {
+      this.monitors[key].addSource(source);
     }
 
     return this.monitors[key];

--- a/src/monitor-factory.ts
+++ b/src/monitor-factory.ts
@@ -25,7 +25,7 @@ export default class MonitorFactory {
 
   /**
    * Creates a Monitor. If a Monitor has already been created, it will be returned.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param object that applies to the Monitor
    * @param property in the object to Monitor
    * @param path describing the object

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -64,6 +64,8 @@ export default class ShimMonitor extends Monitor {
         value: this.state,
         writable: this.writable,
       });
+
+      this.sources.clear();
     } catch (err) {
       Logger.getInstance().error(LogMessageType.MonitorRemoveError,
         { path: this.path, property: this.property, reason: err.message });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -11,7 +11,7 @@ export default abstract class Monitor {
 
   /**
    * Creates a Monitor.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param object containing the property or function to watch
    * @param property to watch (can hold a value or function)
    * @param path to the data layer object
@@ -43,7 +43,7 @@ export default abstract class Monitor {
 
   /**
    * Registers a rule source to be notified when monitored data layer objects change
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    */
   addSource(source: string) {
     this.sources.add(source);

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -139,7 +139,7 @@ export class DataLayerObserver {
 
   /**
    * Creates and adds a DataHandler.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param target to the data layer
    * @param debug when true enables debugging of operator transformations
    * @param debounce number of milliseconds to debounce property assignments before handling the event
@@ -155,7 +155,7 @@ export class DataLayerObserver {
   /**
    * Adds monitor to a target in the data layer. If a monitor already exists, calling this
    * function will result in a no-op.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param target to add monitors into
    */
   private addMonitor(source: string, target: DataLayerTarget) {
@@ -256,7 +256,7 @@ export class DataLayerObserver {
    * Registers a data layer target by creating the handler and monitor. This results in the target
    * being inspected, adding a DataHandler with any Operators, registering a source and
    * destination, and monitoring for changes or function calls.
-   * @param source source from the rule monitoring the data layer
+   * @param source from the rule monitoring the data layer
    * @param target from the data layer
    * @param options list of OperatorOptions to transform data before a destination
    * @param destination function using selector syntax or native function

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -139,13 +139,14 @@ export class DataLayerObserver {
 
   /**
    * Creates and adds a DataHandler.
+   * @param source source from the rule monitoring the data layer
    * @param target to the data layer
    * @param debug when true enables debugging of operator transformations
    * @param debounce number of milliseconds to debounce property assignments before handling the event
    */
-  private addHandler(target: DataLayerTarget, debug = false,
+  private addHandler(source: string, target: DataLayerTarget, debug = false,
     debounce = DataHandler.DefaultDebounceTime): DataHandler {
-    const handler = new DataHandler(target, debug, debounce);
+    const handler = new DataHandler(source, target, debug, debounce);
     this.handlers.push(handler);
 
     return handler;
@@ -154,19 +155,20 @@ export class DataLayerObserver {
   /**
    * Adds monitor to a target in the data layer. If a monitor already exists, calling this
    * function will result in a no-op.
+   * @param source source from the rule monitoring the data layer
    * @param target to add monitors into
    */
-  private addMonitor(target: DataLayerTarget) {
+  private addMonitor(source: string, target: DataLayerTarget) {
     const {
       subject, property, subjectPath, path: targetPath, selector, type,
     } = target;
 
     if (type === 'function') {
-      MonitorFactory.getInstance().create(subject, property, targetPath);
+      MonitorFactory.getInstance().create(source, subject, property, targetPath);
     } else {
       // when a selector gets used, we know the full path through the data layer and can monitor
       if (selector) {
-        MonitorFactory.getInstance().create(subject, property, subjectPath); // monitor the subject for re-assignments
+        MonitorFactory.getInstance().create(source, subject, property, subjectPath); // monitor the subject for re-assignments
       }
 
       // NOTE only the properties that would be returned from a query
@@ -174,7 +176,7 @@ export class DataLayerObserver {
       const subjectRef = target.value;
       const subjectProps = Object.getOwnPropertyNames(target.query());
       subjectProps.forEach((childProperty: string) => {
-        MonitorFactory.getInstance().create(subjectRef, childProperty, targetPath);
+        MonitorFactory.getInstance().create(source, subjectRef, childProperty, targetPath);
       });
     }
   }
@@ -253,6 +255,7 @@ export class DataLayerObserver {
    * Registers a data layer target by creating the handler and monitor. This results in the target
    * being inspected, adding a DataHandler with any Operators, registering a source and
    * destination, and monitoring for changes or function calls.
+   * @param source source from the rule monitoring the data layer
    * @param target from the data layer
    * @param options list of OperatorOptions to transform data before a destination
    * @param destination function using selector syntax or native function
@@ -263,6 +266,7 @@ export class DataLayerObserver {
    * @throws error if an error occurs during handler creation
    */
   registerTarget(
+    source: string,
     target: DataLayerTarget,
     options: OperatorOptions[],
     destination: string | Function,
@@ -280,7 +284,7 @@ export class DataLayerObserver {
      */
     if (monitor && Array.isArray(targetValue)) {
       if (targetValue.push && targetValue.unshift) {
-        this.registerTarget(DataLayerTarget.find(`${target.path}.unshift`), options, destination, false, true,
+        this.registerTarget(source, DataLayerTarget.find(`${target.path}.unshift`), options, destination, false, true,
           debug, debounce);
         workingTarget = DataLayerTarget.find(`${target.path}.push`);
       } else {
@@ -293,7 +297,7 @@ export class DataLayerObserver {
       }
     }
 
-    const handler = this.addHandler(workingTarget, !!debug, debounce);
+    const handler = this.addHandler(source, workingTarget, !!debug, debounce);
     this.addOperators(handler, options, destination);
 
     if (read) {
@@ -330,7 +334,7 @@ export class DataLayerObserver {
     // NOTE functions are always monitored
     if (monitor || workingTarget.type === 'function') {
       try {
-        this.addMonitor(workingTarget);
+        this.addMonitor(source, workingTarget);
       } catch (err) {
         Logger.getInstance().warn(LogMessageType.MonitorCreateError,
           {
@@ -420,7 +424,7 @@ export class DataLayerObserver {
     try {
       const register = () => {
         const target = DataLayerTarget.find(source);
-        this.registerTarget(target, operators, destination, readOnLoad, monitor, debug, debounce);
+        this.registerTarget(source, target, operators, destination, readOnLoad, monitor, debug, debounce);
       };
       const timeout = () => Logger.getInstance().warn(LogMessageType.RuleRegistrationError, {
         rule: id, source, reason: 'Max Retries Attempted',

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -168,7 +168,8 @@ export class DataLayerObserver {
     } else {
       // when a selector gets used, we know the full path through the data layer and can monitor
       if (selector) {
-        MonitorFactory.getInstance().create(source, subject, property, subjectPath); // monitor the subject for re-assignments
+        // monitor the subject for re-assignments
+        MonitorFactory.getInstance().create(source, subject, property, subjectPath);
       }
 
       // NOTE only the properties that would be returned from a query

--- a/test/handler.spec.ts
+++ b/test/handler.spec.ts
@@ -109,22 +109,26 @@ describe('DataHandler unit tests', () => {
   });
 
   it('data handlers should find a data layer for a given target and property', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.cart')!);
+    const source = 'digitalData.cart';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
     expect(handler).to.not.be.undefined;
   });
 
   it('data handlers should find a data layer using a path', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.user.profile[0]')!);
+    const source = 'digitalData.user.profile[0]';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
     expect(handler).to.not.be.undefined;
   });
 
   it('non-existent data layers should throw an Error', () => {
-    expect(() => new DataHandler(DataLayerTarget.find('notFound')!)).to.throw();
-    expect(() => new DataHandler(DataLayerTarget.find('notFound')!)).to.throw();
+    const source = 'notFound';
+    expect(() => new DataHandler(source, DataLayerTarget.find(source)!)).to.throw();
+    expect(() => new DataHandler(source, DataLayerTarget.find(source)!)).to.throw();
   });
 
   it('data layer event data should pass to the first operator', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
+    const source = 'digitalData.page.pageInfo';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -136,7 +140,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('transformed data should pass from operator to operator', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+    const source = 'digitalData.page';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -153,7 +158,8 @@ describe('DataHandler unit tests', () => {
   it('debug should print operator transformations to console.debug', () => {
     expectNoCalls(console, 'debug');
 
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+    const source = 'digitalData.page';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
     handler.debug = true;
 
     const seen: any[] = [];
@@ -186,7 +192,8 @@ describe('DataHandler unit tests', () => {
   it('debug output function can be configured', () => {
     const debugMessages: string[] = [];
 
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+    const source = 'digitalData.page';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
     handler.debug = true;
     handler.debugger = (message: string) => debugMessages.push(message);
 
@@ -200,7 +207,8 @@ describe('DataHandler unit tests', () => {
 
   [null, []].forEach((val) => {
     it(`returning ${JSON.stringify(val)} in an operator should halt data handling`, () => {
-      const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+      const source = 'digitalData.page';
+      const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
       const seen: any[] = [];
 
@@ -216,7 +224,8 @@ describe('DataHandler unit tests', () => {
 
   it('empty object should halt data handling', () => {
     (globalThis as any).digitalData.emptyObject = { undefinedChild: undefined };
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.emptyObject')!);
+    const source = 'digitalData.emptyObject';
+    const handler = new DataHandler(source, DataLayerTarget.find(source));
 
     const seen: any[] = [];
 
@@ -231,7 +240,8 @@ describe('DataHandler unit tests', () => {
   [0, '', false, null, []].forEach((val) => {
     it(`non-empty object with child property value ${JSON.stringify(val)} should not halt data handling`, () => {
       (globalThis as any).digitalData.nonEmptyObject = { undefinedChild: undefined, definedChild: val };
-      const handler = new DataHandler(DataLayerTarget.find('digitalData.nonEmptyObject')!);
+      const source = 'digitalData.nonEmptyObject';
+      const handler = new DataHandler(source, DataLayerTarget.find(source));
 
       const seen: any[] = [];
 
@@ -250,7 +260,8 @@ describe('DataHandler unit tests', () => {
   [0, '', false].forEach((val) => {
     it(`${typeof val} value should not halt data handling`, () => {
       (globalThis as any).digitalData.nonEmptyObject = { val };
-      const handler = new DataHandler(DataLayerTarget.find('digitalData.nonEmptyObject'));
+      const source = 'digitalData.nonEmptyObject';
+      const handler = new DataHandler(source, DataLayerTarget.find(source));
 
       const seen: any[] = [];
 
@@ -267,7 +278,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('operator exceptions should fail gracefully', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page')!);
+    const source = 'digitalData.page';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -281,9 +293,10 @@ describe('DataHandler unit tests', () => {
   });
 
   it('objects should only allow manual firing of events', () => {
+    const source = 'digitalData.fn';
     // @ts-ignore
     (globalThis as any).digitalData.fn = () => console.log('Hello World'); // eslint-disable-line no-console
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.fn')!);
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -294,7 +307,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('events with unknown types should not be handled', () => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
+    const source = 'digitalData.page.pageInfo';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -309,7 +323,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('data layer events should be delayed to allow debouncing', (done) => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
+    const source = 'digitalData.page.pageInfo';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -317,7 +332,7 @@ describe('DataHandler unit tests', () => {
     handler.push(echo);
 
     (globalThis as any).digitalData.page.pageInfo.pageID = 'changedPage';
-    handler.handleEvent(createEvent((globalThis as any).digitalData.page, 'pageInfo',
+    handler.handleEvent(createEvent(source, (globalThis as any).digitalData.page, 'pageInfo',
       (globalThis as any).digitalData.page.pageInfo, 'digitalData.page.pageInfo'));
 
     // since this occurs immediately after the handleEvent call, the debounce delay hasn't fully elapsed
@@ -330,7 +345,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('multiple data layer events should be debounced', (done) => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo')!);
+    const source = 'digitalData.page.pageInfo';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -338,11 +354,11 @@ describe('DataHandler unit tests', () => {
     handler.push(echo);
 
     (globalThis as any).digitalData.page.pageInfo.pageID = 'changedAgain';
-    handler.handleEvent(createEvent((globalThis as any).digitalData.page, 'pageInfo',
+    handler.handleEvent(createEvent(source, (globalThis as any).digitalData.page, 'pageInfo',
       (globalThis as any).digitalData.page.pageInfo, 'digitalData.page.pageInfo'));
 
     (globalThis as any).digitalData.page.pageInfo.pageID = 'changedOneMoreTime';
-    handler.handleEvent(createEvent((globalThis as any).digitalData.page, 'pageInfo',
+    handler.handleEvent(createEvent(source, (globalThis as any).digitalData.page, 'pageInfo',
       (globalThis as any).digitalData.page.pageInfo, 'digitalData.page.pageInfo'));
 
     setTimeout(() => {
@@ -352,7 +368,8 @@ describe('DataHandler unit tests', () => {
   });
 
   it('an object with no properties selected from an event should not be handled', (done) => {
-    const handler = new DataHandler(DataLayerTarget.find('digitalData.page.pageInfo[(missingProperty)]')!);
+    const source = 'digitalData.page.pageInfo[(missingProperty)]';
+    const handler = new DataHandler(source, DataLayerTarget.find(source)!);
 
     const seen: any[] = [];
 
@@ -360,7 +377,7 @@ describe('DataHandler unit tests', () => {
     handler.push(echo);
 
     (globalThis as any).digitalData.page.pageInfo.pageID = '1234';
-    handler.handleEvent(createEvent((globalThis as any).digitalData.page, 'pageInfo',
+    handler.handleEvent(createEvent(source, (globalThis as any).digitalData.page, 'pageInfo',
       (globalThis as any).digitalData.page.pageInfo, 'digitalData.page.pageInfo'));
 
     setTimeout(() => {

--- a/test/monitor-factory.spec.ts
+++ b/test/monitor-factory.spec.ts
@@ -33,10 +33,11 @@ describe('MonitorFactory unit tests', () => {
   it('it should return an existing Monitor if recreated', () => {
     expect(globalMock.digitalData.cart).to.not.be.undefined;
 
-    const cartMonitor = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    const source = 'digitalData.cart';
+    const cartMonitor = MonitorFactory.getInstance().create(source, globalMock.digitalData.cart, 'cartID', source);
     expect(cartMonitor).to.not.be.undefined;
 
-    const cartMonitor2 = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    const cartMonitor2 = MonitorFactory.getInstance().create(source, globalMock.digitalData.cart, 'cartID', source);
     expect(cartMonitor2).to.not.be.undefined;
     expect(cartMonitor2).to.eq(cartMonitor);
   });
@@ -44,12 +45,13 @@ describe('MonitorFactory unit tests', () => {
   it('it should remove a Monitor', () => {
     expect(globalMock.digitalData.cart).to.not.be.undefined;
 
-    const cartMonitor = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    const source = 'digitalData.cart';
+    const cartMonitor = MonitorFactory.getInstance().create(source, globalMock.digitalData.cart, 'cartID', source);
     expect(cartMonitor).to.not.be.undefined;
 
     MonitorFactory.getInstance().remove('digitalData.cart.cartID');
 
-    const cartMonitor2 = MonitorFactory.getInstance().create(globalMock.digitalData.cart, 'cartID', 'digitalData.cart');
+    const cartMonitor2 = MonitorFactory.getInstance().create(source, globalMock.digitalData.cart, 'cartID', source);
     expect(cartMonitor2).to.not.be.undefined;
     expect(cartMonitor2).to.not.eq(cartMonitor);
   });

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -691,7 +691,7 @@ describe('DataLayerObserver unit tests', () => {
     const target = new DataLayerTarget(user, 'profileInfo', 'myUser');
     expect(target).to.not.be.undefined;
 
-    observer.registerTarget(target, [{ name: 'query', select: '$[(profileID)]' }],
+    observer.registerTarget('digitalData.user.profile[0]', target, [{ name: 'query', select: '$[(profileID)]' }],
       (...data: any[]) => { changes = data; }, true);
 
     // check the readOnLoad

--- a/test/rules-custom.spec.ts
+++ b/test/rules-custom.spec.ts
@@ -2,7 +2,7 @@ import 'mocha';
 
 import { DataLayerRule } from '../src/observer';
 import {
-  expectEqual, waitForFS, setupGlobals, ExpectObserver, expectGlobal,
+  expectEqual, waitForFS, setupGlobals, ExpectObserver, expectGlobal, expectNoCalls,
 } from './utils/mocha';
 
 describe('Custom rules', () => {
@@ -10,7 +10,9 @@ describe('Custom rules', () => {
     ExpectObserver.getInstance().cleanup();
   });
 
-  it('should only trigger rules for property changes that match rule selector', async () => {
+  it('should only trigger rules for property changes that match rule selector', async function test() {
+    (this as any)!.timeout(3000);
+
     const s = {
       eVar11: 'test',
       eVar22: 'test',
@@ -57,5 +59,13 @@ describe('Custom rules', () => {
     [eventName, payload] = await waitForFS('event');
     expectEqual('eVar2', eventName);
     expectEqual(22, payload.eVar22);
+
+    // Verify no other calls were made to rule destinations
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expectNoCalls(expectGlobal('FS'), 'event');
+        resolve();
+      }, 1000);
+    });
   });
 });

--- a/test/rules-custom.spec.ts
+++ b/test/rules-custom.spec.ts
@@ -1,0 +1,61 @@
+import 'mocha';
+
+import { DataLayerRule } from '../src/observer';
+import {
+  expectEqual, waitForFS, setupGlobals, ExpectObserver, expectGlobal,
+} from './utils/mocha';
+
+describe('Custom rules', () => {
+  afterEach(() => {
+    ExpectObserver.getInstance().cleanup();
+  });
+
+  it('should only trigger rules for property changes that match rule selector', async () => {
+    const s = {
+      eVar11: 'test',
+      eVar22: 'test',
+    };
+
+    setupGlobals(([
+      ['s', s],
+    ]));
+
+    const rules: DataLayerRule[] = [
+      {
+        source: 's[^(eVar1)]',
+        operators: [
+          {
+            name: 'insert',
+            value: 'eVar1',
+          },
+        ],
+        destination: 'FS.event',
+      },
+      {
+        source: 's[^(eVar2)]',
+        operators: [
+          {
+            name: 'insert',
+            value: 'eVar2',
+          },
+        ],
+        destination: 'FS.event',
+      },
+    ];
+
+    ExpectObserver.getInstance().create({ rules });
+
+    expectGlobal('s').eVar11 = 11;
+
+    // Wait for event dispatch to result in rule destination calls
+    let [eventName, payload] = await waitForFS('event');
+    expectEqual('eVar1', eventName);
+    expectEqual(11, payload.eVar11);
+
+    expectGlobal('s').eVar22 = 22;
+
+    [eventName, payload] = await waitForFS('event');
+    expectEqual('eVar2', eventName);
+    expectEqual(22, payload.eVar22);
+  });
+});

--- a/test/rules-custom.spec.ts
+++ b/test/rules-custom.spec.ts
@@ -11,7 +11,8 @@ describe('Custom rules', () => {
   });
 
   it('should only trigger rules for property changes that match rule selector', async function test() {
-    (this as any)!.timeout(3000);
+    // Extend test timeout to accommodate waits for event dispatching
+    (this as any).timeout(3000);
 
     const s = {
       eVar11: 'test',

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -163,34 +163,35 @@ describe('ShimMonitor unit tests', () => {
     window.removeEventListener(createEventType(source, source), listener);
   });
 
-  it('it should remove a monitor and reassign the original value', () => {
-    const source = 'o';
-    const o = { message: 'Hello World' };
+  ['o', 'o[(message)]'].forEach((source) => {
+    it(`it should remove a monitor and reassign the original value: source ${source}`, () => {
+      const o = { message: 'Hello World' };
 
-    let descriptor = Object.getOwnPropertyDescriptor(o, 'message');
-    expect(descriptor).to.not.be.undefined;
+      let descriptor = Object.getOwnPropertyDescriptor(o, 'message');
+      expect(descriptor).to.not.be.undefined;
 
-    const { configurable, enumerable, writable } = descriptor!;
+      const { configurable, enumerable, writable } = descriptor!;
 
-    const monitor = new ShimMonitor(source, o, 'message', source);
-    expect(monitor).to.not.be.undefined;
+      const monitor = new ShimMonitor(source, o, 'message', 'o');
+      expect(monitor).to.not.be.undefined;
 
-    descriptor = Object.getOwnPropertyDescriptor(o, 'message');
-    expect(descriptor).to.not.be.undefined;
+      descriptor = Object.getOwnPropertyDescriptor(o, 'message');
+      expect(descriptor).to.not.be.undefined;
 
-    expect(descriptor!.get).to.not.be.undefined;
-    expect(descriptor!.set).to.not.be.undefined;
+      expect(descriptor!.get).to.not.be.undefined;
+      expect(descriptor!.set).to.not.be.undefined;
 
-    monitor.remove();
+      monitor.remove();
 
-    descriptor = Object.getOwnPropertyDescriptor(o, 'message');
+      descriptor = Object.getOwnPropertyDescriptor(o, 'message');
 
-    expect(descriptor).to.not.be.undefined;
-    expect(descriptor!.get).to.be.undefined;
-    expect(descriptor!.set).to.be.undefined;
-    expect(descriptor!.configurable).to.eq(configurable);
-    expect(descriptor!.enumerable).to.eq(enumerable);
-    expect(descriptor!.writable).to.eq(writable);
+      expect(descriptor).to.not.be.undefined;
+      expect(descriptor!.get).to.be.undefined;
+      expect(descriptor!.set).to.be.undefined;
+      expect(descriptor!.configurable).to.eq(configurable);
+      expect(descriptor!.enumerable).to.eq(enumerable);
+      expect(descriptor!.writable).to.eq(writable);
+    });
   });
 
   it('it should throw an error for sealed and frozen objects', () => {
@@ -201,6 +202,6 @@ describe('ShimMonitor unit tests', () => {
     Object.seal(s);
 
     expect(() => new ShimMonitor('f', f, 'message', 'f')).to.throw();
-    expect(() => new ShimMonitor('s', s, 'message', 's')).to.throw();
+    expect(() => new ShimMonitor('s[(message)]', s, 'message', 's')).to.throw();
   });
 });

--- a/test/shim-monitor.spec.ts
+++ b/test/shim-monitor.spec.ts
@@ -132,7 +132,8 @@ describe('ShimMonitor unit tests', () => {
       throw new Error(message);
     };
 
-    expectEventListener(createEventType(source, source), ['Hello World'], done); // NOTE the value emitted is a list of args
+    // NOTE the value emitted is a list of args
+    expectEventListener(createEventType(source, source), ['Hello World'], done);
 
     const listMonitor = new ShimMonitor(source, globalMock.dataLayer, 'error', source);
     expect(listMonitor).to.not.be.undefined;

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -284,13 +284,45 @@ export function expectRule(id: string, ruleset?: string): DataLayerRule {
 }
 
 /**
+ * Valid FullStory object method names.
+ */
+type FSMethodName = 'event' | 'identify' | 'log' | 'setVars' | 'setUserVars';
+
+/**
  * A convenience method for `expectParams` that checks the global FullStory object.
  * @param methodName FullStory API function (`methodName` arg for `expectParams`)
  * @param namespace Global object if FullStory is not `FS`
  */
-export function expectFS(methodName: 'event' | 'identify' | 'log' | 'setVars' | 'setUserVars',
-  namespace = 'FS'): any[] {
+export function expectFS(methodName: FSMethodName, namespace = 'FS'): any[] {
   const fs = expectGlobal(namespace);
   expect(fs).to.be.ok;
   return expectParams(fs, methodName);
+}
+
+/**
+ * Similar to `expectFS`, `waitForFS` is a convenicne method for `expectParams` that
+ * checks the global FullStory object. Unlike `expectFS`, `waitForFS` supports waiting
+ * for a global FullStory object method call within a timeout period.
+ * @param methodName FullStory API function (`methodName` arg for `expectParams`)
+ * @param namespace Global object if FullStory is not `FS`
+ * @param timeout Time in milliseconds after which the Promise is rejected
+ */
+export function waitForFS(methodName: FSMethodName, namespace = 'FS', timeout: number = 1000): Promise<any[]> {
+  const startTime = new Date().getTime();
+
+  return new Promise<any[]>((resolve, reject) => {
+    const expectFSInterval = setInterval(() => {
+      try {
+        const params = expectFS(methodName, namespace);
+        clearInterval(expectFSInterval);
+        resolve(params);
+      } catch {
+        const elapsedTime = new Date().getTime() - startTime;
+        if (elapsedTime >= timeout) {
+          clearInterval(expectFSInterval);
+          reject(new Error('waitForFS timeout exceeded.'));
+        }
+      }
+    }, 50);
+  });
 }

--- a/test/utils/mocha.ts
+++ b/test/utils/mocha.ts
@@ -307,7 +307,7 @@ export function expectFS(methodName: FSMethodName, namespace = 'FS'): any[] {
  * @param namespace Global object if FullStory is not `FS`
  * @param timeout Time in milliseconds after which the Promise is rejected
  */
-export function waitForFS(methodName: FSMethodName, namespace = 'FS', timeout: number = 1000): Promise<any[]> {
+export function waitForFS(methodName: FSMethodName, namespace = 'FS', timeout: number = 500): Promise<any[]> {
   const startTime = new Date().getTime();
 
   return new Promise<any[]>((resolve, reject) => {


### PR DESCRIPTION
When applying selector patterns (e.g. prefix / head match) to rule sources it was previously possible for a rule to be triggered by changes to a property on the underlying source even if the property that changed didn't match the rule's selector pattern.

Example: Rule source `s[^(eVar1)]` should only care about changes to `s.eVar1`, `s.eVar10`, `s.eVar100`, etc. However, if another rule were monitoring `s[^(eVar2)]` and the value of `s.eVar2` changed the rule monitoring `s[^(eVar1)]` would've been triggered since both rules monitored the same source `s`. This change partitions eventing by rule source such that rules with different sources are triggered independently by the properties they're monitoring.