### PR TITLE
Fully reference latest DLO version and suggested beforeDestination operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add Data Layer Observer to your web site or web app by including the following s
 ```html
 <script>
  window['_dlo_appender'] = 'fullstory';
- window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, index: -1 },{ name: 'suffix' }];
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, preserveArray: true, index: -1 },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;     // set to false in production to send data to the destination
  window['_dlo_readOnLoad'] = true;      // see docs on usage
  window['_dlo_validateRules'] = true;
@@ -21,7 +21,7 @@ Add Data Layer Observer to your web site or web app by including the following s
   // add your rules here
  ];
  </script>
- <script async="true" src="https://edge.fullstory.com/datalayer/v1/latest.js"></script>
+ <script async="true" src="https://edge.fullstory.com/datalayer/v2/latest.js"></script>
 ```
 
 ### Examples
@@ -72,7 +72,7 @@ DLO is configurable by adding relevant options as `window` properties to the pag
 
 ```html
 <script>
- window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, index: -1 },{ name: 'suffix' }];
+ window['_dlo_beforeDestination'] = [{ name: 'convert', enumerate: true, preserveArray: true, index: -1 },{ name: 'suffix' }];
  window['_dlo_previewMode'] = true;
  window['_dlo_readOnLoad'] = true;
  window['_dlo_validateRules'] = true;


### PR DESCRIPTION
Updates README to fully reference the latest DLO version (v2). Also updates `beforeDestination` operator references to match those served by FullStory data layer integrations.