### PR TITLE
ignore time spans that are negative or not a number

### DIFF
--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -164,13 +164,13 @@ class DefaultTelemetrySpan implements TelemetrySpan {
 
   /**
    * Ends the timespan, calculating the duration and invoking the given sendSpan
-   * callback with a timespan event. Only exports positive durations.
+   * callback with a timespan event. Only exports valid durations.
    */
   end() {
     try {
       const duration = DefaultTelemetrySpan.getCurrentTime() - this.startTime;
       if (duration < 0 || Number.isNaN(duration)) {
-        Logger.getInstance().debug(`ignoring span, calculated a non-positive duration: ${duration}`);
+        Logger.getInstance().debug(`ignoring span, calculated an invalid duration: ${duration}`);
         return;
       }
 

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -163,16 +163,22 @@ class DefaultTelemetrySpan implements TelemetrySpan {
   }
 
   /**
-   * Ends the timespan, calculating the duration and invoking the given
-   * sendSpan callback with a timespan event
+   * Ends the timespan, calculating the duration and invoking the given sendSpan
+   * callback with a timespan event. Only exports positive durations.
    */
   end() {
     try {
+      const duration = DefaultTelemetrySpan.getCurrentTime() - this.startTime;
+      if (duration < 0 || Number.isNaN(duration)) {
+        Logger.getInstance().debug(`ignoring span, calculated a non-positive duration: ${duration}`);
+        return;
+      }
+
       this.sendSpan({
         name: this.name,
         timestamp: new Date().toISOString(),
         attributes: this.attributes,
-        duration: DefaultTelemetrySpan.getCurrentTime() - this.startTime,
+        duration,
       });
     } catch (err) {
       Logger.getInstance().debug(`Error sending telemetry span: ${err.message}`);

--- a/test/telemetry.spec.ts
+++ b/test/telemetry.spec.ts
@@ -247,7 +247,6 @@ describe('DefaultTelemetryProvider', () => {
     const provider = new DefaultTelemetryProvider(exporter);
 
     const span = provider.startSpan('test span');
-    provider.count('test count', 1);
 
     const mockPerf = {
       now: () => -9999999999,
@@ -264,7 +263,6 @@ describe('DefaultTelemetryProvider', () => {
     const provider = new DefaultTelemetryProvider(exporter);
 
     const span = provider.startSpan('test span');
-    provider.count('test count', 1);
 
     const mockPerf = {
       now: () => 'potato',
@@ -281,7 +279,6 @@ describe('DefaultTelemetryProvider', () => {
     const provider = new DefaultTelemetryProvider(exporter);
 
     const span = provider.startSpan('test span');
-    provider.count('test count', 1);
 
     const mockPerf = {
       now: () => { throw new Error('tomato'); },


### PR DESCRIPTION
This PR prevents the DefaultTelemetryProvider from exporting or sending negative or non number values.