### PR TITLE
Support optionally running Adobe ruleset tests in browsers

### DIFF
--- a/rulesets/adobe-app-measurement.js
+++ b/rulesets/adobe-app-measurement.js
@@ -1,0 +1,24 @@
+window['_dlo_rules_adobe_am'] = [
+  {
+    "id": "fs-event-adobe-evars",
+    "source": "s[^(eVar)]",
+    "operators": [
+      {
+        "name": "insert",
+        "value": "eVars"
+      }
+    ],
+    "destination": "FS.event"
+  },
+  {
+    "id": "fs-event-adobe-props",
+    "source": "s[^(prop)]",
+    "operators": [
+      {
+        "name": "insert",
+        "value": "props"
+      }
+    ],
+    "destination": "FS.event"
+  }
+];

--- a/test/mocks/adobe.ts
+++ b/test/mocks/adobe.ts
@@ -367,4 +367,8 @@ export const basicAppMeasurement: AppMeasurement = {
   eVar50: 'cca-1234',
   eVar60: '21.95',
   prop1: 'USD',
+  prop10: 'prop-10',
+  prop20: 'prop-20',
+  prop50: 'prop-50',
+  prop60: 'prop-60',
 };


### PR DESCRIPTION
- Updates Adobe ruleset rules to match rules served with data layer capture integrations.
- Adds support for optionally running Adobe ruleset tests in browsers.