### PR TITLE
Remove record log level

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -115,7 +115,6 @@ export class DataLayerObserver {
     readOnLoad: false,
     validateRules: true,
   }) {
-    const startTime = Date.now();
     const { appender, logLevel, rules } = config;
     if (appender) {
       if (typeof appender === 'string') {
@@ -136,17 +135,11 @@ export class DataLayerObserver {
         ruleCount: rules.length,
       });
       rules.forEach((rule: DataLayerRule) => this.registerRule(rule));
-      // TODO(nate): Remove this call when the record log level is deprecated. Removing breaks tests
-      // so there may be some test state management issues to address
-      Logger.getInstance().record('DLO rule count', { numericValue: rules.length });
       ruleRegistrationSpan.end();
       Telemetry.count(telemetryType.ruleCount, rules.length);
     } else {
       Telemetry.count(telemetryType.ruleCount, 0);
     }
-    // TODO(nate): Remove this call when the record log level is deprecated. Removing breaks tests
-    // so there may be some test state management issues to address
-    Logger.getInstance().record('DLO constructor time', { numericValue: startTime - Date.now() });
   }
 
   /**

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -12,7 +12,6 @@ export enum LogLevel {
   WARN,
   INFO,
   DEBUG,
-  RECORD, // Record information for statistical analysis
 }
 
 export enum LogMessageType {
@@ -61,9 +60,6 @@ export class ConsoleAppender implements LogAppender {
     const consoleMessage = `${message}${context ? ` ${JSON.stringify(context)}` : ''}`;
 
     switch (level) {
-      case LogLevel.RECORD:
-        // By default we do nothing with stats
-        return undefined;
       case LogLevel.ERROR: return console.error(consoleMessage);
       case LogLevel.WARN: return console.warn(consoleMessage);
       case LogLevel.INFO: return console.info(consoleMessage);
@@ -105,14 +101,8 @@ export class FullStoryAppender implements LogAppender {
 
         this.timeoutId = window.setTimeout(() => {
           this.timeoutId = null;
-          if (event.level === LogLevel.RECORD) {
-            // TODO handle LogLevel.RECORD events with upcoming fs stats call
-          } else {
-            fs.event(customEventName, customEventPayload, customEventSource);
-          }
+          fs.event(customEventName, customEventPayload, customEventSource);
         }, FullStoryAppender.debounceTime);
-      } else if (event.level === LogLevel.RECORD) {
-        // TODO handle LogLevel.RECORD events with upcoming fs stats call
       } else {
         fs.event(customEventName, customEventPayload, customEventSource);
       }
@@ -213,7 +203,7 @@ export class Logger {
    * @param context provides additional metadata related to the log event
    */
   private log(level: LogLevel, message: string, context?: LogContext) {
-    if (level <= this.level || level === LogLevel.RECORD) {
+    if (level <= this.level) {
       this.appender.log({
         level,
         message,
@@ -236,10 +226,5 @@ export class Logger {
 
   debug(message: string, context?: LogContext) {
     this.log(LogLevel.DEBUG, message, context);
-  }
-
-  // Record information for statistical analysis
-  record(message: string, context?: LogContext) {
-    this.log(LogLevel.RECORD, message, context);
   }
 }

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -691,10 +691,6 @@ describe('DataLayerObserver unit tests', () => {
     expect(observer.handlers.length).to.eq(1);
     expect(globalMock.dataLayer.length).to.eq(0);
 
-    // Ignore the first two as they are observation messages
-    expectParams(appender, 'log');
-    expectParams(appender, 'log');
-
     const [event] = expectParams(appender, 'log') as LogEvent[];
     expect(event.level).to.eq(LogLevel.WARN);
     expect(event.context?.reason).to.contain('push'); // just make sure the warning is related to push missing


### PR DESCRIPTION
The `record` log level was originally positioned to collect stats but was never implemented. Instead, in DLO v2.0.0 [telemetry was enhanced to collect stats](https://github.com/fullstorydev/fullstory-data-layer-observer/blob/main/CHANGELOG.md#200). Since we're approaching a DLO major version bump, this PR removes the `record` log level which has always been a noop but which could be referenced by library consumers. Accordingly, it seems to make sense to treat this as a breaking change.