### PR TITLE
Remove unexpected empty space in convert operator docs

### DIFF
--- a/docs/operator_convert.md
+++ b/docs/operator_convert.md
@@ -136,7 +136,7 @@ Options with an asterisk are required. Note that `enumerate` can be used by itse
 ```javascript
 [
  {
-  userId: '300456',   
+  userId: '300456',
   available: 'false',
   basePrice: '15.55',
   priceWithTax: '16.95',


### PR DESCRIPTION
This throws off a pre-commit hook when we sync to deploy a new CDN version.

In the future, it'd be good to match those pre-commit hook rules in the pre-commit hook rules for this repo.