### PR TITLE
Irv fs/convert nested

### DIFF
--- a/docs/operator_convert.md
+++ b/docs/operator_convert.md
@@ -6,18 +6,19 @@ Convert is most useful when paired with `FS.event` for cart and checkout events 
 
 ## Options
 
-Options with an asterisk are required. Note that `enumerate` can be used by itself or with `properties`.
+Note that `enumerate` can be used by itself or with `properties`.
 
 | Option           | Type                   | Default     | Description                                                                                                                                                                                                   |
 |------------------|------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `enumerate`*     | `boolean`              | `false`     | Automatically converts all string values into their numeric equivalent.                                                                                                                                       |
+| `enumerate`      | `boolean`              | `false`     | Automatically converts all string values into their numeric equivalent.                                                                                                                                       |
 | `ignore`         | `string` or `string[]` | `undefined` | Can be paired with `enumerate` option to ignore one or more properties when performing the `enumerate`.                                                                                                       |
 | `ignoreSuffixed` | `boolean` | `true`      | Can be paired with `enumerate` option to ignore any properties with [known type suffixes](https://help.fullstory.com/hc/en-us/articles/360020623234#property-name-requirements) when performing the `enumerate` |
-| `force`         | `boolean` | `false`     | If the property is undefined or has value `null`, forcibly add the property with value `0`, `0.0`,`false` or empty string.                                                                                    |
-| `index`         | `number` | `0`         | Position of the object to convert in the operator input list.                                                                                                                                                 |
-| `preserveArray` | `boolean` | `false`     | If the conversion value is a list, keep the array type even if the array has a single value.                                                                                                                  |
-| `properties`*   | `string` or `string[]` | `undefined` | List of properties to convert.                                                                                                                                                                                |
-| `type`*         | `string` | `undefined` | The desired type to convert properties to.                                                                                                                                                                    |
+| `force`          | `boolean` | `false`     | If the property is undefined or has value `null`, forcibly add the property with value `0`, `0.0`,`false` or empty string.                                                                                    |
+| `index`          | `number` | `0`         | Position of the object to convert in the operator input list.                                                                                                                                                 |
+| `preserveArray`  | `boolean` | `false`     | If the conversion value is a list, keep the array type even if the array has a single value.                                                                                                                  |
+| `properties`     | `string` or `string[]` | `undefined` | List of properties to convert.                                                                                                                                                                                |
+| `type`           | `string` | `undefined` | The desired type to convert properties to.                                                                                                                                                                    |
+| `maxDepth`       | `string` | `1`          | The max depth to look for properties.  If maxDepth is > 1, then the `properties`, `ignore`, and `ignoreSuffixed` will only apply to leaf properties, not to objects themselves.  
 
 > **Tip:** Set the `properties` option to the string `*` to convert *all* properties in an object to a desired type.
 
@@ -243,6 +244,47 @@ Options with an asterisk are required. Note that `enumerate` can be used by itse
   basePrice: 15.55,
   priceWithTax: 16.95,
   cartTotal: 21.95,
+ }
+]
+```
+## Convert "numeric" strings with a nested object 
+
+### Rule
+
+```javascript
+{
+ source: 'digitalData[(cart)]',
+ operators: [
+   { name: 'convert', enumerate: true, properties: 'available', type: 'bool', maxDepth: 2 },
+   { name: 'insert', value: 'Product Viewed' },
+ ],
+ destination: 'FS.event'
+}
+```
+
+### Input
+
+```javascript
+[
+ cart: {
+  available: 'false',
+  basePrice: '15.55',
+  priceWithTax: '16.95',
+  cartTotal: '21.95',
+ }
+]
+```
+
+### Output
+
+```javascript
+[
+ 'Product Viewed',
+ {
+   cart.available: false,
+   cart.basePrice: 15.55,
+   cart.priceWithTax: 16.95,
+   cart.cartTotal: 21.95,
  }
 ]
 ```

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -203,6 +203,9 @@ export class ConvertOperator implements Operator {
     if (currentDepth > maxDepth) {
       return;
     }
+    if (source === null || source === undefined || converted === null || converted === undefined) {
+      return;
+    }
     Object.getOwnPropertyNames(source).forEach((property) => {
       let alreadyConverted = false;
       const original = source[property];
@@ -239,14 +242,16 @@ export class ConvertOperator implements Operator {
       if (isConvertible && !alreadyConverted && enumerate) {
         if (originalType === 'string') {
           // it seems best to leave an empty string as-is rather than have it converted to 0
-          if (original !== '') {
+          // eslint-disable-next-line no-prototype-builtins
+          if ((original !== '') && (converted.hasOwnProperty(property))) {
             // eslint-disable-next-line no-param-reassign
             converted[property] = ConvertOperator.convert('real', original);
             ConvertOperator.verifyConversion('real', property, converted, source);
           }
         } else if (Array.isArray(original) && (original.length > 0) && (typeof original[0] === 'string')) {
           (original as Array<string>).forEach((item, index) => {
-            if (item !== '') {
+            // eslint-disable-next-line no-prototype-builtins
+            if ((item !== '') && (converted.hasOwnProperty(property))) {
               // eslint-disable-next-line no-param-reassign
               converted[property][index] = ConvertOperator.convert('real', item);
             }

--- a/src/operators/convert.ts
+++ b/src/operators/convert.ts
@@ -3,6 +3,7 @@ import {
 } from '../operator';
 import { Logger, LogMessageType } from '../utils/logger';
 import { SuffixOperator } from './suffix';
+import { deepClone } from '../utils/object';
 
 type ConvertibleType = 'bool' | 'date' | 'int' | 'real' | 'string';
 
@@ -186,7 +187,7 @@ export class ConvertOperator implements Operator {
   deepConvert(data:any, index:number, enumerate:boolean|undefined, properties:string[]|undefined,
     type:ConvertibleType|undefined, force: boolean|undefined, ignore:string[]|undefined, ignoreSuffixed:boolean,
     maxDepth:number, preserveArray:boolean|undefined) {
-    const deepConverted = structuredClone(data[index]);
+    const deepConverted = deepClone(data[index]);
     this.deepConvertHelper(data[index], deepConverted, enumerate, properties, type, force, ignore, ignoreSuffixed,
       maxDepth, 1, preserveArray);
     if (!preserveArray) {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -81,3 +81,29 @@ export function endsWith(target: string, searchString: string, position?: number
 
   return target.slice(Math.max(0, pos - searchString.length), pos) === searchString;
 }
+
+/**
+ * Deep clones an object.  Will use structuredClone if present, otherwise will fall back to a simple JSON serialize/deserialize
+ * The fallback method will prune circular references for the 2nd time an object is seen.
+ * @param obj
+ */
+export function deepClone(obj: any): any {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(obj);
+    } catch {
+      // Fall back to JSON-based clone with circular reference handling
+    }
+  }
+
+  const seen = new WeakSet();
+  return JSON.parse(JSON.stringify(obj, (key, value) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return {}; // Replace circular reference with empty object
+      }
+      seen.add(value);
+    }
+    return value;
+  }));
+}

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -96,13 +96,13 @@ export function deepClone(obj: any): any {
     }
   }
 
-  const seen = new WeakSet();
+  const seen = new WeakMap();
   return JSON.parse(JSON.stringify(obj, (key, value) => {
     if (typeof value === 'object' && value !== null) {
       if (seen.has(value)) {
         return {}; // Replace circular reference with empty object
       }
-      seen.add(value);
+      seen.set(value, true);
     }
     return value;
   }));

--- a/test/operator-convert-nested.spec.ts
+++ b/test/operator-convert-nested.spec.ts
@@ -29,38 +29,61 @@ const test = {
   },
 };
 
-describe.only('convert operator nested object unit tests', () => {
+describe('convert operator nested object unit tests', () => {
   it('it should not change the original object', () => {
-    const list = [test];
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 3 });
-    operator.handleData(list)!;
-    expect(test.nested).to.deep.eq(test.nested);
+    operator.handleData([deepClone])!;
+    expect(deepClone).to.deep.eq(test);
   });
 
   it('it should honor default maxDepth of 1', () => {
-    const list = [test];
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
-    const [int] = operator.handleData(list)!;
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
     expect(int.nested).to.deep.eq(test.nested);
   });
 
   it('it should honor maxDepth specified under amount', () => {
-    const list = [test];
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, maxDepth: 2 });
-    const [int] = operator.handleData(list)!;
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
     expect(int.nested).to.deep.eq(test.nested);
   });
 
-  it.only('it should work on values with settings correct ', () => {
-    const list = [test];
+  it('it should work on values with settings correct ', () => {
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 3 });
-    const [int] = operator.handleData(list)!;
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should work even with maxDepth set too large ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      { name: 'convert', enumerate: true, maxDepth: 10 });
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -80,353 +103,385 @@ describe.only('convert operator nested object unit tests', () => {
   });
 
   it('it should honor preserveArray ', () => {
-    const list = [test];
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, preserveArray: true, maxDepth: 3,
       });
-    const [int] = operator.handleData(list)!;
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.salePrice).to.deep.eq([24.99]);
     expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
   });
 
-  /*
-
-  it('it should convert all properties using *', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', properties: '*', type: 'int' });
-    const { quantity, stock } = item;
-    const [int] = operator.handleData([{ quantity, stock }])!;
+  it('it should convert to int', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'quantity', type: 'int', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
-    expect(int!.quantity).to.eq(10);
-    expect(int!.stock).to.eq(10);
-    expect(quantity).to.eq('10'); // don't mutate the actual data layer
-    expect(stock).to.eq('10'); // don't mutate the actual data layer
+    expect(int.nested.item.quantity).to.eq(10);
+    // the rest should be identical
+    delete deepClone.nested.item.quantity;
+    delete int.nested.item.quantity;
+    expect(deepClone).to.deep.eq(int);
   });
 
-  it('it should convert space separated props', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity, stock', type: 'int' });
-    const { quantity, stock } = item;
-    const [int] = operator.handleData([{ quantity, stock }])!;
+  it('it should convert to real', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: ['price', 'tax'], type: 'real', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
 
     expect(int).to.not.be.null;
-    expect(int!.quantity).to.eq(10);
-    expect(int!.stock).to.eq(10);
-    expect(quantity).to.eq('10');
-    expect(stock).to.eq('10');
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    // the rest should be identical
+    delete deepClone.nested.item.price;
+    delete deepClone.nested.item.tax;
+    delete int.nested.item.price;
+    delete int.nested.item.tax;
+    expect(deepClone).to.deep.eq(int);
+  });
+
+  it('it should convert to bool', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'available', type: 'bool', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.available).to.eq(false);
+    // the rest should be identical
+    delete deepClone.nested.item.available;
+    delete int.nested.item.available;
+    expect(deepClone).to.deep.eq(int);
+  });
+
+  it('it should convert to string', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'size', type: 'string', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.size).to.eq('5');
+    // the rest should be identical
+    delete deepClone.nested.item.size;
+    delete int.nested.item.size;
+    expect(deepClone).to.deep.eq(int);
+  });
+
+  it('it should convert to date', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'saleDate,tax', type: 'date', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.saleDate.getTime()).to.eq(new Date('12-26-2020').getTime());
+    // the rest should be identical, skipping tax as it is not a date
+    delete deepClone.nested.item.saleDate;
+    delete int.nested.item.saleDate;
+    expect(deepClone).to.deep.eq(int);
+  });
+
+  it('it should convert all properties using *', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: '*', type: 'int', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.empty).to.eq(0);
+    expect(int.nested.item.salePrice).to.deep.eq([24.99]);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    // the rest should be identical, skipping tax as it is not a date
+    delete deepClone.nested.item.quantity;
+    delete deepClone.nested.item.stock;
+    delete deepClone.nested.item.price;
+    delete deepClone.nested.item.salePrice;
+    delete deepClone.nested.item.tax;
+    delete deepClone.nested.item.discountTiers;
+    delete deepClone.nested.item.empty;
+    delete int.nested.item.quantity;
+    delete int.nested.item.stock;
+    delete int.nested.item.price;
+    delete int.nested.item.salePrice;
+    delete int.nested.item.tax;
+    delete int.nested.item.discountTiers;
+    delete int.nested.item.empty;
+    expect(deepClone).to.deep.eq(int);
   });
 
   it('it should not convert unsupported types', () => {
-    // @ts-ignore
-    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'array' });
-    const [unsupported] = operator.handleData([item])!;
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'size', type: 'array', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
 
-    expect(unsupported).to.not.be.null;
-    expect(unsupported!.quantity).to.eq(item.quantity); // no format occurs
+    expect(int).to.not.be.null;
+    expect(deepClone).to.deep.eq(int);
   });
 
   it('it should convert an object at a specific index', () => {
-    const operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'quantity', type: 'int', index: 1,
-    });
-    const [event, int, last, rest] = operator.handleData(['Product View', item, 'dlo'])!;
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', index: 1, properties: 'quantity', type: 'int', maxDepth: 3, preserveArray: true,
+      });
+    const [first, int, third] = operator.handleData(['Test', deepClone, 'Another Test'])!;
 
-    expect(event).to.not.be.null;
+    expect(first).to.not.be.null;
     expect(int).to.not.be.null;
-    expect(int.quantity).to.eq(10);
-    expect(last).to.eq('dlo');
-    expect(rest).to.be.undefined;
-  });
+    expect(third).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(first).to.eq('Test');
+    expect(third).to.eq('Another Test');
 
-  it('it should not fail if NaN is the result of conversion', () => {
-    let operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'empty', type: 'int',
-    });
-
-    const [int] = operator.handleData([item])!;
-
-    expect(int).to.not.be.null;
-    expect(int.empty).to.eq(0);
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'empty', type: 'real',
-    });
-
-    const [real] = operator.handleData([item])!;
-
-    expect(real).to.not.be.null;
-    expect(real.empty).to.eq(0);
-  });
-
-  it('it should convert undefined/null string to empty string when force is used', () => {
-    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'string' });
-    let [string] = operator.handleData([item])!;
-
-    expect(string).to.not.be.null;
-    expect(string!.vat).to.be.null;
-    expect(string!.nothing).to.be.undefined;
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'vat,nothing', type: 'string', force: true,
-    });
-    [string] = operator.handleData([item])!;
-
-    expect(string).to.not.be.null;
-    expect(string!.vat).to.be.empty;
-    expect(string!.nothing).to.be.empty;
-  });
-
-  it('it should convert undefined/null boolean to false when force is used', () => {
-    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'bool' });
-    let [bool] = operator.handleData([item])!;
-
-    expect(bool).to.not.be.null;
-    expect(bool!.vat).to.be.null;
-    expect(bool!.nothing).to.be.undefined;
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'vat,nothing', type: 'bool', force: true,
-    });
-    [bool] = operator.handleData([item])!;
-
-    expect(bool).to.not.be.null;
-    expect(bool!.vat).to.be.false;
-    expect(bool!.nothing).to.be.false;
-  });
-
-  it('it should convert undefined/null int or real to zero when force is used', () => {
-    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'real' });
-    let [real] = operator.handleData([item])!;
-
-    expect(real).to.not.be.null;
-    expect(real!.vat).to.be.null;
-    expect(real!.nothing).to.be.undefined;
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'vat,nothing', type: 'real', force: true,
-    });
-    [real] = operator.handleData([item])!;
-
-    expect(real).to.not.be.null;
-    expect(real!.vat).to.eq(0.0);
-    expect(real!.nothing).to.eq(0.0);
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'vat,nothing', type: 'int', force: false,
-    });
-    let [int] = operator.handleData([item])!;
-
-    expect(int).to.not.be.null;
-    expect(int!.vat).to.be.null;
-    expect(int!.nothing).to.be.undefined;
-
-    operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'vat,nothing', type: 'int', force: true,
-    });
-    [int] = operator.handleData([item])!;
-
-    expect(int).to.not.be.null;
-    expect(int!.vat).to.eq(0);
-    expect(int!.nothing).to.eq(0);
-  });
-
-  it('it should convert a list to a single converted value', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'salePrice', type: 'real' });
-    const [real] = operator.handleData([item])!;
-
-    expect(real).to.not.be.null;
-    expect(real.salePrice).to.eq(24.99);
-    expect(real.size).to.eq(5); // non-converted properties remain
-    expect(item.salePrice).to.eql(['24.99']); // don't mutate the actual data layer
+    // the rest should be identical
+    delete deepClone.nested.item.quantity;
+    delete int.nested.item.quantity;
+    expect(deepClone).to.deep.eq(int);
   });
 
   it('it should convert a list to a list of a single converted value', () => {
-    const operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'salePrice', preserveArray: true, type: 'real',
-    });
-    const [reals] = operator.handleData([item])!;
-
-    expect(reals).to.not.be.null;
-    expect(reals.salePrice).to.eql([24.99]);
-    expect(reals.size).to.eq(5); // non-converted properties remain
-    expect(item.salePrice).to.eql(['24.99']); // don't mutate the actual data layer
-  });
-
-  it('it should convert a list to a list of converted values', () => {
-    const operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'discountTiers', type: 'real',
-    });
-    const [reals] = operator.handleData([item])!;
-
-    expect(reals).to.not.be.null;
-    expect(reals.discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(reals.size).to.eq(5); // non-converted properties remain
-    expect(item.discountTiers).to.eql(['24.99', '19.99', '12.99']); // don't mutate the actual data layer
-  });
-
-  it('strings can be enumerated', () => {
-    for (let number = 0; number <= 101; number += 1) {
-      expect(ConvertOperator.enumerate(`${number}`)).to.eq(number);
-    }
-    expect(ConvertOperator.enumerate('-1')).to.eql(-1);
-  });
-
-  it('invalid strings should not be enumerated', () => {
-    expect(ConvertOperator.enumerate('foo')).to.eql(NaN);
-    expect(ConvertOperator.enumerate('1foo2')).to.eql(NaN);
-    expect(ConvertOperator.enumerate('1 foo 2')).to.eql(NaN);
-    expect(ConvertOperator.enumerate('1 2')).to.eql(NaN);
-  });
-
-  it('strings can be converted automatically to numbers', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
-    } = enumerated;
-
-    expect(quantity).to.eq(10);
-    expect(price).to.eq(29.99);
-    expect(available).to.eq('false');
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(empty).to.eq('');
-    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
-  });
-
-  it('ignore should cause single property to be skipped', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'price' });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
-    } = enumerated;
-
-    expect(quantity).to.eq(10);
-    expect(price).to.eq('29.99');
-    expect(available).to.eq('false');
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(empty).to.eq('');
-    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
-  });
-
-  it('ignore should cause multiple properties to be skipped', () => {
+    const deepClone = structuredClone(test);
     const operator = OperatorFactory.create('convert',
-      { name: 'convert', enumerate: true, ignore: ['price', 'quantity'] });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
-    } = enumerated;
+      {
+        name: 'convert', properties: 'salePrice', type: 'real', maxDepth: 3, preserveArray: true,
+      });
+    const [int] = operator.handleData([deepClone])!;
 
-    expect(quantity).to.eq('10');
-    expect(price).to.eq('29.99');
-    expect(available).to.eq('false');
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(empty).to.eq('');
-    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
-  });
-
-  it('ignore with commas should cause multiple properties to be skipped', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'price,quantity' });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
-    } = enumerated;
-
-    expect(quantity).to.eq('10');
-    expect(price).to.eq('29.99');
-    expect(available).to.eq('false');
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(empty).to.eq('');
-    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
-  });
-
-  it('non matching ignore should not affect the object', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'foo' });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
-    } = enumerated;
-
-    expect(quantity).to.eq(10);
-    expect(price).to.eq(29.99);
-    expect(available).to.eq('false');
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-    expect(empty).to.eq('');
-    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
-  });
-
-  it('ignoreSuffix should not convert suffixed vales', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      // eslint-disable-next-line camelcase
-      forced_str,
-    } = enumerated;
-
-    expect(forced_str).to.eq('12345');
-  });
-
-  it('ignoreSuffix set to false should convert suffixed vales', () => {
-    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignoreSuffixed: false });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      // eslint-disable-next-line camelcase
-      forced_str,
-    } = enumerated;
-
-    expect(forced_str).to.eq(12345);
-  });
-
-  it('strings can be converted automatically to numbers while converting specific properties', () => {
-    const operator = OperatorFactory.create('convert', {
-      name: 'convert', enumerate: true, properties: 'available', type: 'bool',
-    });
-    const [enumerated] = operator.handleData([item])!;
-    const {
-      quantity, price, available, saleDate, type, vat, salePrice, discountTiers,
-    } = enumerated;
-
-    expect(quantity).to.eq(10);
-    expect(price).to.eq(29.99);
-    expect(available).to.eq(false);
-    expect(saleDate).to.eq('12-26-2020');
-    expect(vat).to.eq(null);
-    expect(type).to.eq(true);
-    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
-    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
-  });
-
-  it('it should convert from the end of a list', () => {
-    const operator = OperatorFactory.create('convert', {
-      name: 'convert', properties: 'quantity', type: 'int', index: -1,
-    });
-    const [eventName, int] = operator.handleData(['track', item])!;
-
-    expect(eventName).to.eql('track');
     expect(int).to.not.be.null;
-    expect(int.quantity).to.eq(10);
-    expect(int.size).to.eq(5); // non-converted properties remain
-    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
-  }); */
+    expect(int.nested.item.salePrice).to.deep.eq([24.99]);
+
+    // the rest should be identical
+    delete deepClone.nested.item.salePrice;
+    delete int.nested.item.salePrice;
+    expect(deepClone).to.deep.eq(int);
+  });
+
+  it('it should skip a single ignored property ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, ignore: 'price', maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq('29.99');
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should skip  multiple ignored properties with an array ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, ignore: ['stock', 'quantity'], maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq('10');
+    expect(int.nested.item.stock).to.eq('10');
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should skip multiple ignored properties with a comma ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, ignore: 'tax,price', maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq('29.99');
+    expect(int.nested.item.tax).to.eq('1.99');
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should skip non matching ignore properties ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, ignore: 'fake,tax,price', maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq('29.99');
+    expect(int.nested.item.tax).to.eq('1.99');
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should convert suffixed properties ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, ignoreSuffixed: false, maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq(12345);
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should convert specific properties as well as enumerate ', () => {
+    const deepClone = structuredClone(test);
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, properties: 'available', type: 'bool', maxDepth: 3,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq(false);
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(int.nested.item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+  });
+
+  it('it should work on array of objects with settings correct ', () => {
+    const deepClone = {
+      nested: [structuredClone(test.nested), structuredClone(test.nested), structuredClone(test.nested)],
+    };
+
+    const operator = OperatorFactory.create('convert',
+      { name: 'convert', enumerate: true, maxDepth: 3 });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+
+    // eslint-disable-next-line no-plusplus
+    for (let x = 0; x < 3; x++) {
+      expect(int.nested[x].item.quantity).to.eq(10);
+      expect(int.nested[x].item.stock).to.eq(10);
+      expect(int.nested[x].item.price).to.eq(29.99);
+      expect(int.nested[x].item.tax).to.eq(1.99);
+      expect(int.nested[x].item.available).to.eq('false');
+      expect(int.nested[x].item.size).to.eq(5);
+      expect(int.nested[x].item.type).to.eq(true);
+      expect(int.nested[x].item.empty).to.eq('');
+      expect(int.nested[x].item.saleDate).to.eq('12-26-2020');
+      expect(int.nested[x].item.vat).to.eq(null);
+      expect(int.nested[x].item.forced_str).to.eq('12345');
+      expect(int.nested[x].item.salePrice).to.deep.eq(24.99);
+      expect(int.nested[x].item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+      expect(int.nested[x].item.promoCodes).to.deep.eq(['', 'bogo', 'july4th']);
+    }
+  });
+
+  it('it should work on a deeper array of objects with specific properties ', () => {
+    const deepClone = structuredClone(test);
+    // @ts-ignore
+    deepClone.nested.anotherElement.deepNested = [
+      { deepTest: '1', noConvert: '1' },
+      { deepTest: '2', noConvert: '2' },
+      { deepTest: '3', noConvert: '3' },
+    ];
+
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', properties: 'deepTest', type: 'int', maxDepth: 4,
+      });
+    const [int] = operator.handleData([deepClone])!;
+
+    expect(int).to.not.be.null;
+    // eslint-disable-next-line no-plusplus
+    for (let x = 1; x < 4; x++) {
+      expect(int.nested.anotherElement.deepNested[x - 1].deepTest).to.eq(x);
+      expect(int.nested.anotherElement.deepNested[x - 1].noConvert).to.eq(`${x}`);
+    }
+  });
 });

--- a/test/operator-convert-nested.spec.ts
+++ b/test/operator-convert-nested.spec.ts
@@ -483,4 +483,30 @@ describe('convert operator nested object unit tests', () => {
       expect(int.nested.anotherElement.deepNested[x - 1].noConvert).to.eq(`${x}`);
     }
   });
+
+  it('it should bypass circular references ', () => {
+    const cloned = deepClone(test);
+    cloned.circular = cloned.nested.item;
+    cloned.nested.item.circular = cloned.circular;
+    const operator = OperatorFactory.create('convert',
+      {
+        name: 'convert', enumerate: true, maxDepth: 4,
+      });
+    const [int] = operator.handleData([cloned])!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.tax).to.eq(1.99);
+    expect(int.nested.item.available).to.eq('false');
+    expect(int.nested.item.size).to.eq(5);
+    expect(int.nested.item.type).to.eq(true);
+    expect(int.nested.item.empty).to.eq('');
+    expect(int.nested.item.saleDate).to.eq('12-26-2020');
+    expect(int.nested.item.vat).to.eq(null);
+    expect(int.nested.item.forced_str).to.eq('12345');
+    expect(int.nested.item.salePrice).to.deep.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+  });
 });

--- a/test/operator-convert-nested.spec.ts
+++ b/test/operator-convert-nested.spec.ts
@@ -2,8 +2,7 @@ import { expect } from 'chai';
 import 'mocha';
 
 import { OperatorFactory } from '../src/factory';
-// import { ConvertOperator } from '../src/operators';
-// import { expectInvalid, expectValid } from './utils/mocha';
+import { deepClone } from '../src/utils/object';
 
 const test = {
   nested: {
@@ -31,36 +30,36 @@ const test = {
 
 describe('convert operator nested object unit tests', () => {
   it('it should not change the original object', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 3 });
-    operator.handleData([deepClone])!;
-    expect(deepClone).to.deep.eq(test);
+    operator.handleData([cloned])!;
+    expect(cloned).to.deep.eq(test);
   });
 
   it('it should honor default maxDepth of 1', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested).to.deep.eq(test.nested);
   });
 
   it('it should honor maxDepth specified under amount', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, maxDepth: 2 });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested).to.deep.eq(test.nested);
   });
 
   it('it should work on values with settings correct ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 3 });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -80,10 +79,10 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should work even with maxDepth set too large ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 10 });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -103,12 +102,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should honor preserveArray ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, preserveArray: true, maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.salePrice).to.deep.eq([24.99]);
@@ -116,95 +115,95 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should convert to int', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'quantity', type: 'int', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
     // the rest should be identical
-    delete deepClone.nested.item.quantity;
+    delete cloned.nested.item.quantity;
     delete int.nested.item.quantity;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert to real', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: ['price', 'tax'], type: 'real', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.price).to.eq(29.99);
     expect(int.nested.item.tax).to.eq(1.99);
     // the rest should be identical
-    delete deepClone.nested.item.price;
-    delete deepClone.nested.item.tax;
+    delete cloned.nested.item.price;
+    delete cloned.nested.item.tax;
     delete int.nested.item.price;
     delete int.nested.item.tax;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert to bool', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'available', type: 'bool', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.available).to.eq(false);
     // the rest should be identical
-    delete deepClone.nested.item.available;
+    delete cloned.nested.item.available;
     delete int.nested.item.available;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert to string', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'size', type: 'string', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.size).to.eq('5');
     // the rest should be identical
-    delete deepClone.nested.item.size;
+    delete cloned.nested.item.size;
     delete int.nested.item.size;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert to date', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'saleDate,tax', type: 'date', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.saleDate.getTime()).to.eq(new Date('12-26-2020').getTime());
     // the rest should be identical, skipping tax as it is not a date
-    delete deepClone.nested.item.saleDate;
+    delete cloned.nested.item.saleDate;
     delete int.nested.item.saleDate;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert all properties using *', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: '*', type: 'int', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -215,13 +214,13 @@ describe('convert operator nested object unit tests', () => {
     expect(int.nested.item.salePrice).to.deep.eq([24.99]);
     expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
     // the rest should be identical, skipping tax as it is not a date
-    delete deepClone.nested.item.quantity;
-    delete deepClone.nested.item.stock;
-    delete deepClone.nested.item.price;
-    delete deepClone.nested.item.salePrice;
-    delete deepClone.nested.item.tax;
-    delete deepClone.nested.item.discountTiers;
-    delete deepClone.nested.item.empty;
+    delete cloned.nested.item.quantity;
+    delete cloned.nested.item.stock;
+    delete cloned.nested.item.price;
+    delete cloned.nested.item.salePrice;
+    delete cloned.nested.item.tax;
+    delete cloned.nested.item.discountTiers;
+    delete cloned.nested.item.empty;
     delete int.nested.item.quantity;
     delete int.nested.item.stock;
     delete int.nested.item.price;
@@ -229,28 +228,28 @@ describe('convert operator nested object unit tests', () => {
     delete int.nested.item.tax;
     delete int.nested.item.discountTiers;
     delete int.nested.item.empty;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should not convert unsupported types', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'size', type: 'array', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert an object at a specific index', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', index: 1, properties: 'quantity', type: 'int', maxDepth: 3, preserveArray: true,
       });
-    const [first, int, third] = operator.handleData(['Test', deepClone, 'Another Test'])!;
+    const [first, int, third] = operator.handleData(['Test', cloned, 'Another Test'])!;
 
     expect(first).to.not.be.null;
     expect(int).to.not.be.null;
@@ -260,35 +259,35 @@ describe('convert operator nested object unit tests', () => {
     expect(third).to.eq('Another Test');
 
     // the rest should be identical
-    delete deepClone.nested.item.quantity;
+    delete cloned.nested.item.quantity;
     delete int.nested.item.quantity;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should convert a list to a list of a single converted value', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', properties: 'salePrice', type: 'real', maxDepth: 3, preserveArray: true,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.salePrice).to.deep.eq([24.99]);
 
     // the rest should be identical
-    delete deepClone.nested.item.salePrice;
+    delete cloned.nested.item.salePrice;
     delete int.nested.item.salePrice;
-    expect(deepClone).to.deep.eq(int);
+    expect(cloned).to.deep.eq(int);
   });
 
   it('it should skip a single ignored property ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, ignore: 'price', maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -308,12 +307,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should skip  multiple ignored properties with an array ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, ignore: ['stock', 'quantity'], maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq('10');
@@ -333,12 +332,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should skip multiple ignored properties with a comma ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, ignore: 'tax,price', maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -358,12 +357,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should skip non matching ignore properties ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, ignore: 'fake,tax,price', maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -383,12 +382,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should convert suffixed properties ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, ignoreSuffixed: false, maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -408,12 +407,12 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should convert specific properties as well as enumerate ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     const operator = OperatorFactory.create('convert',
       {
         name: 'convert', enumerate: true, properties: 'available', type: 'bool', maxDepth: 3,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     expect(int.nested.item.quantity).to.eq(10);
@@ -433,13 +432,13 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should work on array of objects with settings correct ', () => {
-    const deepClone = {
-      nested: [structuredClone(test.nested), structuredClone(test.nested), structuredClone(test.nested)],
+    const cloned = {
+      nested: [deepClone(test.nested), deepClone(test.nested), deepClone(test.nested)],
     };
 
     const operator = OperatorFactory.create('convert',
       { name: 'convert', enumerate: true, maxDepth: 3 });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
 
@@ -463,9 +462,9 @@ describe('convert operator nested object unit tests', () => {
   });
 
   it('it should work on a deeper array of objects with specific properties ', () => {
-    const deepClone = structuredClone(test);
+    const cloned = deepClone(test);
     // @ts-ignore
-    deepClone.nested.anotherElement.deepNested = [
+    cloned.nested.anotherElement.deepNested = [
       { deepTest: '1', noConvert: '1' },
       { deepTest: '2', noConvert: '2' },
       { deepTest: '3', noConvert: '3' },
@@ -475,7 +474,7 @@ describe('convert operator nested object unit tests', () => {
       {
         name: 'convert', properties: 'deepTest', type: 'int', maxDepth: 4,
       });
-    const [int] = operator.handleData([deepClone])!;
+    const [int] = operator.handleData([cloned])!;
 
     expect(int).to.not.be.null;
     // eslint-disable-next-line no-plusplus

--- a/test/operator-convert-nested.spec.ts
+++ b/test/operator-convert-nested.spec.ts
@@ -1,0 +1,466 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { OperatorFactory } from '../src/factory';
+// import { ConvertOperator } from '../src/operators';
+// import { expectInvalid, expectValid } from './utils/mocha';
+
+const test = {
+  nested: {
+    item: {
+      quantity: '10',
+      stock: '10',
+      price: '29.99',
+      tax: '1.99',
+      available: 'false',
+      size: 5,
+      type: true,
+      empty: '',
+      saleDate: '12-26-2020',
+      vat: null,
+      forced_str: '12345',
+      salePrice: ['24.99'],
+      discountTiers: ['24.99', '19.99', '12.99'],
+      promoCodes: ['', 'bogo', 'july4th'],
+    },
+    anotherElement: {
+      name: 'Test Element',
+    },
+  },
+};
+
+describe.only('convert operator nested object unit tests', () => {
+  it('it should not change the original object', () => {
+    const list = [test];
+    const operator = OperatorFactory.create('convert',
+      { name: 'convert', enumerate: true, maxDepth: 3 });
+    const [int] = operator.handleData(list)!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested.item.quantity).to.eq(10);
+    expect(int.nested.item.stock).to.eq(10);
+    expect(int.nested.item.price).to.eq(29.99);
+    expect(int.nested.item.salePrice).to.eq(24.99);
+    expect(int.nested.item.discountTiers).to.deep.eq([24.99, 19.99, 12.99]);
+    expect(test.nested).to.deep.eq(test.nested);
+  });
+
+  it('it should honor maxDepth of 1', () => {
+    const list = [test];
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
+    const [int] = operator.handleData(list)!;
+
+    expect(int).to.not.be.null;
+    expect(int.nested).to.deep.eq(test.nested);
+    expect(test.nested).to.deep.eq(test.nested);
+  });
+
+  /*
+  it('it should convert to int', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'int' });
+    const [int] = operator.handleData([nested])!;
+
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(int.size).to.eq(5); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to real', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: ['price', 'tax'], type: 'real' });
+    const [reals] = operator.handleData([item])!;
+
+    expect(reals).to.not.be.null;
+    expect(reals!.price).to.eq(29.99);
+    expect(reals!.tax).to.eq(1.99);
+    expect(reals.type).to.eq(true); // non-converted properties remain
+    expect(item.price).to.eq('29.99'); // don't mutate the actual data layer
+    expect(item.tax).to.eq('1.99'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to bool', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'available', type: 'bool' });
+    const [bool] = operator.handleData([item])!;
+
+    expect(bool).to.not.be.null;
+    expect(bool!.available).to.eq(false);
+    expect(bool.stock).to.eq('10'); // non-converted properties remain
+    expect(item.available).to.eq('false'); // don't mutate the actual data layer
+  });
+
+  it('it should convert to string', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'size', type: 'string' });
+    const [stringInt] = operator.handleData([item])!;
+
+    expect(stringInt).to.not.be.null;
+    expect(stringInt.size).to.eq('5');
+    expect(item.size).to.eq(5); // don't mutate the actual data layer
+
+    operator = OperatorFactory.create('convert', { name: 'convert', properties: 'type', type: 'string' });
+    const [stringBool] = operator.handleData([item])!;
+
+    expect(stringBool).to.not.be.null;
+    expect(stringBool.type).to.eq('true');
+    expect(stringBool.tax).to.eq('1.99'); // non-converted properties remain
+    expect(item.type).to.eq(true); // don't mutate the actual data layer
+  });
+
+  it('it should convert to date', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'saleDate,tax', type: 'date' });
+    const [date] = operator.handleData([item])!;
+
+    expect(date).to.not.be.null;
+    expect(date!.saleDate.toString()).to.eq(new Date('12-26-2020').toString());
+    expect(date.tax).to.eq(item.tax); // failed conversions should be the original value
+    expect(date.stock).to.eq('10'); // non-converted properties remain
+    expect(item.saleDate).to.eq('12-26-2020'); // don't mutate the actual data layer
+  });
+
+  it('it should convert CSV input', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity,stock', type: 'int' });
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(int.type).to.eq(true); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+    expect(item.stock).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert all properties using *', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: '*', type: 'int' });
+    const { quantity, stock } = item;
+    const [int] = operator.handleData([{ quantity, stock }])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(quantity).to.eq('10'); // don't mutate the actual data layer
+    expect(stock).to.eq('10'); // don't mutate the actual data layer
+  });
+
+  it('it should convert space separated props', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity, stock', type: 'int' });
+    const { quantity, stock } = item;
+    const [int] = operator.handleData([{ quantity, stock }])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.quantity).to.eq(10);
+    expect(int!.stock).to.eq(10);
+    expect(quantity).to.eq('10');
+    expect(stock).to.eq('10');
+  });
+
+  it('it should not convert unsupported types', () => {
+    // @ts-ignore
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'quantity', type: 'array' });
+    const [unsupported] = operator.handleData([item])!;
+
+    expect(unsupported).to.not.be.null;
+    expect(unsupported!.quantity).to.eq(item.quantity); // no format occurs
+  });
+
+  it('it should convert an object at a specific index', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'quantity', type: 'int', index: 1,
+    });
+    const [event, int, last, rest] = operator.handleData(['Product View', item, 'dlo'])!;
+
+    expect(event).to.not.be.null;
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(last).to.eq('dlo');
+    expect(rest).to.be.undefined;
+  });
+
+  it('it should not fail if NaN is the result of conversion', () => {
+    let operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'empty', type: 'int',
+    });
+
+    const [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int.empty).to.eq(0);
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'empty', type: 'real',
+    });
+
+    const [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real.empty).to.eq(0);
+  });
+
+  it('it should convert undefined/null string to empty string when force is used', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'string' });
+    let [string] = operator.handleData([item])!;
+
+    expect(string).to.not.be.null;
+    expect(string!.vat).to.be.null;
+    expect(string!.nothing).to.be.undefined;
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'vat,nothing', type: 'string', force: true,
+    });
+    [string] = operator.handleData([item])!;
+
+    expect(string).to.not.be.null;
+    expect(string!.vat).to.be.empty;
+    expect(string!.nothing).to.be.empty;
+  });
+
+  it('it should convert undefined/null boolean to false when force is used', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'bool' });
+    let [bool] = operator.handleData([item])!;
+
+    expect(bool).to.not.be.null;
+    expect(bool!.vat).to.be.null;
+    expect(bool!.nothing).to.be.undefined;
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'vat,nothing', type: 'bool', force: true,
+    });
+    [bool] = operator.handleData([item])!;
+
+    expect(bool).to.not.be.null;
+    expect(bool!.vat).to.be.false;
+    expect(bool!.nothing).to.be.false;
+  });
+
+  it('it should convert undefined/null int or real to zero when force is used', () => {
+    let operator = OperatorFactory.create('convert', { name: 'convert', properties: 'vat,nothing', type: 'real' });
+    let [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real!.vat).to.be.null;
+    expect(real!.nothing).to.be.undefined;
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'vat,nothing', type: 'real', force: true,
+    });
+    [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real!.vat).to.eq(0.0);
+    expect(real!.nothing).to.eq(0.0);
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'vat,nothing', type: 'int', force: false,
+    });
+    let [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.vat).to.be.null;
+    expect(int!.nothing).to.be.undefined;
+
+    operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'vat,nothing', type: 'int', force: true,
+    });
+    [int] = operator.handleData([item])!;
+
+    expect(int).to.not.be.null;
+    expect(int!.vat).to.eq(0);
+    expect(int!.nothing).to.eq(0);
+  });
+
+  it('it should convert a list to a single converted value', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', properties: 'salePrice', type: 'real' });
+    const [real] = operator.handleData([item])!;
+
+    expect(real).to.not.be.null;
+    expect(real.salePrice).to.eq(24.99);
+    expect(real.size).to.eq(5); // non-converted properties remain
+    expect(item.salePrice).to.eql(['24.99']); // don't mutate the actual data layer
+  });
+
+  it('it should convert a list to a list of a single converted value', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'salePrice', preserveArray: true, type: 'real',
+    });
+    const [reals] = operator.handleData([item])!;
+
+    expect(reals).to.not.be.null;
+    expect(reals.salePrice).to.eql([24.99]);
+    expect(reals.size).to.eq(5); // non-converted properties remain
+    expect(item.salePrice).to.eql(['24.99']); // don't mutate the actual data layer
+  });
+
+  it('it should convert a list to a list of converted values', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'discountTiers', type: 'real',
+    });
+    const [reals] = operator.handleData([item])!;
+
+    expect(reals).to.not.be.null;
+    expect(reals.discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(reals.size).to.eq(5); // non-converted properties remain
+    expect(item.discountTiers).to.eql(['24.99', '19.99', '12.99']); // don't mutate the actual data layer
+  });
+
+  it('strings can be enumerated', () => {
+    for (let number = 0; number <= 101; number += 1) {
+      expect(ConvertOperator.enumerate(`${number}`)).to.eq(number);
+    }
+    expect(ConvertOperator.enumerate('-1')).to.eql(-1);
+  });
+
+  it('invalid strings should not be enumerated', () => {
+    expect(ConvertOperator.enumerate('foo')).to.eql(NaN);
+    expect(ConvertOperator.enumerate('1foo2')).to.eql(NaN);
+    expect(ConvertOperator.enumerate('1 foo 2')).to.eql(NaN);
+    expect(ConvertOperator.enumerate('1 2')).to.eql(NaN);
+  });
+
+  it('strings can be converted automatically to numbers', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
+    } = enumerated;
+
+    expect(quantity).to.eq(10);
+    expect(price).to.eq(29.99);
+    expect(available).to.eq('false');
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
+  });
+
+  it('ignore should cause single property to be skipped', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'price' });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
+    } = enumerated;
+
+    expect(quantity).to.eq(10);
+    expect(price).to.eq('29.99');
+    expect(available).to.eq('false');
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
+  });
+
+  it('ignore should cause multiple properties to be skipped', () => {
+    const operator = OperatorFactory.create('convert',
+      { name: 'convert', enumerate: true, ignore: ['price', 'quantity'] });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
+    } = enumerated;
+
+    expect(quantity).to.eq('10');
+    expect(price).to.eq('29.99');
+    expect(available).to.eq('false');
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
+  });
+
+  it('ignore with commas should cause multiple properties to be skipped', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'price,quantity' });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
+    } = enumerated;
+
+    expect(quantity).to.eq('10');
+    expect(price).to.eq('29.99');
+    expect(available).to.eq('false');
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
+  });
+
+  it('non matching ignore should not affect the object', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignore: 'foo' });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers, empty, promoCodes,
+    } = enumerated;
+
+    expect(quantity).to.eq(10);
+    expect(price).to.eq(29.99);
+    expect(available).to.eq('false');
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+    expect(empty).to.eq('');
+    expect(promoCodes).to.eql(['', 'bogo', 'july4th']); // NOTE empty string should not become 0
+  });
+
+  it('ignoreSuffix should not convert suffixed vales', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      // eslint-disable-next-line camelcase
+      forced_str,
+    } = enumerated;
+
+    expect(forced_str).to.eq('12345');
+  });
+
+  it('ignoreSuffix set to false should convert suffixed vales', () => {
+    const operator = OperatorFactory.create('convert', { name: 'convert', enumerate: true, ignoreSuffixed: false });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      // eslint-disable-next-line camelcase
+      forced_str,
+    } = enumerated;
+
+    expect(forced_str).to.eq(12345);
+  });
+
+  it('strings can be converted automatically to numbers while converting specific properties', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', enumerate: true, properties: 'available', type: 'bool',
+    });
+    const [enumerated] = operator.handleData([item])!;
+    const {
+      quantity, price, available, saleDate, type, vat, salePrice, discountTiers,
+    } = enumerated;
+
+    expect(quantity).to.eq(10);
+    expect(price).to.eq(29.99);
+    expect(available).to.eq(false);
+    expect(saleDate).to.eq('12-26-2020');
+    expect(vat).to.eq(null);
+    expect(type).to.eq(true);
+    expect(salePrice).to.eq(24.99); // NOTE because preserveArray is not true, it becomes a single value
+    expect(discountTiers).to.eql([24.99, 19.99, 12.99]);
+  });
+
+  it('it should convert from the end of a list', () => {
+    const operator = OperatorFactory.create('convert', {
+      name: 'convert', properties: 'quantity', type: 'int', index: -1,
+    });
+    const [eventName, int] = operator.handleData(['track', item])!;
+
+    expect(eventName).to.eql('track');
+    expect(int).to.not.be.null;
+    expect(int.quantity).to.eq(10);
+    expect(int.size).to.eq(5); // non-converted properties remain
+    expect(item.quantity).to.eq('10'); // don't mutate the actual data layer
+  }); */
+});


### PR DESCRIPTION
This is to add the ability for the `convert` operator to work on nested objects.  Right now it only works on one level, this adds a new property called `maxDepth` (following the pattern of the `flatten` operator), that triggers the new behavior.