### PR TITLE
Allowing testing of empty string for selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 1.12.1
+
+- Change made to allow searching for empty strings with ```''``` or ```""```.  Technically any string comparison can be quoted, but this was specifically added for searching for empty string 
+
 ### 1.12.0
 
 - Rules can no longer be triggered by changes to properties which don't match a rule's selector

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/v1.12.0.js
+- https://edge.fullstory.com/datalayer/v1/v1.12.1.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -393,14 +393,25 @@ class PathElement {
         case 'boolean':
           if (prop[opProp.name] !== (opProp.value.toLowerCase() === 'true')) return undefined;
           break;
-        case 'string':
+        case 'string': {
+          let realString = opProp.value;
+          // look for quoted values, and strip the quotes off if they are there
+          if (opProp.value) {
+            const firstCharacter = realString.charAt(0);
+            const lastCharacter = realString.charAt(realString.length - 1);
+            if ((firstCharacter === '"' && lastCharacter === '"')
+              || (firstCharacter === "'" && lastCharacter === "'")) {
+              realString = realString.substring(1, realString.length - 1);
+            }
+          }
           // eslint-disable-next-line eqeqeq
-          if (opProp.operator === '==' && prop[opProp.name] != opProp.value) return undefined;
+          if (opProp.operator === '==' && prop[opProp.name] != realString) return undefined;
           // eslint-disable-next-line eqeqeq
-          if (opProp.operator == '!=' && prop[opProp.name] == opProp.value) return undefined;
-          if (opProp.operator === '=^' && !startsWith(prop[opProp.name], opProp.value)) return undefined;
-          if (opProp.operator === '!^' && startsWith(prop[opProp.name], opProp.value)) return undefined;
+          if (opProp.operator == '!=' && prop[opProp.name] == realString) return undefined;
+          if (opProp.operator === '=^' && !startsWith(prop[opProp.name], realString)) return undefined;
+          if (opProp.operator === '!^' && startsWith(prop[opProp.name], realString)) return undefined;
           break;
+        }
         case 'number':
           // eslint-disable-next-line eqeqeq
           if (opProp.operator === '==' && prop[opProp.name] != opProp.value) return undefined;

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -248,6 +248,12 @@ describe('test selection paths', () => {
     expect(select('favorites[?(emptyString!="")]', testData)).to.be.undefined;
     expect(select('favorites[?(emptyString!=" ")]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(emptyString=" ")]', testData)).to.be.undefined;
+    expect(select('favorites[?(color="red)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color=red")]', testData)).to.be.undefined;
+    expect(select("favorites[?(color='red)]", testData)).to.be.undefined;
+    expect(select("favorites[?(color=red')]", testData)).to.be.undefined;
+    expect(select("favorites[?(color=')]", testData)).to.be.undefined;
+    expect(select('favorites[?(color=")]', testData)).to.be.undefined;
   });
 
   it('filter notation should return a reference to the object', () => {

--- a/test/selector.spec.ts
+++ b/test/selector.spec.ts
@@ -7,6 +7,7 @@ import { select, validate, Path } from '../src/selector';
 const testData = {
   favorites: {
     color: 'red',
+    emptyString: '',
     number: 25,
     pickle: 'dill',
     films: {
@@ -196,6 +197,10 @@ describe('test selection paths', () => {
     expect(select('favorites[?(bogus)]', testData)).to.be.undefined;
     expect(select('favorites[?(color=red)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(color!=red)]', testData)).to.be.undefined;
+    expect(select('favorites[?(color="red")]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(color!="red")]', testData)).to.be.undefined;
+    expect(select("favorites[?(color='red')]", testData)).to.eq(testData.favorites);
+    expect(select("favorites[?(color!='red')]", testData)).to.be.undefined;
     expect(select('favorites[?(dot.prop)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(dot.prop=1.0)]', testData)).to.eq(testData.favorites);
     expect(select('favorites[?(dot.prop=2.0)]', testData)).to.be.undefined;
@@ -233,6 +238,16 @@ describe('test selection paths', () => {
     expect(select('myEvent[?(event=^gtm.)]', testData)).to.be.undefined;
     expect(select('myEvent[?(event=^my)]', testData)).to.not.be.undefined;
     expect(select('favorites[?(missing=^my)]', testData)).to.be.undefined;
+    expect(select('gtmEvent[?(event!^"gtm.")]', testData)).to.be.undefined;
+    expect(select('gtmEvent[?(event=^"gtm.")]', testData)).to.not.be.undefined;
+    expect(select('myEvent[?(event!^"gtm.")]', testData)).to.not.be.undefined;
+    expect(select('myEvent[?(event=^"gtm.")]', testData)).to.be.undefined;
+    expect(select('myEvent[?(event=^"my")]', testData)).to.not.be.undefined;
+    expect(select('favorites[?(missing=^"my")]', testData)).to.be.undefined;
+    expect(select('favorites[?(emptyString="")]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(emptyString!="")]', testData)).to.be.undefined;
+    expect(select('favorites[?(emptyString!=" ")]', testData)).to.eq(testData.favorites);
+    expect(select('favorites[?(emptyString=" ")]', testData)).to.be.undefined;
   });
 
   it('filter notation should return a reference to the object', () => {


### PR DESCRIPTION
This pull request allows string values to be quoted with `'` or `"` values.  To be backwards compatible, the quotes are optional.  In the code I simply look for them in string values and strip them off if they are there.  Tests were updated to try with and without quotes, as well as testing for empty string.  Empty string can be tested by doing ?(attribute='') in the selector.