### PR TITLE
Instrument significant timings, rule counts, and error counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 2.0.0
+
+- Changes telemetry collection interfaces from e.g. `Telemetry.getInstance().startSpan` to `Telemetry.startSpan`
+- Instruments significant timing and count metrics
+
 ### 1.13.1
 
 - Fixed an initialization bug which prevented configuring a log level of `0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.13.1",
       "license": "MIT",
       "devDependencies": {
+        "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-typescript": "^5.0.1",
         "@types/chai": "^4.2.11",
         "@types/jsdom": "^16.2.3",
@@ -433,6 +434,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -7125,6 +7138,15 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
     },
     "@rollup/plugin-typescript": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "1.13.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "1.13.1",
+  "version": "2.0.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/fullstorydev/fullstory-data-layer-observer#readme",
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-typescript": "^5.0.1",
     "@types/chai": "^4.2.11",
     "@types/jsdom": "^16.2.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
-import {terser} from 'rollup-plugin-terser';
+import json from '@rollup/plugin-json';
+import { terser } from 'rollup-plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 
 export default {
@@ -6,25 +7,27 @@ export default {
   output: [
     {
       format: 'iife',
-      file: 'build/dlo.js'
+      file: 'build/dlo.js',
     },
     {
       file: 'build/dlo.min.js',
       format: 'cjs',
       name: 'version',
       plugins: [terser({
-        enclose: true
-      })]
-    }
+        enclose: true,
+      })],
+    },
   ],
   plugins: [
+    json(),
     typescript({
-      target: "es5",
-      module: "es2015",
+      target: 'es5',
+      module: 'es2015',
       declaration: false,
       declarationMap: false,
       sourceMap: false,
-      resolveJsonModule: false
-    })
-  ]
+      resolveJsonModule: true,
+      moduleResolution: 'node',
+    }),
+  ],
 };

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -2,7 +2,9 @@
 import { Logger, LogMessageType } from '../utils/logger';
 import { startsWith } from '../utils/object';
 import { DataLayerObserver } from '../observer';
-import { defaultDloAttributes, Telemetry, telemetryType } from '../utils/telemetry';
+import {
+  defaultDloAttributes, errorAttributes, errorType, Telemetry, telemetryType,
+} from '../utils/telemetry';
 
 /*
 This is where we initialize the DataLayerObserver from this info:
@@ -87,6 +89,7 @@ function _dlo_collectRules(): any[] {
     return results;
   } catch (err) {
     Logger.getInstance().error(LogMessageType.RuleRegistrationError, { reason: `Error: ${err}` });
+    Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.ruleRegistrationError));
     return [];
   }
 }
@@ -139,5 +142,6 @@ export default function _dlo_initializeFromWindow() {
     initializationSpan.end();
   } catch (err) {
     Logger.getInstance().error(LogMessageType.ObserverInitializationError, { reason: `Error: ${err}` });
+    Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerInitializationError));
   }
 }

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -2,7 +2,7 @@
 import { Logger, LogMessageType } from '../utils/logger';
 import { startsWith } from '../utils/object';
 import { DataLayerObserver } from '../observer';
-import { Telemetry } from '../utils/telemetry';
+import { defaultDloAttributes, Telemetry, telemetryType } from '../utils/telemetry';
 
 /*
 This is where we initialize the DataLayerObserver from this info:
@@ -67,7 +67,7 @@ window['_dlo_rulesFromOpsTeam'] = [
 
 function _dlo_collectRules(): any[] {
   try {
-    const startTime = Date.now();
+    const ruleCollectionSpan = Telemetry.startSpan(telemetryType.ruleCollectionSpan);
     const results: any[] = [];
     Object.getOwnPropertyNames(window).forEach((propName) => {
       if (startsWith(propName, '_dlo_rules') === false) return;
@@ -83,7 +83,7 @@ function _dlo_collectRules(): any[] {
         results.push(rule);
       });
     });
-    Logger.getInstance().record('DLO rule processing time', { numericValue: startTime - Date.now() });
+    ruleCollectionSpan.end();
     return results;
   } catch (err) {
     Logger.getInstance().error(LogMessageType.RuleRegistrationError, { reason: `Error: ${err}` });
@@ -93,7 +93,6 @@ function _dlo_collectRules(): any[] {
 
 export default function _dlo_initializeFromWindow() {
   try {
-    const startTime = Date.now();
     const win = (window as { [key: string]: any });
 
     /*
@@ -104,10 +103,16 @@ export default function _dlo_initializeFromWindow() {
 
     // Logging must be initialized before telemetry since telemetry errors may be logged
     if (win._dlo_telemetryProvider) {
-      Telemetry.setInstance(win._dlo_telemetryProvider);
+      Telemetry.setProvider(win._dlo_telemetryProvider);
     } else {
-      Telemetry.setInstance(Telemetry.withExporter(win._dlo_telemetryExporter));
+      Telemetry.setProvider(
+        Telemetry
+          .withExporter(win._dlo_telemetryExporter)
+          .withDefaultAttributes(defaultDloAttributes),
+      );
     }
+
+    const initializationSpan = Telemetry.startSpan(telemetryType.initializationSpan);
 
     if (win._dlo_observer) {
       Logger.getInstance().warn(LogMessageType.ObserverMultipleLoad);
@@ -131,7 +136,7 @@ export default function _dlo_initializeFromWindow() {
       urlValidator: win._dlo_urlValidator || undefined,
       rules,
     });
-    Logger.getInstance().record('DLO initialization time', { numericValue: startTime - Date.now() });
+    initializationSpan.end();
   } catch (err) {
     Logger.getInstance().error(LogMessageType.ObserverInitializationError, { reason: `Error: ${err}` });
   }

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -110,6 +110,7 @@ export default function _dlo_initializeFromWindow() {
     } else {
       Telemetry.setProvider(
         Telemetry
+          // An undefined or null telemetry exporter does not send telemetry to any destination
           .withExporter(win._dlo_telemetryExporter)
           .withDefaultAttributes(defaultDloAttributes),
       );

--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -3,7 +3,7 @@ import { Logger, LogMessageType } from '../utils/logger';
 import { startsWith } from '../utils/object';
 import { DataLayerObserver } from '../observer';
 import {
-  defaultDloAttributes, errorAttributes, errorType, Telemetry, telemetryType,
+  defaultDloAttributes, errorType, Telemetry, telemetryType,
 } from '../utils/telemetry';
 
 /*
@@ -89,7 +89,7 @@ function _dlo_collectRules(): any[] {
     return results;
   } catch (err) {
     Logger.getInstance().error(LogMessageType.RuleRegistrationError, { reason: `Error: ${err}` });
-    Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.ruleRegistrationError));
+    Telemetry.error(errorType.ruleRegistrationError);
     return [];
   }
 }
@@ -143,6 +143,6 @@ export default function _dlo_initializeFromWindow() {
     initializationSpan.end();
   } catch (err) {
     Logger.getInstance().error(LogMessageType.ObserverInitializationError, { reason: `Error: ${err}` });
-    Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerInitializationError));
+    Telemetry.error(errorType.observerInitializationError);
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,7 +3,9 @@ import { Operator } from './operator';
 import { DataLayerDetail, createEventType } from './event';
 import DataLayerTarget from './target';
 import { FanOutOperator } from './operators/fan-out';
-import { Telemetry, telemetryType } from './utils/telemetry';
+import {
+  Telemetry, telemetryType, errorAttributes, errorType,
+} from './utils/telemetry';
 
 /**
  * DataHandler listens for changes from lower level PropertyListeners. Events emitted from
@@ -152,6 +154,7 @@ export default class DataHandler {
         this.runDebugger(`[${i}] ${name} output ${stats}`, handledData, '  ');
       } catch (err) {
         Logger.getInstance().error(LogMessageType.OperatorError, { operator: name, path, reason: err.message });
+        Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
         return null;
       }
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -63,8 +63,6 @@ export default class DataHandler {
       operatorCount: this.operators.length,
       operatorNames: this.operators
         .map((operator) => operator.options.name)
-        // Unique operator names
-        .filter((name, index, self) => self.indexOf(name) === index)
         .join(','),
     });
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -3,9 +3,7 @@ import { Operator } from './operator';
 import { DataLayerDetail, createEventType } from './event';
 import DataLayerTarget from './target';
 import { FanOutOperator } from './operators/fan-out';
-import {
-  Telemetry, telemetryType, errorAttributes, errorType,
-} from './utils/telemetry';
+import { Telemetry, telemetryType, errorType } from './utils/telemetry';
 
 /**
  * DataHandler listens for changes from lower level PropertyListeners. Events emitted from
@@ -152,7 +150,7 @@ export default class DataHandler {
         this.runDebugger(`[${i}] ${name} output ${stats}`, handledData, '  ');
       } catch (err) {
         Logger.getInstance().error(LogMessageType.OperatorError, { operator: name, path, reason: err.message });
-        Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
+        Telemetry.error(errorType.operatorError);
         return null;
       }
     }

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -1,5 +1,8 @@
 import Monitor from './monitor';
 import { Logger, LogMessage, LogMessageType } from './utils/logger';
+import {
+  errorAttributes, Telemetry, telemetryType, errorType,
+} from './utils/telemetry';
 
 /**
  * ShimMonitor watches for changes and function calls through a shim technique.
@@ -69,6 +72,7 @@ export default class ShimMonitor extends Monitor {
     } catch (err) {
       Logger.getInstance().error(LogMessageType.MonitorRemoveError,
         { path: this.path, property: this.property, reason: err.message });
+      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorRemovalError));
     }
   }
 
@@ -82,6 +86,7 @@ export default class ShimMonitor extends Monitor {
       } catch (err) {
         Logger.getInstance().error(LogMessageType.MonitorCallError,
           { path: this.property, property: this.property, reason: err.message });
+        Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorCallError));
         return null;
       }
     };

--- a/src/monitor-shim.ts
+++ b/src/monitor-shim.ts
@@ -1,8 +1,6 @@
 import Monitor from './monitor';
 import { Logger, LogMessage, LogMessageType } from './utils/logger';
-import {
-  errorAttributes, Telemetry, telemetryType, errorType,
-} from './utils/telemetry';
+import { Telemetry, errorType } from './utils/telemetry';
 
 /**
  * ShimMonitor watches for changes and function calls through a shim technique.
@@ -72,7 +70,7 @@ export default class ShimMonitor extends Monitor {
     } catch (err) {
       Logger.getInstance().error(LogMessageType.MonitorRemoveError,
         { path: this.path, property: this.property, reason: err.message });
-      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorRemovalError));
+      Telemetry.error(errorType.monitorRemovalError);
     }
   }
 
@@ -86,7 +84,7 @@ export default class ShimMonitor extends Monitor {
       } catch (err) {
         Logger.getInstance().error(LogMessageType.MonitorCallError,
           { path: this.property, property: this.property, reason: err.message });
-        Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorCallError));
+        Telemetry.error(errorType.monitorCallError);
         return null;
       }
     };

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,8 +1,6 @@
 import { createEvent } from './event';
 import { Logger, LogMessage, LogMessageType } from './utils/logger';
-import {
-  errorAttributes, errorType, Telemetry, telemetryType,
-} from './utils/telemetry';
+import { errorType, Telemetry } from './utils/telemetry';
 
 /**
  * Monitor watches for property changes or function calls.
@@ -72,7 +70,7 @@ export default abstract class Monitor {
     } catch (err) {
       Logger.getInstance().error(LogMessageType.MonitorEmitError,
         { path: this.path, property: this.property, reason: err.message });
-      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorEmitError));
+      Telemetry.error(errorType.monitorEmitError);
     }
   }
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,5 +1,8 @@
 import { createEvent } from './event';
 import { Logger, LogMessage, LogMessageType } from './utils/logger';
+import {
+  errorAttributes, errorType, Telemetry, telemetryType,
+} from './utils/telemetry';
 
 /**
  * Monitor watches for property changes or function calls.
@@ -69,6 +72,7 @@ export default abstract class Monitor {
     } catch (err) {
       Logger.getInstance().error(LogMessageType.MonitorEmitError,
         { path: this.path, property: this.property, reason: err.message });
+      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.monitorEmitError));
     }
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -8,7 +8,9 @@ import {
 import { FunctionOperator } from './operators';
 import DataLayerTarget from './target';
 import MonitorFactory from './monitor-factory';
-import { Telemetry, telemetryType } from './utils/telemetry';
+import {
+  errorAttributes, errorType, Telemetry, telemetryType,
+} from './utils/telemetry';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -221,6 +223,7 @@ export class DataLayerObserver {
     } catch (err) {
       this.removeHandler(handler);
       Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
+      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
       throw err;
     }
   }
@@ -243,6 +246,7 @@ export class DataLayerObserver {
       return operator;
     } catch (err) {
       Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
+      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
       throw err;
     }
   }
@@ -325,6 +329,7 @@ export class DataLayerObserver {
                 selector: workingTarget.selector,
                 reason: err.message,
               });
+            Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerReadError));
           }
         }
       } else if (workingTarget.type === 'object') {
@@ -338,6 +343,7 @@ export class DataLayerObserver {
               selector: workingTarget.selector,
               reason: err.message,
             });
+          Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerReadError));
         }
       }
     }
@@ -424,6 +430,7 @@ export class DataLayerObserver {
     if (!source || !destination) {
       Logger.getInstance().error(LogMessageType.RuleInvalid,
         { rule: id, source, reason: `Missing ${source ? 'destination' : 'source'}` });
+      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.invalidRuleError));
       return;
     }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -8,6 +8,7 @@ import {
 import { FunctionOperator } from './operators';
 import DataLayerTarget from './target';
 import MonitorFactory from './monitor-factory';
+import { Telemetry, telemetryType } from './utils/telemetry';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -131,9 +132,18 @@ export class DataLayerObserver {
     }
 
     if (rules) {
+      const ruleRegistrationSpan = Telemetry.startSpan(telemetryType.ruleRegistrationSpan);
       rules.forEach((rule: DataLayerRule) => this.registerRule(rule));
+      // TODO(nate): Remove this call when the record log level is deprecated. Removing breaks tests
+      // so there may be some test state management issues to address
       Logger.getInstance().record('DLO rule count', { numericValue: rules.length });
+      ruleRegistrationSpan.end();
+      Telemetry.count(telemetryType.ruleCount, rules.length);
+    } else {
+      Telemetry.count(telemetryType.ruleCount, 0);
     }
+    // TODO(nate): Remove this call when the record log level is deprecated. Removing breaks tests
+    // so there may be some test state management issues to address
     Logger.getInstance().record('DLO constructor time', { numericValue: startTime - Date.now() });
   }
 

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -8,9 +8,7 @@ import {
 import { FunctionOperator } from './operators';
 import DataLayerTarget from './target';
 import MonitorFactory from './monitor-factory';
-import {
-  errorAttributes, errorType, Telemetry, telemetryType,
-} from './utils/telemetry';
+import { errorType, Telemetry, telemetryType } from './utils/telemetry';
 
 /**
  * DataLayerConfig provides global settings for a DataLayerObserver.
@@ -223,7 +221,7 @@ export class DataLayerObserver {
     } catch (err) {
       this.removeHandler(handler);
       Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
-      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
+      Telemetry.error(errorType.operatorError);
       throw err;
     }
   }
@@ -246,7 +244,7 @@ export class DataLayerObserver {
       return operator;
     } catch (err) {
       Logger.getInstance().error(LogMessageType.OperatorError, { operator: JSON.stringify(options) });
-      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.operatorError));
+      Telemetry.error(errorType.operatorError);
       throw err;
     }
   }
@@ -329,7 +327,7 @@ export class DataLayerObserver {
                 selector: workingTarget.selector,
                 reason: err.message,
               });
-            Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerReadError));
+            Telemetry.error(errorType.observerReadError);
           }
         }
       } else if (workingTarget.type === 'object') {
@@ -343,7 +341,7 @@ export class DataLayerObserver {
               selector: workingTarget.selector,
               reason: err.message,
             });
-          Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.observerReadError));
+          Telemetry.error(errorType.observerReadError);
         }
       }
     }
@@ -430,7 +428,7 @@ export class DataLayerObserver {
     if (!source || !destination) {
       Logger.getInstance().error(LogMessageType.RuleInvalid,
         { rule: id, source, reason: `Missing ${source ? 'destination' : 'source'}` });
-      Telemetry.count(telemetryType.clientError, 1, errorAttributes(errorType.invalidRuleError));
+      Telemetry.error(errorType.invalidRuleError);
       return;
     }
 

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -30,15 +30,6 @@ export const errorType = {
 };
 
 /**
- * Returns {@link Attributes} containing the given error type
- *
- * @param type The error type to report as a client error telemetry count
- */
-export const errorAttributes = (type: string): Attributes => ({
-  errorType: type,
-});
-
-/**
  * Default telemetry attributes for DLO
  */
 export const defaultDloAttributes = {
@@ -364,5 +355,15 @@ export class Telemetry {
    */
   static count(name: string, value: number, attributes?: Attributes): void {
     Telemetry.getInstance().count(name, value, attributes);
+  }
+
+  /**
+   * Convenience function for collecting client errors as telemetry counts,
+   * reporting the error type as metadata
+   *
+   * @param type The error type
+   */
+  static error(type: string): void {
+    Telemetry.count(telemetryType.clientError, 1, { errorType: type });
   }
 }

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -217,7 +217,7 @@ export class DefaultTelemetryProvider implements TelemetryProvider {
       return new DefaultTelemetrySpan(
         name,
         this.exporter.sendSpan,
-        this.insertDefaultAttributes(attributes),
+        this.mergeWithDefaultAttributes(attributes),
       );
     } catch (err) {
       Logger.getInstance().debug(`Error starting telemetry span: ${err.message}`);
@@ -239,7 +239,7 @@ export class DefaultTelemetryProvider implements TelemetryProvider {
       this.exporter.sendCount({
         name,
         timestamp: new Date().toISOString(),
-        attributes: this.insertDefaultAttributes(attributes),
+        attributes: this.mergeWithDefaultAttributes(attributes),
         value,
       });
     } catch (err) {
@@ -258,21 +258,8 @@ export class DefaultTelemetryProvider implements TelemetryProvider {
     return this;
   }
 
-  private insertDefaultAttributes(attributes?: Attributes): Attributes {
-    // We're avoiding Object.assign and object literal spreading since they're
-    // not supported by IE11
-    const mergedAttributes: Attributes = {};
-    [attributes, this.defaultAttributes].forEach((attributeSet) => {
-      if (!attributeSet) {
-        return;
-      }
-      Object.getOwnPropertyNames(attributeSet).forEach((prop) => {
-        if (!Object.prototype.hasOwnProperty.call(mergedAttributes, prop)) {
-          mergedAttributes[prop] = attributeSet[prop];
-        }
-      });
-    });
-    return mergedAttributes;
+  private mergeWithDefaultAttributes(attributes?: Attributes): Attributes {
+    return { ...this.defaultAttributes, ...attributes };
   }
 }
 

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -11,7 +11,32 @@ export const telemetryType = {
   ruleRegistrationSpan: 'dlo_rule_registration_span',
   ruleCount: 'dlo_rule_count',
   handleEventSpan: 'dlo_handle_event_span',
+  clientError: 'dlo_client_error',
 };
+
+/**
+ * Constants used for error types in client error telemetry. These string values should
+ * never change
+ */
+export const errorType = {
+  operatorError: 'dlo_operator_error',
+  monitorRemovalError: 'dlo_monitor_removal_error',
+  monitorCallError: 'dlo_monitor_call_error',
+  monitorEmitError: 'dlo_monitor_emit_error',
+  observerReadError: 'dlo_observer_read_error',
+  invalidRuleError: 'dlo_invalid_rule_error',
+  ruleRegistrationError: 'dlo_rule_registration_error',
+  observerInitializationError: 'dlo_observer_init_error',
+};
+
+/**
+ * Returns {@link Attributes} containing the given error type
+ *
+ * @param type The error type to report as a client error telemetry count
+ */
+export const errorAttributes = (type: string): Attributes => ({
+  errorType: type,
+});
 
 /**
  * Default telemetry attributes for DLO

--- a/test/telemetry.spec.ts
+++ b/test/telemetry.spec.ts
@@ -143,6 +143,8 @@ describe('DefaultTelemetryProvider', () => {
     const [error] = expectParams(mockConsole, 'debug');
     expect(error).to.equal('Error sending telemetry count: test error');
   });
+
+  // TODO(nate): Add tests for default attribute handling
 });
 
 describe('ConsoleTelemetryExporter', () => {
@@ -236,15 +238,14 @@ describe('Direct telemetry initialization', () => {
 
   it('sets and returns the given telemetry provider', () => {
     const mockProvider = new MockTelemetryProvider();
-    Telemetry.setInstance(mockProvider);
-    const provider = Telemetry.getInstance();
+    Telemetry.setProvider(mockProvider);
 
     // endSpan is defined on MockTelemetryProvider to track span.end() calls
     expectNoCalls(mockProvider, 'endSpan');
     expectNoCalls(mockProvider, 'count');
 
-    const span = provider.startSpan('test span');
-    provider.count('test count', 1);
+    const span = Telemetry.startSpan('test span');
+    Telemetry.count('test count', 1);
     span.end();
 
     expectCall(mockProvider, 'endSpan', 1);
@@ -328,11 +329,10 @@ describe('Telemetry initialization from window', () => {
     it('uses the default telemetry provider and null telemetry exporter by default', () => {
       win._dlo_telemetryExporter = exporter;
       initializeFromWindow();
-      const provider = Telemetry.getInstance();
 
       expect(() => {
-        const span = provider.startSpan('test span');
-        provider.count('test count', 1);
+        const span = Telemetry.startSpan('test span');
+        Telemetry.count('test count', 1);
         span.end();
       }).not.to.throw();
 
@@ -345,13 +345,12 @@ describe('Telemetry initialization from window', () => {
     const mockExporter = new MockTelemetryExporter();
     win._dlo_telemetryExporter = mockExporter;
     initializeFromWindow();
-    const provider = Telemetry.getInstance();
 
     expectNoCalls(mockExporter, 'sendSpan');
     expectNoCalls(mockExporter, 'sendCount');
 
-    const span = provider.startSpan('test span');
-    provider.count('test count', 1);
+    const span = Telemetry.startSpan('test span');
+    Telemetry.count('test count', 1);
     span.end();
 
     expectCall(mockExporter, 'sendSpan', 1);
@@ -361,12 +360,11 @@ describe('Telemetry initialization from window', () => {
   it('uses the default telemetry provider and console telemetry exporter given a \'console\' configuration', () => {
     win._dlo_telemetryExporter = 'console';
     initializeFromWindow();
-    const provider = Telemetry.getInstance();
 
     expectNoCalls(mockConsole, 'debug');
 
-    const span = provider.startSpan('test span');
-    provider.count('test count', 1);
+    const span = Telemetry.startSpan('test span');
+    Telemetry.count('test count', 1);
     span.end();
 
     expectCall(mockConsole, 'debug', 2);
@@ -378,14 +376,13 @@ describe('Telemetry initialization from window', () => {
     win._dlo_telemetryProvider = mockProvider;
     win._dlo_telemetryExporter = mockExporter;
     initializeFromWindow();
-    const provider = Telemetry.getInstance();
 
     // endSpan is defined on MockTelemetryProvider to track span.end() calls
     expectNoCalls(mockProvider, 'endSpan');
     expectNoCalls(mockProvider, 'count');
 
-    const span = provider.startSpan('test span');
-    provider.count('test count', 1);
+    const span = Telemetry.startSpan('test span');
+    Telemetry.count('test count', 1);
     span.end();
 
     expectCall(mockProvider, 'endSpan', 1);


### PR DESCRIPTION
This PR uses telemetry to instrument the following:
- Overall DLO initialization time
- Time to collect configured rules from the `window` object
- Time to register all rules
- Time to handle each event (execute operator pipeline and send to configured rule destination) along with the number of operators and type of operators configured for a given event
- Count of client errors segmented by error type
- Count of rules configured for the DLO instance