### PR TITLE
Add telemetry abstractions and default provider implementation

### DIFF
--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,0 +1,98 @@
+/**
+ * Optional metadata to include with telemetry events
+ */
+type Attributes = Record<string, any>;
+
+/**
+ * A base telemetry event representing data applicable to all telemetry events
+ */
+interface TelemetryEvent {
+  /**
+   * The name of the event
+   */
+  name: string;
+
+  /**
+   * The time at which the event was captured; typically an ISO-8601 UTC string
+   */
+  timestamp: string;
+
+  /**
+   * Optional metadata to include with the event
+   */
+  attributes?: Attributes;
+}
+
+/**
+ * A timespan telemetry event which captures the duration of some operation
+ */
+interface TelemetrySpanEvent extends TelemetryEvent {
+  /**
+   * The timespan event duration; typically captured in milliseconds
+   */
+  duration: number;
+}
+
+/**
+ * A count telemetry event which captures an incrementing count of some measurement
+ */
+interface TelemetryCountEvent extends TelemetryEvent {
+  value: number;
+}
+
+/**
+ * Sends transient telemetry events to some destination where they may be
+ * persisted and analyzed
+ */
+interface TelemetryExporter {
+  /**
+   * Sends a timespan event to some destination
+   *
+   * @param {TelemetrySpanEvent} span The timespan event to send
+   */
+  sendSpan: (span: TelemetrySpanEvent) => void;
+
+  /**
+   * Sends a count event to some destination.
+   *
+   * @param {TelemetryCountEvent} count The count event to send
+   */
+  sendCount: (count: TelemetryCountEvent) => void;
+}
+
+/**
+ * A timespan duration which, when ended, should report telemetry to
+ * its parent {@link TelemetryProvider}. The parent {@link TelemetryProvider}
+ * may export this telemetry for persistence and analysis
+ */
+interface TelemetrySpan {
+  /**
+   * Ends the timespan duration, at which point this duration should be
+   * reported to the parent {@link TelemetryProvider}.
+   */
+  end: () => void;
+}
+
+/**
+ * Captures telemetry events which may be exported to a destination for
+ * persistence and analysis. May export telemetry events using a
+ * {@link TelemetryExporter}
+ */
+interface TelemetryProvider {
+  /**
+   * Starts a new timespan to measure the duration of some operation
+   *
+   * @param {string} name The name of the timespan event
+   * @param {Attributes | undefined} attributes Optional metadata to include with the event
+   */
+  startSpan: (name: string, attributes?: Attributes) => TelemetrySpan
+
+  /**
+   * Captures a new increment value for some count
+   *
+   * @param {string} name The name of the count event
+   * @param {number} value The value by which to increment the count event
+   * @param {Attributes | undefined} attributes Optional metadata to include with the event
+   */
+  count: (name: string, value: number, attributes?: Attributes) => void;
+}

--- a/test/telemetry.spec.ts
+++ b/test/telemetry.spec.ts
@@ -1,0 +1,87 @@
+/* eslint-disable class-methods-use-this, @typescript-eslint/no-unused-vars */
+import { expect } from 'chai';
+import 'mocha';
+
+import DefaultTelemetryProvider from '../src/utils/telemetry';
+import { MockClass } from './mocks/mock';
+import { expectNoCalls, expectParams } from './utils/mocha';
+
+class MockTelemetryExporter extends MockClass {
+  sendSpan(): void {}
+
+  sendCount(): void {}
+}
+
+describe('DefaultTelemetryProvider', () => {
+  describe('startSpan', () => {
+    it('sends span event to telemetry exporter when span is ended', async () => {
+      const name = 'test';
+      const attributes: Record<string, any> = {
+        prop: 'value',
+      };
+      const exporter = new MockTelemetryExporter();
+      const provider = new DefaultTelemetryProvider(exporter);
+
+      const span = provider.startSpan(name, attributes);
+      const startTime = new Date().getTime();
+      expectNoCalls(exporter, 'sendSpan');
+
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          span.end();
+          resolve();
+        }, 50);
+      });
+
+      const endTime = new Date().getTime();
+      const expectedDuration = endTime - startTime;
+      const [spanEvent] = expectParams(exporter, 'sendSpan');
+
+      expect(spanEvent.name).to.equal(name);
+      expect(spanEvent.duration).to.be.greaterThan(expectedDuration * 0.9);
+      expect(spanEvent.duration).to.be.lessThan(expectedDuration * 1.1);
+
+      Object.keys(attributes).forEach((key) => {
+        expect(spanEvent.attributes[key]).to.equal(attributes[key]);
+      });
+
+      const timestamp = Date.parse(spanEvent.timestamp);
+      expect(timestamp).to.be.gte(startTime);
+      expect(timestamp).to.be.lte(endTime);
+
+      expectNoCalls(exporter, 'sendCount');
+    });
+  });
+
+  describe('count', () => {
+    it('sends count event to telemetry exporter', () => {
+      const name = 'test';
+      const attributes: Record<string, any> = {
+        prop: 'value',
+      };
+      const value = 73;
+      const exporter = new MockTelemetryExporter();
+      const provider = new DefaultTelemetryProvider(exporter);
+      const startTime = new Date().getTime();
+      expectNoCalls(exporter, 'sendCount');
+
+      provider.count(name, value, attributes);
+
+      const endTime = new Date().getTime();
+      const [countEvent] = expectParams(exporter, 'sendCount');
+
+      expect(countEvent.name).to.equal(name);
+      expect(countEvent.value).to.equal(value);
+
+      Object.keys(attributes).forEach((key) => {
+        expect(countEvent.attributes[key]).to.equal(attributes[key]);
+      });
+
+      const timestamp = Date.parse(countEvent.timestamp);
+      expect(timestamp).to.be.gte(startTime);
+      expect(timestamp).to.be.lte(endTime);
+
+      expectNoCalls(exporter, 'sendSpan');
+    });
+  });
+});


### PR DESCRIPTION
Adds initial abstractions and a default provider implementation for collecting telemetry. The following work will build upon the changes in this PR:

- Implement "safe" telemetry wrappers which prevent telemetry collection and reporting from throwing errors
- Wire up telemetry to collect metrics (e.g. initialization duration)
- Add a console telemetry exporter which is used by default
- Enable configuring a custom telemetry provider or telemetry exporter

I haven't bumped the library version as part of these changes since these abstractions and the default provider implementation are unused and will not be included in build bundles.