### PR TITLE
Support optionally running Tealium ruleset tests in browsers

### DIFF
--- a/rulesets/tealium-retail.js
+++ b/rulesets/tealium-retail.js
@@ -1,0 +1,12 @@
+window['_dlo_rules_tealium_retail'] = [
+  {
+    id: "fs-tealium-event",
+    source: "utag.data[^(brand_,browse_,cart_,category_,customer_,language_,page_,product_,order_,search_,site_,tealium_event)]",
+    operators: [
+      { name: "query", select: "$[?(tealium_event)]" },
+      { name: "query", select: "$[!(customer_email,customer_first_name,customer_last_name)]" },
+      { name: "insert", select: "tealium_event" }
+    ],
+    destination: "FS.event"
+  }
+];

--- a/test/rules-tealium-fullstory.spec.ts
+++ b/test/rules-tealium-fullstory.spec.ts
@@ -55,7 +55,7 @@ describe('Ruleset: Tealium to FullStory rules', () => {
         expectEqual(id, 'product_view');
         expectMatch(payload, tealiumRetail, 'product_id');
         expectEqual(payload.order_total, '54.47');
-        expectEqual(payload.product_discount_amount, ['2.98']); // NOTE list reduced to single value
+        expectEqual(payload.product_discount_amount, ['2.98']);
         expectUndefined(payload, 'customer_first_name', 'customer_last_name', 'customer_email');
       });
 

--- a/test/rules-tealium-fullstory.spec.ts
+++ b/test/rules-tealium-fullstory.spec.ts
@@ -53,9 +53,7 @@ describe('Ruleset: Tealium to FullStory rules', () => {
 
         const [id, payload] = await testHarness.popEvent();
         expectEqual(id, 'product_view');
-        expectMatch(payload, tealiumRetail, 'product_id');
-        expectEqual(payload.order_total, '54.47');
-        expectEqual(payload.product_discount_amount, ['2.98']);
+        expectMatch(payload, tealiumRetail, 'product_id', 'order_total', 'product_discount_amount');
         expectUndefined(payload, 'customer_first_name', 'customer_last_name', 'customer_email');
       });
 

--- a/test/rules-tealium-fullstory.spec.ts
+++ b/test/rules-tealium-fullstory.spec.ts
@@ -1,90 +1,79 @@
 import 'mocha';
 
-import DataHandler from '../src/handler';
-import { rules } from '../examples/rules/tealium-fullstory.json';
+import { expectEqual, expectUndefined, expectMatch } from './utils/mocha';
+import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
+import { tealiumRetail, RetailDefinition } from './mocks/tealium';
 
-import { tealiumRetail } from './mocks/tealium';
-import {
-  expectEqual, expectRule, expectFS, setupGlobals, ExpectObserver, expectNoCalls, expectGlobal, expectUndefined,
-  expectMatch,
-} from './utils/mocha';
+import '../rulesets/tealium-retail.js';
 
