### PR TITLE
Add rule count as attribute to rule registration span telemetry; deprecate rule count telemetry type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
-### 2.1.1
+### 2.1.0
 
 - Adds rule count attribute to rule registration span telemetry. Deprecates dedicated rule count telemetry type for removal in a future release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 2.1.1
+
+- Adds rule count attribute to rule registration span telemetry. Deprecates dedicated rule count telemetry type for removal in a future release.
+
 ### 2.0.1
 
 - Fixed a bug where debounce time was included in measured event handling duration

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v1/v1.13.1.js
-- https://edge.fullstory.com/datalayer/v1/latest.js
+- https://edge.fullstory.com/datalayer/v2/v2.1.1.js
+- https://edge.fullstory.com/datalayer/v2/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v2/v2.1.1.js
+- https://edge.fullstory.com/datalayer/v2/v2.1.0.js
 - https://edge.fullstory.com/datalayer/v2/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "2.0.1",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "2.1.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -132,7 +132,9 @@ export class DataLayerObserver {
     }
 
     if (rules) {
-      const ruleRegistrationSpan = Telemetry.startSpan(telemetryType.ruleRegistrationSpan);
+      const ruleRegistrationSpan = Telemetry.startSpan(telemetryType.ruleRegistrationSpan, {
+        ruleCount: rules.length,
+      });
       rules.forEach((rule: DataLayerRule) => this.registerRule(rule));
       // TODO(nate): Remove this call when the record log level is deprecated. Removing breaks tests
       // so there may be some test state management issues to address

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -9,6 +9,10 @@ export const telemetryType = {
   initializationSpan: 'dlo_init_span',
   ruleCollectionSpan: 'dlo_rule_collection_span',
   ruleRegistrationSpan: 'dlo_rule_registration_span',
+  /**
+   * @deprecated Rule count is reported as metadata on {@link ruleRegistrationSpan} events
+   * and will be removed as a dedicated telemetry type in a future release.
+   */
   ruleCount: 'dlo_rule_count',
   handleEventSpan: 'dlo_handle_event_span',
   clientError: 'dlo_client_error',


### PR DESCRIPTION
This PR adds rule count as an attribute to the rule registration span telemetry type and deprecates the dedicated rule count telemetry type for removal in a future major version release. The structure and naming of `ruleCount` matches the `operatorCount` attribute on the handle event duration telemetry type.