### PR TITLE
Support FS dataLayer

### DIFF
--- a/src/target.ts
+++ b/src/target.ts
@@ -46,7 +46,9 @@ export default class DataLayerTarget {
    */
   constructor(public subject: Object, public property: string, public path: string,
     public selector = '') {
-    if (typeof subject !== 'object') {
+    // NB special case added to support new FS.dataLayer observation
+    // eslint-disable-next-line no-underscore-dangle
+    if (typeof subject !== 'object' && subject !== (window as any)[(window as any)._fs_namespace]) {
       throw new Error(LogMessage.TargetSubjectObject);
     }
 


### PR DESCRIPTION
There is a new object in the `FS` SDK called `dataLayer`.  As the name indicates, it is a data layer containing Fullstory-specific content (e.g. model scores).  Unfortunately, we can't observe it due to a guard in DLO.  The guard checks if the data layer is an object since many of our historical data layers were object-based.  The check `typeof FS` returns a "function" so observation fails with a `Rule Registration Error`.  Rather than make the guard too much more permissive, I'm making an exception for `FS` specifically.

I've done manual testing and can confirm registration succeeds.