### PR TITLE
Fixing logLevel bug where ERROR (0) would get dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/v1.12.1.js
+- https://edge.fullstory.com/datalayer/v1/v1.13.1.js
 - https://edge.fullstory.com/datalayer/v1/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-typescript": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -130,6 +130,7 @@ export default function _dlo_initializeFromWindow() {
         break;
       case 'string':
         level = parseInt(win._dlo_logLevel, 10);
+        level = Number.isNaN(level) ? undefined : level;
         break;
       default:
         level = undefined;

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -120,25 +120,10 @@ export default function _dlo_initializeFromWindow() {
       Logger.getInstance().warn(LogMessageType.ObserverRulesNone);
     }
 
-    // get the log level from win._dlo_logLevel
-    // we allow string or number, and use parseInt if it is a string
-    // otherwise it is set to undefined, which will use the default log level
-    let level;
-    switch (typeof win._dlo_logLevel) {
-      case 'number':
-        level = win._dlo_logLevel;
-        break;
-      case 'string':
-        level = parseInt(win._dlo_logLevel, 10);
-        level = Number.isNaN(level) ? undefined : level;
-        break;
-      default:
-        level = undefined;
-    }
     win._dlo_observer = new DataLayerObserver({
       appender: win._dlo_appender || undefined,
       beforeDestination: win._dlo_beforeDestination || undefined,
-      logLevel: level,
+      logLevel: win._dlo_logLevel,
       previewMode: win._dlo_previewMode === true,
       previewDestination: win._dlo_previewDestination || undefined,
       readOnLoad: win._dlo_readOnLoad === true,

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -120,10 +120,24 @@ export default function _dlo_initializeFromWindow() {
       Logger.getInstance().warn(LogMessageType.ObserverRulesNone);
     }
 
+    // get the log level from win._dlo_logLevel
+    // we allow string or number, and use parseInt if it is a string
+    // otherwise it is set to undefined, which will use the default log level
+    let level;
+    switch (typeof win._dlo_logLevel) {
+      case 'number':
+        level = win._dlo_logLevel;
+        break;
+      case 'string':
+        level = parseInt(win._dlo_logLevel, 10);
+        break;
+      default:
+        level = undefined;
+    }
     win._dlo_observer = new DataLayerObserver({
       appender: win._dlo_appender || undefined,
       beforeDestination: win._dlo_beforeDestination || undefined,
-      logLevel: win._dlo_logLevel || undefined,
+      logLevel: level,
       previewMode: win._dlo_previewMode === true,
       previewDestination: win._dlo_previewDestination || undefined,
       readOnLoad: win._dlo_readOnLoad === true,

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -126,7 +126,7 @@ export class DataLayerObserver {
 
     // set the level after the appender is assigned since the first call to getInstance()
     // inits the Logger; else the Logger will use the default appender (e.g. console)
-    if (logLevel) {
+    if (logLevel !== undefined) {
       Logger.getInstance().level = logLevel;
     }
 

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -12,7 +12,7 @@ import {
   expectParams, expectNoCalls, expectCall, ExpectObserver, expectGlobal, expectEqual, setGlobal,
 } from './utils/mocha';
 import { Operator, OperatorOptions } from '../src/operator';
-import { LogEvent, LogLevel } from '../src/utils/logger';
+import { LogEvent, LogLevel, Logger } from '../src/utils/logger';
 import DataHandler from '../src/handler';
 import { MockClass } from './mocks/mock';
 import MonitorFactory from '../src/monitor-factory';
@@ -411,6 +411,28 @@ describe('DataLayerObserver unit tests', () => {
     expect(event).to.not.be.undefined;
 
     ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  [
+    { configLevel: 0, expectedLevel: 0 },
+    { configLevel: 1, expectedLevel: 1 },
+    { configLevel: 2, expectedLevel: 2 },
+    { configLevel: 3, expectedLevel: 3 },
+    // Passing undefined shouldn't change the global log level
+    { configLevel: undefined, expectedLevel: () => Logger.getInstance().level },
+  ].forEach((tc) => {
+    it(`sets the global log level to ${tc.expectedLevel} given config value ${tc.configLevel}`, () => {
+      const expectedLevel = typeof tc.expectedLevel === 'function' ? tc.expectedLevel() : tc.expectedLevel;
+
+      const observer = ExpectObserver.getInstance().create({
+        logLevel: tc.configLevel,
+        rules: [],
+      });
+
+      expect(Logger.getInstance().level).to.equal(expectedLevel);
+
+      ExpectObserver.getInstance().cleanup(observer);
+    });
   });
 
   it('updating properties should trigger the data handler', (done) => {


### PR DESCRIPTION
Due to the previous technique of || the value 0 would never come through.  This allows that value to come through as well as officially trying to parse string values if they contain numbers