### PR TITLE
Add console telemetry exporter

### DIFF
--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -144,7 +144,7 @@ class DefaultTelemetrySpan implements TelemetrySpan {
  * A default {@link TelemetryProvider} implementation which handles timespan
  * measurement and which sends telemetry events to the given {@link TelemetryExporter}
  */
-export default class DefaultTelemetryProvider implements TelemetryProvider {
+export class DefaultTelemetryProvider implements TelemetryProvider {
   /**
    * Creates a new {@link DefaultTelemetryProvider} instance
    *
@@ -183,3 +183,27 @@ export default class DefaultTelemetryProvider implements TelemetryProvider {
     });
   }
 }
+
+/**
+ * A {@link TelemetryExporter} which writes telemetry events to
+ * console.debug
+ */
+export const consoleTelemetryExporter: TelemetryExporter = {
+  /**
+   * Writes the given timespan event to console.debug
+   *
+   * @param span The timespan event to write
+   */
+  sendSpan: (span: TelemetrySpanEvent) => {
+    console.debug('Telemetry Span', span);
+  },
+
+  /**
+   * Writes the given count event to console.debug
+   *
+   * @param count The count event to write
+   */
+  sendCount: (count: TelemetryCountEvent) => {
+    console.debug('Telemetry Count', count);
+  },
+};

--- a/test/operator-function.spec.ts
+++ b/test/operator-function.spec.ts
@@ -25,7 +25,7 @@ describe('function operator unit tests', () => {
   });
 
   afterEach(() => {
-    (globalThis as any) = originalConsole;
+    (globalThis as any).console = originalConsole;
     delete (globalThis as any).testClosure;
   });
 

--- a/test/telemetry.spec.ts
+++ b/test/telemetry.spec.ts
@@ -7,9 +7,6 @@ import { MockClass } from './mocks/mock';
 import Console from './mocks/console';
 import { expectNoCalls, expectParams } from './utils/mocha';
 
-const originalConsole = globalThis.console;
-const mockConsole = new Console();
-
 class MockTelemetryExporter extends MockClass {
   sendSpan(): void {}
 
@@ -17,141 +14,137 @@ class MockTelemetryExporter extends MockClass {
 }
 
 describe('DefaultTelemetryProvider', () => {
-  describe('startSpan', () => {
-    it('sends span event to telemetry exporter when span is ended', async () => {
-      const name = 'test';
-      const attributes: Record<string, any> = {
-        prop: 'value',
-      };
-      const exporter = new MockTelemetryExporter();
-      const provider = new DefaultTelemetryProvider(exporter);
+  it('sends span event to telemetry exporter when span is ended', async () => {
+    const name = 'test';
+    const attributes: Record<string, any> = {
+      prop: 'value',
+    };
+    const exporter = new MockTelemetryExporter();
+    const provider = new DefaultTelemetryProvider(exporter);
 
-      const span = provider.startSpan(name, attributes);
-      const startTime = new Date().getTime();
-      expectNoCalls(exporter, 'sendSpan');
+    const span = provider.startSpan(name, attributes);
+    const startTime = new Date().getTime();
+    expectNoCalls(exporter, 'sendSpan');
 
-      await new Promise<void>((resolve) => {
-        setTimeout(() => {
-          span.end();
-          resolve();
-        }, 50);
-      });
-
-      const endTime = new Date().getTime();
-      const expectedDuration = endTime - startTime;
-      const [spanEvent] = expectParams(exporter, 'sendSpan');
-
-      expect(spanEvent.name).to.equal(name);
-      expect(spanEvent.duration).to.be.greaterThan(expectedDuration * 0.9);
-      expect(spanEvent.duration).to.be.lessThan(expectedDuration * 1.1);
-
-      Object.keys(attributes).forEach((key) => {
-        expect(spanEvent.attributes[key]).to.equal(attributes[key]);
-      });
-
-      const timestamp = Date.parse(spanEvent.timestamp);
-      expect(timestamp).to.be.gte(startTime);
-      expect(timestamp).to.be.lte(endTime);
-
-      expectNoCalls(exporter, 'sendCount');
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        span.end();
+        resolve();
+      }, 50);
     });
+
+    const endTime = new Date().getTime();
+    const expectedDuration = endTime - startTime;
+    const [spanEvent] = expectParams(exporter, 'sendSpan');
+
+    expect(spanEvent.name).to.equal(name);
+    expect(spanEvent.duration).to.be.greaterThan(expectedDuration * 0.9);
+    expect(spanEvent.duration).to.be.lessThan(expectedDuration * 1.1);
+
+    Object.keys(attributes).forEach((key) => {
+      expect(spanEvent.attributes[key]).to.equal(attributes[key]);
+    });
+
+    const timestamp = Date.parse(spanEvent.timestamp);
+    expect(timestamp).to.be.gte(startTime);
+    expect(timestamp).to.be.lte(endTime);
+
+    expectNoCalls(exporter, 'sendCount');
   });
 
-  describe('count', () => {
-    it('sends count event to telemetry exporter', () => {
-      const name = 'test';
-      const attributes: Record<string, any> = {
-        prop: 'value',
-      };
-      const value = 73;
-      const exporter = new MockTelemetryExporter();
-      const provider = new DefaultTelemetryProvider(exporter);
-      const startTime = new Date().getTime();
-      expectNoCalls(exporter, 'sendCount');
+  it('sends count event to telemetry exporter', () => {
+    const name = 'test';
+    const attributes: Record<string, any> = {
+      prop: 'value',
+    };
+    const value = 73;
+    const exporter = new MockTelemetryExporter();
+    const provider = new DefaultTelemetryProvider(exporter);
+    const startTime = new Date().getTime();
+    expectNoCalls(exporter, 'sendCount');
 
-      provider.count(name, value, attributes);
+    provider.count(name, value, attributes);
 
-      const endTime = new Date().getTime();
-      const [countEvent] = expectParams(exporter, 'sendCount');
+    const endTime = new Date().getTime();
+    const [countEvent] = expectParams(exporter, 'sendCount');
 
-      expect(countEvent.name).to.equal(name);
-      expect(countEvent.value).to.equal(value);
+    expect(countEvent.name).to.equal(name);
+    expect(countEvent.value).to.equal(value);
 
-      Object.keys(attributes).forEach((key) => {
-        expect(countEvent.attributes[key]).to.equal(attributes[key]);
-      });
-
-      const timestamp = Date.parse(countEvent.timestamp);
-      expect(timestamp).to.be.gte(startTime);
-      expect(timestamp).to.be.lte(endTime);
-
-      expectNoCalls(exporter, 'sendSpan');
+    Object.keys(attributes).forEach((key) => {
+      expect(countEvent.attributes[key]).to.equal(attributes[key]);
     });
+
+    const timestamp = Date.parse(countEvent.timestamp);
+    expect(timestamp).to.be.gte(startTime);
+    expect(timestamp).to.be.lte(endTime);
+
+    expectNoCalls(exporter, 'sendSpan');
   });
 });
 
 describe('ConsoleTelemetryExporter', () => {
-  before(() => {
+  const originalConsole = globalThis.console;
+  let mockConsole: Console;
+
+  beforeEach(() => {
+    mockConsole = new Console();
     (globalThis as any).console = mockConsole;
   });
 
-  after(() => {
+  afterEach(() => {
     (globalThis as any).console = originalConsole;
   });
 
-  describe('sendSpan', () => {
-    it('writes telemetry span to console.debug', () => {
-      expectNoCalls(mockConsole, 'debug');
-      const span = {
-        name: 'test',
-        timestamp: new Date().toISOString(),
-        attributes: {
-          prop: 'value',
-        },
-        duration: 23,
-      };
+  it('writes telemetry span to console.debug', () => {
+    expectNoCalls(mockConsole, 'debug');
+    const span = {
+      name: 'test',
+      timestamp: new Date().toISOString(),
+      attributes: {
+        prop: 'value',
+      },
+      duration: 23,
+    };
 
-      consoleTelemetryExporter.sendSpan(span);
-      const [message, event] = expectParams(mockConsole, 'debug');
+    consoleTelemetryExporter.sendSpan(span);
+    const [message, event] = expectParams(mockConsole, 'debug');
 
-      expect(message).to.equal('Telemetry Span');
-      expect(event.name).to.equal(span.name);
-      expect(event.timestamp).to.equal(span.timestamp);
-      expect(event.attributes.prop).to.equal(span.attributes.prop);
-      expect(event.duration).to.equal(span.duration);
+    expect(message).to.equal('Telemetry Span');
+    expect(event.name).to.equal(span.name);
+    expect(event.timestamp).to.equal(span.timestamp);
+    expect(event.attributes.prop).to.equal(span.attributes.prop);
+    expect(event.duration).to.equal(span.duration);
 
-      expectNoCalls(mockConsole, 'log');
-      expectNoCalls(mockConsole, 'info');
-      expectNoCalls(mockConsole, 'error');
-      expectNoCalls(mockConsole, 'warn');
-    });
+    expectNoCalls(mockConsole, 'log');
+    expectNoCalls(mockConsole, 'info');
+    expectNoCalls(mockConsole, 'error');
+    expectNoCalls(mockConsole, 'warn');
   });
 
-  describe('sendCount', () => {
-    it('writes telemetry count to console.debug', () => {
-      expectNoCalls(mockConsole, 'debug');
-      const count = {
-        name: 'test',
-        timestamp: new Date().toISOString(),
-        attributes: {
-          prop: 'value',
-        },
-        value: 32,
-      };
+  it('writes telemetry count to console.debug', () => {
+    expectNoCalls(mockConsole, 'debug');
+    const count = {
+      name: 'test',
+      timestamp: new Date().toISOString(),
+      attributes: {
+        prop: 'value',
+      },
+      value: 32,
+    };
 
-      consoleTelemetryExporter.sendCount(count);
-      const [message, event] = expectParams(mockConsole, 'debug');
+    consoleTelemetryExporter.sendCount(count);
+    const [message, event] = expectParams(mockConsole, 'debug');
 
-      expect(message).to.equal('Telemetry Count');
-      expect(event.name).to.equal(count.name);
-      expect(event.timestamp).to.equal(count.timestamp);
-      expect(event.attributes.prop).to.equal(count.attributes.prop);
-      expect(event.value).to.equal(count.value);
+    expect(message).to.equal('Telemetry Count');
+    expect(event.name).to.equal(count.name);
+    expect(event.timestamp).to.equal(count.timestamp);
+    expect(event.attributes.prop).to.equal(count.attributes.prop);
+    expect(event.value).to.equal(count.value);
 
-      expectNoCalls(mockConsole, 'log');
-      expectNoCalls(mockConsole, 'info');
-      expectNoCalls(mockConsole, 'error');
-      expectNoCalls(mockConsole, 'warn');
-    });
+    expectNoCalls(mockConsole, 'log');
+    expectNoCalls(mockConsole, 'info');
+    expectNoCalls(mockConsole, 'error');
+    expectNoCalls(mockConsole, 'warn');
   });
 });


### PR DESCRIPTION
Adds a console telemetry exporter which will be the default telemetry exporter once telemetry collection is wired up. Builds upon work in #161.

Upcoming work:
- Implement "safe" telemetry wrappers which prevent telemetry collection and reporting from throwing errors
- Wire up telemetry to collect metrics (e.g. initialization duration)
- Enable configuring a custom telemetry provider or telemetry exporter

I haven't bumped the library version as part of these changes since this exporter is unused and will not be included in build bundles.