### PR TITLE
Fix GA4 browser ruleset tests to pass parent scope values

### DIFF
--- a/test/rules-google-enhanced-ecommerce-ga4-fullstory.spec.ts
+++ b/test/rules-google-enhanced-ecommerce-ga4-fullstory.spec.ts
@@ -625,14 +625,14 @@ describe('Ruleset: Google Analytics Enhanced Ecommerce (GA4) to FullStory', () =
         'view_promotion',
       ].forEach((eventName) => {
         it(`gracefully handles empty ecommerce.items for ${eventName} gtm events`, async () => {
-          await testHarness.execute(() => {
+          await testHarness.execute(([localEventName]) => {
             globalThis.dataLayer.push({
-              event: eventName,
+              event: localEventName,
               ecommerce: {
                 items: [],
               },
             });
-          });
+          }, [eventName]);
 
           const event = await testHarness.popEvent();
           expect(event).to.be.undefined;
@@ -642,15 +642,15 @@ describe('Ruleset: Google Analytics Enhanced Ecommerce (GA4) to FullStory', () =
         });
 
         it(`gracefully handles empty items for ${eventName} gtag events`, async () => {
-          await testHarness.execute(() => {
+          await testHarness.execute(([localEventName]) => {
             globalThis.dataLayer.push([
               'event',
-              eventName,
+              localEventName,
               {
                 items: [],
               },
             ]);
-          });
+          }, [eventName]);
 
           const event = await testHarness.popEvent();
           expect(event).to.be.undefined;


### PR DESCRIPTION
These tests were passing when running in a Node environment. However, when passing in a browser parent scope values must be explicitly passed to the test harness. See Adobe tests for an example: https://github.com/fullstorydev/fullstory-data-layer-observer/blob/main/test/rules-adobe-fullstory.spec.ts#L43-L51