### PR TITLE
Clean up whitespace which fails release sync precommit hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ### 1.12.1
 
-- Change made to allow searching for empty strings with ```''``` or ```""```.  Technically any string comparison can be quoted, but this was specifically added for searching for empty string 
+- Change made to allow searching for empty strings with ```''``` or ```""```.  Technically any string comparison can be quoted, but this was specifically added for searching for empty string
 
 ### 1.12.0
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -49,4 +49,3 @@ The following additional adjustments can be made:
 - If rules have been thoroughly tested, _dlo_validateRules can be set to false.
 - Use the global readOnLoad configuration option only if you have a static data layer.  Each rule can have an individual readOnLoad option depending on the data layer’s behavior.
 - Do not use previewMode set to true when conducting performance tests.  This will result in stringifying data and printing to the console leading to significant time in the fireEvent step.
-


### PR DESCRIPTION
I haven't bumped the library version since there aren't any behavior changes. This extraneous whitespace trips up precommit hooks as part of synchronizing for releases.