### PR TITLE
Cleans up recent browser test efforts

### DIFF
--- a/test/rules-adobe-fullstory.spec.ts
+++ b/test/rules-adobe-fullstory.spec.ts
@@ -28,7 +28,7 @@ describe('Ruleset: Adobe to FullStory rules', () => {
         await testEnv.tearDown();
       });
 
-      it('sends Adobe eVars and props to FS.event', async () => {
+      it('sends Adobe eVars to FS.event', async () => {
         testHarness = await testEnv.createTestHarness(adobeRules, {
           s: {
             eVar1: '',
@@ -36,11 +36,6 @@ describe('Ruleset: Adobe to FullStory rules', () => {
             eVar20: '',
             eVar50: '',
             eVar60: '',
-            prop1: '',
-            prop10: '',
-            prop20: '',
-            prop50: '',
-            prop60: '',
             pageName: '',
           } as AppMeasurement,
         });
@@ -52,6 +47,28 @@ describe('Ruleset: Adobe to FullStory rules', () => {
           globalThis.s.eVar50 = localAppMeasurement.eVar50;
           globalThis.s.eVar60 = localAppMeasurement.eVar60;
 
+          globalThis.s.pageName = localAppMeasurement.pageName;
+        }, [basicAppMeasurement]);
+
+        const [eventName, payload] = await testHarness.popEvent();
+        expectEqual(eventName, 'eVars');
+        expectMatch(basicAppMeasurement, payload, 'eVar1', 'eVar10', 'eVar20', 'eVar50', 'eVar60');
+        expectUndefined(payload, 'pageName');
+      });
+
+      it('sends Adobe props to FS.event', async () => {
+        testHarness = await testEnv.createTestHarness(adobeRules, {
+          s: {
+            prop1: '',
+            prop10: '',
+            prop20: '',
+            prop50: '',
+            prop60: '',
+            pageName: '',
+          } as AppMeasurement,
+        });
+
+        await testHarness.execute(([localAppMeasurement]) => {
           globalThis.s.prop1 = localAppMeasurement.prop1;
           globalThis.s.prop10 = localAppMeasurement.prop10;
           globalThis.s.prop20 = localAppMeasurement.prop20;
@@ -61,14 +78,9 @@ describe('Ruleset: Adobe to FullStory rules', () => {
           globalThis.s.pageName = localAppMeasurement.pageName;
         }, [basicAppMeasurement]);
 
-        let [eventName, payload] = await testHarness.popEvent();
+        const [eventName, payload] = await testHarness.popEvent();
         expectEqual(eventName, 'props');
         expectMatch(basicAppMeasurement, payload, 'prop1', 'prop10', 'prop20', 'prop50', 'prop60');
-        expectUndefined(payload, 'pageName');
-
-        [eventName, payload] = await testHarness.popEvent();
-        expectEqual(eventName, 'eVars');
-        expectMatch(basicAppMeasurement, payload, 'eVar1', 'eVar10', 'eVar20', 'eVar50', 'eVar60');
         expectUndefined(payload, 'pageName');
       });
 

--- a/test/rules-adobe-fullstory.spec.ts
+++ b/test/rules-adobe-fullstory.spec.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import { expect } from 'chai';
 
 import { expectEqual, expectMatch, expectUndefined } from './utils/mocha';
 import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
@@ -79,15 +80,7 @@ describe('Ruleset: Adobe to FullStory rules', () => {
           globalThis.s.prop1 = undefined;
         });
 
-        await new Promise<void>((resolve, reject) => {
-          testHarness.popEvent(500)
-            .then(() => {
-              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
-            })
-            .catch(() => {
-              resolve();
-            });
-        });
+        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
     });
   });

--- a/test/rules-ceddl-fullstory.spec.ts
+++ b/test/rules-ceddl-fullstory.spec.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import { expect } from 'chai';
 
 import { expectEqual, expectMatch, expectUndefined } from './utils/mocha';
 import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
@@ -88,15 +89,7 @@ describe('Ruleset: CEDDL to FullStory', () => {
       it('does not send CEDDL cart item products to FS.event on load', async () => {
         // digitalData.cart.item already has an item. Here, we're verifying no FS.event
         // calls were made as would occur if readOnLoad were true
-        await new Promise<void>((resolve, reject) => {
-          testHarness.popEvent(500)
-            .then(() => {
-              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
-            })
-            .catch(() => {
-              resolve();
-            });
-        });
+        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
 
       it('sends CEDDL page properties to FS.event', async () => {

--- a/test/rules-custom.spec.ts
+++ b/test/rules-custom.spec.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import { expect } from 'chai';
 
 import { DataLayerRule } from '../src/observer';
 import { expectEqual } from './utils/mocha';
@@ -71,16 +72,7 @@ describe('Ruleset: Custom rules', () => {
         expectEqual('eVar2', eventName);
         expectEqual('22', payload.eVar22);
 
-        // Verify no other calls were made to rule destinations
-        await new Promise<void>((resolve, reject) => {
-          testHarness.popEvent(500)
-            .then(() => {
-              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
-            })
-            .catch(() => {
-              resolve();
-            });
-        });
+        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
     });
   });

--- a/test/rules-google-event-measurement-fullstory.spec.ts
+++ b/test/rules-google-event-measurement-fullstory.spec.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import { expect } from 'chai';
 
 import { expectEqual, expectUndefined } from './utils/mocha';
 import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
@@ -58,15 +59,7 @@ describe('Ruleset: Google Analytics Event Measurement to FullStory', () => {
         });
 
         // now check that no calls get queued
-        await new Promise<void>((resolve, reject) => {
-          testHarness.popEvent(500)
-            .then(() => {
-              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
-            })
-            .catch(() => {
-              resolve();
-            });
-        });
+        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
     });
   });

--- a/test/rules-tealium-fullstory.spec.ts
+++ b/test/rules-tealium-fullstory.spec.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import { expect } from 'chai';
 
 import { expectEqual, expectUndefined, expectMatch } from './utils/mocha';
 import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
@@ -62,15 +63,7 @@ describe('Ruleset: Tealium to FullStory rules', () => {
           utag.data.outsideScope = true;
         });
 
-        await new Promise<void>((resolve, reject) => {
-          testHarness.popEvent(500)
-            .then(() => {
-              reject(new Error('Expected rejected promise due to no FS.event calls being present.'));
-            })
-            .catch(() => {
-              resolve();
-            });
-        });
+        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
     });
   });


### PR DESCRIPTION
- Extracts common logic waiting to verify no `FS.event` calls are queued
- Fixes a race condition that was resolving differently in CI than locally