### PR TITLE
CEDDL digitalData.cart.item rule is no longer readOnLoad: false

### DIFF
--- a/rulesets/ceddl.js
+++ b/rulesets/ceddl.js
@@ -10,7 +10,6 @@ window['_dlo_rules_ceddl'] = [
   },
   {
     "id": "fs-event-ceddl-cart-item", "source": "digitalData.cart.item",
-    "readOnLoad": false,
     "operators": [
       { "name": "query", "select": "$[!(linkedProduct)]" },
       { "name": "insert", "value": "cart_item" },

--- a/test/rules-ceddl-fullstory.spec.ts
+++ b/test/rules-ceddl-fullstory.spec.ts
@@ -1,5 +1,4 @@
 import 'mocha';
-import { expect } from 'chai';
 
 import { expectEqual, expectMatch, expectUndefined } from './utils/mocha';
 import { RulesetTestHarness, getRulesetTestEnvironments } from './utils/ruleset-test-harness';
@@ -84,12 +83,6 @@ describe('Ruleset: CEDDL to FullStory', () => {
         expectEqual(eventName, 'cart_item');
         expectEqual(payload.productInfo.sku, secondProduct.productInfo.sku);
         expectUndefined(payload, 'linkedProduct');
-      });
-
-      it('does not send CEDDL cart item products to FS.event on load', async () => {
-        // digitalData.cart.item already has an item. Here, we're verifying no FS.event
-        // calls were made as would occur if readOnLoad were true
-        expect(await testHarness.popEvent(500)).to.be.undefined;
       });
 
       it('sends CEDDL page properties to FS.event', async () => {


### PR DESCRIPTION
Reflects changes to default, out-of-the-box rules.