### PR TITLE
Releasing v4.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 4.1.6
+- Centralizes FullStory namespace resolution via `getFsNamespace`, matching `@fullstory/browser-api` resolution order (`data-fs-namespace` attribute, `_fs_namespace` global, default `FS`).
+
 ### 4.1.5
 - Adds optional support for replaying the readOnload functionality if Fullstory is restarted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Data Layer Observer follows semantic versioning when releasing updates.
 ## History
 
 ### 4.1.6
-- Centralizes FullStory namespace resolution via `getFsNamespace`, matching `@fullstory/browser-api` resolution order (`data-fs-namespace` attribute, `_fs_namespace` global, default `FS`).
+- Centralizes FullStory namespace resolution via `getFsNamespace`, matching fs.js resolution order (`data-fs-namespace` attribute, `_fs_namespace` global, default `FS`).
 
 ### 4.1.5
 - Adds optional support for replaying the readOnload functionality if Fullstory is restarted

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v4/v4.1.5.js
+- https://edge.fullstory.com/datalayer/v4/v4.1.6.js
 - https://edge.fullstory.com/datalayer/v4/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Releases **v4.1.6** (patch).
- Centralizes FullStory namespace resolution via `getFsNamespace`, matching fs.js resolution order (`data-fs-namespace` attribute, `_fs_namespace` global, default `FS`). Shipped in #250.
- Bumps `package.json` / `package-lock.json` to `4.1.6` and updates `CHANGELOG.md` + `README.md` CDN reference.

## Test plan
- [ ] CircleCI green (build, lint, `npm test`)
- [ ] One Eco team approval
- [ ] After merge: push `v4.1.6` tag from `main`, create GitHub release