### PR TITLE
Remove .only from operator-parse.spec test

### DIFF
--- a/test/operator-parse.spec.ts
+++ b/test/operator-parse.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 import { ParseOperator } from '../src/operators';
 
-describe.only('parse operator unit test', () => {
+describe('parse operator unit test', () => {
   it('it should validate options', () => {
     expect(() => new ParseOperator({
       name: 'parse',


### PR DESCRIPTION
This is causing the regular tests to not run as expected.