-describe('Tealium to FullStory rules', () => {
-  beforeEach(() => setupGlobals([
-    ['utag', { data: tealiumRetail }], // NOTE the expando becomes utag.data
-    ['_dlo_rules', rules],
-  ]));
+const tealiumRulesKey = '_dlo_rules_tealium_retail';
+const tealiumRules = (window as Record<string, any>)[tealiumRulesKey];
 
-  afterEach(() => {
-    ExpectObserver.getInstance().cleanup();
-  });
+interface ExtendedRetailDefintion extends RetailDefinition {
+  // eslint-disable-next-line camelcase
+  tealium_event?: string;
+  outsideScope?: boolean;
+}
 
-  it('should read tealium_event', () => {
-    expectGlobal('utag').data.tealium_event = 'product_view';
+declare global {
+  // eslint-disable-next-line no-var, vars-on-top
+  var utag: {
+    data: ExtendedRetailDefintion
+  };
+}
 
-    ExpectObserver.getInstance().create({
-      rules: [expectRule('fs-tealium-event')],
+describe('Ruleset: Tealium to FullStory rules', () => {
+  getRulesetTestEnvironments().forEach((testEnv) => {
+    describe(`test environment: ${testEnv.name}`, () => {
+      let testHarness: RulesetTestHarness;
+
+      beforeEach(async () => {
+        testHarness = await testEnv.createTestHarness(tealiumRules, {
+          utag: {
+            data: {
+              ...tealiumRetail,
+              tealium_event: '',
+            },
+          },
+        });
+      });
+
+      afterEach(async () => {
+        await testHarness.tearDown();
+      });
+
+      after(async () => {
+        await testEnv.tearDown();
+      });
+
+      it('monitors tealium_event', async () => {
+        await testHarness.execute(() => {
+          globalThis.utag.data.tealium_event = 'product_view';
+        });
+
+        const [id, payload] = await testHarness.popEvent();
+        expectEqual(id, 'product_view');
+        expectMatch(payload, tealiumRetail, 'product_id');
+        expectEqual(payload.order_total, '54.47');
+        expectEqual(payload.product_discount_amount, ['2.98']); // NOTE list reduced to single value
+        expectUndefined(payload, 'customer_first_name', 'customer_last_name', 'customer_email');
+      });
+
+      it('does not monitor properties not included in the source', async () => {
+        await testHarness.execute(() => {
+          utag.data.outsideScope = true;
+        });
+
+        await new Promise<void>((resolve, reject) => {
+          testHarness.popEvent(500)
+            .then(() => {
+              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
+            })
+            .catch(() => {
+              resolve();
+            });
+        });
+      });
     });
-
-    const [id, payload] = expectFS('event');
-    expectEqual(id, 'product_view');
-    expectMatch(payload, tealiumRetail, 'product_id');
-    expectEqual(payload.order_total, 54.47);
-    expectEqual(payload.product_discount_amount, 2.98); // NOTE list reduced to single value
-    expectUndefined(payload, 'customer_first_name', 'customer_last_name', 'customer_email');
-  });
-
-  it('should not monitor properties not included in the source', (done) => {
-    expectGlobal('utag').data.tealium_event = 'product_view';
-
-    ExpectObserver.getInstance().create({
-      // ensure this rule never reads on load
-      rules: [{ ...expectRule('fs-tealium-event'), readOnLoad: false }],
-    });
-
-    // NOTE this is a valid property to monitor
-    expectGlobal('utag').data.product_id = ['PROD789'];
-
-    // check the assignment
-    setTimeout(() => {
-      const [id, payload] = expectFS('event');
-      expectEqual(id, 'product_view');
-      expectEqual(payload.product_id, 'PROD789');
-    }, DataHandler.DefaultDebounceTime * 1.5);
-
-    // NOTE this is an invalid property to monitor because it is not picked
-    expectGlobal('utag').data.outsideScope = true;
-
-    // check the assignment
-    setTimeout(() => {
-      expectNoCalls(expectGlobal('FS'), 'event');
-      done();
-    }, DataHandler.DefaultDebounceTime * 1.5);
-  });
-
-  it('should identify user', () => {
-    expectGlobal('utag').data.tealium_event = 'user_registration';
-
-    ExpectObserver.getInstance().create({
-      rules: [expectRule('fs-tealium-user-registration')],
-    });
-
-    const [uid, payload] = expectFS('identify');
-    expectEqual(uid, tealiumRetail.customer_id);
-    expectUndefined(payload, 'customer_first_name'); // NOTE renamed to displayName
-    expectMatch(payload, tealiumRetail, 'customer_last_name', 'customer_city');
-    expectEqual(payload.email, tealiumRetail.customer_email);
-    expectEqual(payload.displayName, tealiumRetail.customer_first_name);
-  });
-
-  it('should setUserVars', () => {
-    expectGlobal('utag').data.tealium_event = 'user_update';
-
-    ExpectObserver.getInstance().create({
-      rules: [expectRule('fs-tealium-user-update')],
-    });
-
-    const [payload] = expectFS('setUserVars');
-    expectMatch(payload, tealiumRetail, 'customer_first_name', 'customer_last_name', 'customer_city');
   });
 });


### PR DESCRIPTION
- Updates Tealium ruleset rules to match rules served with data layer capture integrations.
- Adds support for optionally running Tealium ruleset tests in browsers.