### PR TITLE
Adding in honoring preview mode with fsApi and a unit test for that.

### DIFF
--- a/src/observer.ts
+++ b/src/observer.ts
@@ -231,6 +231,14 @@ export class DataLayerObserver {
         beforeOptions.forEach((operator) => handler.push(this.getOperator(operator)));
       }
 
+      // preview mode uses destination, so if previewMode get rid of fsApi
+      if (previewMode && fsApi) {
+        // eslint-disable-next-line no-param-reassign
+        destination = fsApi;
+        // eslint-disable-next-line no-param-reassign
+        fsApi = undefined;
+      }
+
       if (fsApi) {
         switch (fsApi) {
           case FS_API_CONSTANTS.SET_IDENTITY:

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -231,15 +231,7 @@ export class DataLayerObserver {
         beforeOptions.forEach((operator) => handler.push(this.getOperator(operator)));
       }
 
-      // preview mode uses destination, so if previewMode get rid of fsApi
-      if (previewMode && fsApi) {
-        // eslint-disable-next-line no-param-reassign
-        destination = fsApi;
-        // eslint-disable-next-line no-param-reassign
-        fsApi = undefined;
-      }
-
-      if (fsApi) {
+      if (fsApi && !previewMode) {
         switch (fsApi) {
           case FS_API_CONSTANTS.SET_IDENTITY:
             handler.push(new SetIdentityOperator({ name: FS_API_CONSTANTS.SET_IDENTITY }));
@@ -256,7 +248,7 @@ export class DataLayerObserver {
           default:
             Logger.getInstance().error(`Unexpected coding error: Unknown fsApi value ${fsApi}`);
         }
-      } else if (destination) {
+      } else if (destination || previewMode) {
         const func = previewMode ? previewDestination : destination;
         // if the version is greater than 1 it should ignore beforeDestination but still add dlo output
         if (version > 1) {
@@ -264,7 +256,8 @@ export class DataLayerObserver {
             name: 'insert', position: -1, value: 'dlo',
           }));
         }
-        handler.push(new FunctionOperator({ name: 'function', func }));
+        // we know func is defined as previewDestination is used with preview mode
+        handler.push(new FunctionOperator({ name: 'function', func: func! }));
       } else {
         Logger.getInstance().error('Unexpected coding error: Missing fsApi or destination');
       }

--- a/test/observer.spec.ts
+++ b/test/observer.spec.ts
@@ -16,7 +16,7 @@ import { LogEvent, LogLevel, Logger } from '../src/utils/logger';
 import DataHandler from '../src/handler';
 import { MockClass } from './mocks/mock';
 import MonitorFactory from '../src/monitor-factory';
-import { DataLayerObserver } from '../src/observer';
+import { DataLayerObserver, FS_API_CONSTANTS } from '../src/observer';
 import DataLayerTarget from '../src/target';
 
 class EchoOperator implements Operator {
@@ -268,6 +268,31 @@ describe('DataLayerObserver unit tests', () => {
           source: 'digitalData.user.profile[0].profileInfo',
           operators: [],
           destination: 'FS.setUserVars',
+          monitor: false,
+        },
+      ],
+    });
+
+    const [profileInfo] = expectParams(globalMock.console, 'log');
+    expect(profileInfo).to.eq(globalMock.digitalData.user.profile[0].profileInfo);
+
+    expectNoCalls(globalMock.FS, 'setUserVars');
+
+    ExpectObserver.getInstance().cleanup(observer);
+  });
+
+  it('previewMode works with fsApi', () => {
+    expectNoCalls(globalMock.console, 'log');
+    expectNoCalls(globalMock.FS, 'setUserVars');
+
+    const observer = ExpectObserver.getInstance().create({
+      previewMode: true,
+      readOnLoad: true,
+      rules: [
+        {
+          source: 'digitalData.user.profile[0].profileInfo',
+          operators: [],
+          fsApi: FS_API_CONSTANTS.TRACK_EVENT,
           monitor: false,
         },
       ],


### PR DESCRIPTION
I realized when coding some changes to Companion to support fsApi that previewMode was not honored with fsApi set.  This probably won't happen too much in production, but if it did it would confuse folks.  So I fixed it and added a test for it so we don't miss something like that again.