### PR TITLE
do not count rule length

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -131,7 +131,7 @@ export class DataLayerObserver {
       Logger.getInstance().level = logLevel;
     }
 
-    if (rules) {
+    if (rules && rules.length > 0) {
       const ruleRegistrationSpan = Telemetry.startSpan(telemetryType.ruleRegistrationSpan, {
         ruleCount: rules.length,
       });


### PR DESCRIPTION
This PR prevents the telemetry provider from sending a `ruleRegistration` metric if there are no rules registered.