### PR TITLE
Exclude debounce time from measured event handling duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 2.0.1
+
+- Fixed a bug where debounce time was included in measured event handling duration
+
 ### 2.0.0
 
 - Changes telemetry collection interfaces from e.g. `Telemetry.getInstance().startSpan` to `Telemetry.startSpan`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -57,13 +57,6 @@ export default class DataHandler {
    * @param event a browser Event or CustomEvent emitted
    */
   handleEvent(event: CustomEvent<DataLayerDetail>): void {
-    const handleEventSpan = Telemetry.startSpan(telemetryType.handleEventSpan, {
-      operatorCount: this.operators.length,
-      operatorNames: this.operators
-        .map((operator) => operator.options.name)
-        .join(','),
-    });
-
     const { detail: { args, value }, type } = event;
     const { path } = this.target;
 
@@ -88,12 +81,10 @@ export default class DataHandler {
           this.timeoutId = window.setTimeout(() => {
             this.timeoutId = null; // clear the timeout used for debouncing
             this.handleData([result]);
-            handleEventSpan.end();
           }, this.debounce);
         }
       } else {
         this.handleData(args || []);
-        handleEventSpan.end();
       }
     } else {
       Logger.getInstance().warn(LogMessageType.EventUnexpected, { path });
@@ -105,6 +96,13 @@ export default class DataHandler {
    * @param data the data as an array of values emitted from the data layer
    */
   private handleData(data: any[] | null, operatorStartIndex: number = 0): any[] | null {
+    const handleEventSpan = Telemetry.startSpan(telemetryType.handleEventSpan, {
+      operatorCount: this.operators.length,
+      operatorNames: this.operators
+        .map((operator) => operator.options.name)
+        .join(','),
+    });
+
     const { path } = this.target;
 
     this.runDebugger(`${path} handleData entry`, data);
@@ -157,6 +155,7 @@ export default class DataHandler {
 
     this.runDebugger(`${path} handleData exit`, handledData);
 
+    handleEventSpan.end();
     return handledData;
   }
 


### PR DESCRIPTION
Before this change, we're including debounce time in the measured event handling duration. By default, this debounce time is 250ms, and that debounce duration will be renewed if there are additional changes to a given rule source and path within the debounce duration. While cumulative debounce time could be interesting to measure explicitly in the future, event handling duration is intended to measure the time it takes to execute an operator pipeline -- including the final function operator call to send the transformed data to the configured rule destination. This PR narrows the scope of the event handling span to operator pipeline execution (excluding debounce time).