### PR TITLE
refactor: route _fs_namespace reads through getFsNamespace helper

### DIFF
--- a/src/embed/init.impl.ts
+++ b/src/embed/init.impl.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle, camelcase */
 import { Logger, LogMessageType } from '../utils/logger';
+import { getFsNamespace } from '../utils/fsNamespace';
 import { startsWith } from '../utils/object';
 import { DataLayerObserver } from '../observer';
 import {
@@ -112,8 +113,8 @@ export function attachDloFullStoryLifecycle(win: { [key: string]: any }): void {
     return;
   }
 
-  const ns = win._fs_namespace;
-  const fs = (typeof ns === 'string' && ns) ? win[ns] : undefined;
+  const ns = getFsNamespace(win as any);
+  const fs = win[ns];
   if (typeof fs !== 'function') {
     return;
   }

--- a/src/operators/fsApi/fsApi.ts
+++ b/src/operators/fsApi/fsApi.ts
@@ -1,5 +1,6 @@
 import { Operator, OperatorOptions, OperatorValidator } from '../../operator';
 import { getGlobal } from '../../utils/object';
+import { getFsNamespace } from '../../utils/fsNamespace';
 
 export interface FSApiOperatorOptions extends OperatorOptions {
 
@@ -14,10 +15,9 @@ export default abstract class FSApiOperator implements Operator {
 
   handleData(data: any[]): any[] | null {
     const thisArg: object = getGlobal();
-    // @ts-ignore
-    const fsFunction:any = thisArg[thisArg._fs_namespace]; // eslint-disable-line
+    const fsFunction: any = (thisArg as any)[getFsNamespace(thisArg as any)];
     if (typeof fsFunction !== 'function') {
-      throw new Error('_fs_namespace is not a function');
+      throw new Error('Fullstory namespace is not a function');
     }
     // subclasses will determine how to prepare the data
     const realData = this.prepareData(data);

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,5 +1,6 @@
 import { parsePath, ElementKind, select } from './selector';
 import { Logger, LogMessage } from './utils/logger';
+import { getFsNamespace } from './utils/fsNamespace';
 import { getGlobal } from './utils/object';
 import DataLayerValue from './value';
 
@@ -48,8 +49,7 @@ export default class DataLayerTarget implements DataLayerValue {
   constructor(public subject: Object, public property: string, public path: string,
     public selector = '') {
     // NB special case added to support new FS.dataLayer observation
-    // eslint-disable-next-line no-underscore-dangle
-    if (typeof subject !== 'object' && subject !== (window as any)[(window as any)._fs_namespace]) {
+    if (typeof subject !== 'object' && subject !== (window as any)[getFsNamespace(window)]) {
       throw new Error(LogMessage.TargetSubjectObject);
     }
 

--- a/src/utils/fsNamespace.ts
+++ b/src/utils/fsNamespace.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-underscore-dangle, import/prefer-default-export */
+
+/**
+ * Resolves the FullStory client namespace on `window`.
+ *
+ * Mirrors the resolution order used by `@fullstory/browser-api`:
+ *   1. The `data-fs-namespace` attribute on `document.currentScript` (best-effort).
+ *   2. The `_fs_namespace` global set on `window` by the FullStory snippet.
+ *   3. The default namespace `'FS'`.
+ *
+ * Note: `document.currentScript` is only meaningful while the helper module is being
+ * evaluated synchronously by a script tag. DLO calls this helper from deferred callbacks
+ * (appender log, operator handleData, lifecycle hook), so the attribute lookup is
+ * opportunistic and the global is the practical fallback floor — same behavior as the
+ * existing `(window as any)._fs_namespace` reads it replaces.
+ *
+ * @param win the global to read from; defaults to `window`
+ */
+export function getFsNamespace(win: any = window): string {
+  try {
+    const script = (win && win.document && win.document.currentScript) as HTMLScriptElement | null;
+    const attr = script && script.getAttribute && script.getAttribute('data-fs-namespace');
+    if (attr) return attr;
+  } catch (_) {
+    // ignore: cross-origin or detached document access can throw
+  }
+  return (win && win._fs_namespace) || 'FS';
+}

--- a/src/utils/fsNamespace.ts
+++ b/src/utils/fsNamespace.ts
@@ -3,7 +3,7 @@
 /**
  * Resolves the FullStory client namespace on `window`.
  *
- * Mirrors the resolution order used by `@fullstory/browser-api`:
+ * Mirrors the resolution order used by fs.js:
  *   1. The `data-fs-namespace` attribute on `document.currentScript` (best-effort).
  *   2. The `_fs_namespace` global set on `window` by the FullStory snippet.
  *   3. The default namespace `'FS'`.

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console, max-classes-per-file */
 
+import { getFsNamespace } from './fsNamespace';
+
 /**
  * A LogAppender simply serializes a LogEvent to a sink.
  */
@@ -88,7 +90,7 @@ export class FullStoryAppender implements LogAppender {
 
   /* eslint-disable class-methods-use-this */
   log(event: LogEvent): void {
-    const fs = (window as any)[(window as any)._fs_namespace]; // eslint-disable-line no-underscore-dangle
+    const fs = (window as any)[getFsNamespace(window)];
 
     const customEventName = 'Data Layer Observer';
     const customEventSource = 'dlo-log';

--- a/test/fs-namespace.spec.ts
+++ b/test/fs-namespace.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable no-underscore-dangle, @typescript-eslint/no-explicit-any */
+import { expect } from 'chai';
+import 'mocha';
+
+import { getFsNamespace } from '../src/utils/fsNamespace';
+
+/**
+ * Builds a minimal fake `window`-like object with optional `_fs_namespace` and
+ * `document.currentScript` pieces so we can exercise the resolution order without
+ * mutating the real jsdom globals (and without coupling this spec to whatever
+ * other specs leave on the real `window`).
+ */
+function makeWin(opts: {
+  fsNamespace?: string;
+  scriptAttr?: string | null;
+  hasDocument?: boolean;
+  throwOnCurrentScript?: boolean;
+} = {}): any {
+  const {
+    fsNamespace, scriptAttr, hasDocument = true, throwOnCurrentScript = false,
+  } = opts;
+
+  const script = scriptAttr === undefined ? null : {
+    getAttribute: (name: string) => (name === 'data-fs-namespace' ? scriptAttr : null),
+  };
+
+  const win: any = {};
+  if (fsNamespace !== undefined) {
+    win._fs_namespace = fsNamespace;
+  }
+  if (hasDocument) {
+    Object.defineProperty(win, 'document', {
+      get() {
+        if (throwOnCurrentScript) {
+          throw new Error('boom');
+        }
+        return { currentScript: script };
+      },
+    });
+  }
+  return win;
+}
+
+describe('getFsNamespace', () => {
+  it('returns the data-fs-namespace attribute when set on document.currentScript', () => {
+    const win = makeWin({ scriptAttr: 'CustomFS', fsNamespace: 'FS' });
+    expect(getFsNamespace(win)).to.eq('CustomFS');
+  });
+
+  it('prefers the script attribute over _fs_namespace when both are present', () => {
+    const win = makeWin({ scriptAttr: 'AttrWins', fsNamespace: 'GlobalLoses' });
+    expect(getFsNamespace(win)).to.eq('AttrWins');
+  });
+
+  it('falls back to _fs_namespace when the script attribute is missing', () => {
+    const win = makeWin({ scriptAttr: null, fsNamespace: 'MyFS' });
+    expect(getFsNamespace(win)).to.eq('MyFS');
+  });
+
+  it('falls back to _fs_namespace when document.currentScript is null (deferred call)', () => {
+    const win = makeWin({ fsNamespace: 'MyFS' });
+    expect(getFsNamespace(win)).to.eq('MyFS');
+  });
+
+  it("falls back to 'FS' when neither the script attribute nor _fs_namespace are set", () => {
+    const win = makeWin({});
+    expect(getFsNamespace(win)).to.eq('FS');
+  });
+
+  it('treats an empty-string script attribute as not set and falls through to the global', () => {
+    const win = makeWin({ scriptAttr: '', fsNamespace: 'MyFS' });
+    expect(getFsNamespace(win)).to.eq('MyFS');
+  });
+
+  it('swallows errors from document access and falls back to the global', () => {
+    const win = makeWin({ throwOnCurrentScript: true, fsNamespace: 'MyFS' });
+    expect(getFsNamespace(win)).to.eq('MyFS');
+  });
+
+  it("returns 'FS' when the global object is missing entirely", () => {
+    expect(getFsNamespace(undefined as any)).to.eq('FS');
+  });
+});


### PR DESCRIPTION
## Summary

DLO had four hard-coded `window._fs_namespace` reads, which silently break for
sites whose FullStory snippet uses a custom namespace (set via the
`data-fs-namespace` script attribute) without also setting the `_fs_namespace`
global. This PR centralizes the lookup behind a single helper that mirrors the
resolution order used by `@fullstory/browser-api`.

- Add `src/utils/fsNamespace.ts` exporting `getFsNamespace(win = window)`:
  `data-fs-namespace` on `document.currentScript` → `_fs_namespace` global → `'FS'`.
  Self-contained (no `@fullstory/browser-api` dependency); defensive `try/catch`
  around `document` access; empty-string attribute falls through to the global.
- Replace the four direct reads with helper calls:
  - `src/utils/logger.ts` — `FullStoryAppender.log`
  - `src/operators/fsApi/fsApi.ts` — `FSApiOperator.handleData`
    (also tightens the throw message to `Fullstory namespace is not a function`)
  - `src/target.ts` — `DataLayerTarget` constructor's "is this the FS object?" guard
  - `src/embed/init.impl.ts` — `attachDloFullStoryLifecycle`

### Behavior

- Existing call sites that only had the `_fs_namespace` global still work — the
  helper falls back to the global, which is the same floor the old code had.
- Sites that set `data-fs-namespace="MyFS"` on the FullStory snippet but do not
  set `_fs_namespace` now resolve correctly (this was the bug).
- `document.currentScript` is only meaningful while a script tag is being
  evaluated synchronously. DLO calls the helper from deferred callbacks
  (appender log, operator `handleData`, lifecycle hook), so the attribute path
  is opportunistic; the global remains the practical fallback. This matches how
  `@fullstory/browser-api`'s own `getFsNamespace` is shaped.

## Test plan

- [x] `npm test` — 428 passing, including 8 new cases in `test/fs-namespace.spec.ts`
      covering: attribute wins over global, empty-string attribute is ignored,
      missing/null `currentScript` falls through, errors during document access
      are swallowed, default `'FS'` floor, and `undefined` window.
- [x] `npm run lint` — clean (only pre-existing `no-console` warnings remain).
- [x] `npm run build` — clean.
- [x] Existing specs that seed `window._fs_namespace = 'FS'` (`logger.spec.ts`,
      `lifecycle-embed.spec.ts`, `operator-fsApi.spec.ts`) still pass via the
      helper's global fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor with global fallback preserved; behavior change only when `_fs_namespace` was unset but a custom script namespace was configured.
> 
> **Overview**
> Introduces **`getFsNamespace`** so DLO resolves the FullStory client the same way as fs.js: `data-fs-namespace` on `document.currentScript` (when available), then `window._fs_namespace`, then **`'FS'`**. That fixes integrations that only set a custom namespace via the script attribute and never set the global.
> 
> **Four call sites** now use the helper instead of reading `_fs_namespace` directly: `FullStoryAppender`, `FSApiOperator.handleData`, the `DataLayerTarget` FS-object guard, and `attachDloFullStoryLifecycle`. The FS API operator error message is updated to *Fullstory namespace is not a function*.
> 
> Adds **`test/fs-namespace.spec.ts`** with eight cases for precedence, fallbacks, empty attribute, document errors, and missing `window`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24894f2ad9f48232eac719c56fcc1d3e5501cff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->