### PR TITLE
Remove deprecated rule count telemetry type

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -136,9 +136,6 @@ export class DataLayerObserver {
       });
       rules.forEach((rule: DataLayerRule) => this.registerRule(rule));
       ruleRegistrationSpan.end();
-      Telemetry.count(telemetryType.ruleCount, rules.length);
-    } else {
-      Telemetry.count(telemetryType.ruleCount, 0);
     }
   }
 

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -9,11 +9,6 @@ export const telemetryType = {
   initializationSpan: 'dlo_init_span',
   ruleCollectionSpan: 'dlo_rule_collection_span',
   ruleRegistrationSpan: 'dlo_rule_registration_span',
-  /**
-   * @deprecated Rule count is reported as metadata on {@link ruleRegistrationSpan} events
-   * and will be removed as a dedicated telemetry type in a future release.
-   */
-  ruleCount: 'dlo_rule_count',
   handleEventSpan: 'dlo_handle_event_span',
   clientError: 'dlo_client_error',
 };


### PR DESCRIPTION
After originally rolling out telemetry, we noticed a couple things:
- Having separate rule count telemetry was resulting in an unnecessarily large volume of events since rule count could reasonably be included as metadata on rule registration timings
- Tracking 0-valued rule counts was skewing metrics for legitimate configurations

Dedicated rule count telemetry was deprecated in [v2.1.0](https://github.com/fullstorydev/fullstory-data-layer-observer/blob/main/CHANGELOG.md#210). In preparing for a major version bump, this PR removes the deprecated rule count telemetry type and its usage.