### PR TITLE
feat: cache FullStory namespace from the executing script tag at load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 4.1.7
+- Caches the FullStory namespace from the executing script tag at load so it resolves in deferred callbacks where document.currentScript is null, without relying on the _fs_namespace global.
+
 ### 4.1.6
 - Centralizes FullStory namespace resolution via `getFsNamespace`, matching fs.js resolution order (`data-fs-namespace` attribute, `_fs_namespace` global, default `FS`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "4.1.6",
+      "version": "4.1.7",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/fsNamespace.ts
+++ b/src/utils/fsNamespace.ts
@@ -3,10 +3,16 @@
 const FS_NAMESPACE_ATTR = 'data-fs-namespace';
 const DEFAULT_NAMESPACE = 'FS';
 
-function readCurrentScriptNamespace(): string | undefined {
+/**
+ * Reads the data-fs-namespace attribute from `win.document.currentScript`.
+ * Returns undefined when there is no document, no current script, no attribute,
+ * or when access throws (e.g. cross-origin or detached document).
+ *
+ * @param win the global to read from
+ */
+function readCurrentScriptNamespace(win: any): string | undefined {
   try {
-    if (typeof document === 'undefined') return undefined;
-    const script = document.currentScript as HTMLScriptElement | null;
+    const script = (win && win.document && win.document.currentScript) as HTMLScriptElement | null;
     return (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR)) || undefined;
   } catch (_) {
     return undefined;
@@ -22,7 +28,7 @@ function readCurrentScriptNamespace(): string | undefined {
  * currentScript is still live and cache the resolved string (not the element, so it
  * can still be garbage collected after DOM removal).
  */
-const cachedScriptNamespace = readCurrentScriptNamespace();
+const cachedScriptNamespace = readCurrentScriptNamespace(typeof window !== 'undefined' ? window : undefined);
 
 /**
  * Resolves the FullStory client namespace on `win`.
@@ -35,15 +41,8 @@ const cachedScriptNamespace = readCurrentScriptNamespace();
  * @param win the global to read from; defaults to `window`
  */
 export function getFsNamespace(win: any = window): string {
-  let fromLiveScript: string | undefined;
-  try {
-    const script = (win && win.document && win.document.currentScript) as HTMLScriptElement | null;
-    fromLiveScript = (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR))
-      || undefined;
-  } catch (_) {
-    // ignore: cross-origin or detached document access can throw. cachedScriptNamespace
-    // is captured at module load and does not depend on win.document, so it is still
-    // consulted below before the global fallback.
-  }
-  return fromLiveScript || cachedScriptNamespace || (win && win._fs_namespace) || DEFAULT_NAMESPACE;
+  return readCurrentScriptNamespace(win)
+    || cachedScriptNamespace
+    || (win && win._fs_namespace)
+    || DEFAULT_NAMESPACE;
 }

--- a/src/utils/fsNamespace.ts
+++ b/src/utils/fsNamespace.ts
@@ -1,28 +1,47 @@
 /* eslint-disable no-underscore-dangle, import/prefer-default-export */
 
+const FS_NAMESPACE_ATTR = 'data-fs-namespace';
+const DEFAULT_NAMESPACE = 'FS';
+
+function readCurrentScriptNamespace(): string | undefined {
+  try {
+    if (typeof document === 'undefined') return undefined;
+    const script = document.currentScript as HTMLScriptElement | null;
+    return (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR)) || undefined;
+  } catch (_) {
+    return undefined;
+  }
+}
+
 /**
- * Resolves the FullStory client namespace on `window`.
- *
- * Mirrors the resolution order used by fs.js:
- *   1. The `data-fs-namespace` attribute on `document.currentScript` (best-effort).
- *   2. The `_fs_namespace` global set on `window` by the FullStory snippet.
- *   3. The default namespace `'FS'`.
- *
- * Note: `document.currentScript` is only meaningful while the helper module is being
- * evaluated synchronously by a script tag. DLO calls this helper from deferred callbacks
- * (appender log, operator handleData, lifecycle hook), so the attribute lookup is
- * opportunistic and the global is the practical fallback floor — same behavior as the
- * existing `(window as any)._fs_namespace` reads it replaces.
+ * The data-fs-namespace value read from the executing script tag at the moment
+ * this module is first evaluated. document.currentScript is only non-null while a
+ * script runs synchronously and is reset to null once control returns to the event
+ * loop, so DLO's deferred callbacks would otherwise never see it. When the DLO
+ * library script tag is stamped with data-fs-namespace, we read it once here while
+ * currentScript is still live and cache the resolved string (not the element, so it
+ * can still be garbage collected after DOM removal).
+ */
+const cachedScriptNamespace = readCurrentScriptNamespace();
+
+/**
+ * Resolves the FullStory client namespace on `win`.
+ * Resolution order:
+ *   1. The data-fs-namespace attribute on the live document.currentScript.
+ *   2. The same attribute captured at module-evaluation time (cachedScriptNamespace).
+ *   3. The _fs_namespace global set on window by the FullStory snippet.
+ *   4. The default namespace 'FS'.
  *
  * @param win the global to read from; defaults to `window`
  */
 export function getFsNamespace(win: any = window): string {
   try {
     const script = (win && win.document && win.document.currentScript) as HTMLScriptElement | null;
-    const attr = script && script.getAttribute && script.getAttribute('data-fs-namespace');
-    if (attr) return attr;
+    const fromScript = (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR))
+      || cachedScriptNamespace;
+    if (fromScript) return fromScript;
   } catch (_) {
     // ignore: cross-origin or detached document access can throw
   }
-  return (win && win._fs_namespace) || 'FS';
+  return (win && win._fs_namespace) || DEFAULT_NAMESPACE;
 }

--- a/src/utils/fsNamespace.ts
+++ b/src/utils/fsNamespace.ts
@@ -35,13 +35,15 @@ const cachedScriptNamespace = readCurrentScriptNamespace();
  * @param win the global to read from; defaults to `window`
  */
 export function getFsNamespace(win: any = window): string {
+  let fromLiveScript: string | undefined;
   try {
     const script = (win && win.document && win.document.currentScript) as HTMLScriptElement | null;
-    const fromScript = (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR))
-      || cachedScriptNamespace;
-    if (fromScript) return fromScript;
+    fromLiveScript = (script && script.getAttribute && script.getAttribute(FS_NAMESPACE_ATTR))
+      || undefined;
   } catch (_) {
-    // ignore: cross-origin or detached document access can throw
+    // ignore: cross-origin or detached document access can throw. cachedScriptNamespace
+    // is captured at module load and does not depend on win.document, so it is still
+    // consulted below before the global fallback.
   }
-  return (win && win._fs_namespace) || DEFAULT_NAMESPACE;
+  return fromLiveScript || cachedScriptNamespace || (win && win._fs_namespace) || DEFAULT_NAMESPACE;
 }

--- a/test/fs-namespace.spec.ts
+++ b/test/fs-namespace.spec.ts
@@ -123,4 +123,10 @@ describe('cached currentScript namespace (captured at module load)', () => {
     const { getFsNamespace: fresh } = loadFresh();
     expect(fresh(makeWin({ fsNamespace: 'GlobalNS' }))).to.eq('CachedNS');
   });
+
+  it('falls back to the cached namespace when live document access throws', () => {
+    stampDocumentCurrentScript('CachedNS');
+    const { getFsNamespace: fresh } = loadFresh();
+    expect(fresh(makeWin({ throwOnCurrentScript: true, fsNamespace: 'GlobalNS' }))).to.eq('CachedNS');
+  });
 });

--- a/test/fs-namespace.spec.ts
+++ b/test/fs-namespace.spec.ts
@@ -81,3 +81,46 @@ describe('getFsNamespace', () => {
     expect(getFsNamespace(undefined as any)).to.eq('FS');
   });
 });
+
+describe('cached currentScript namespace (captured at module load)', () => {
+  const modulePath = '../src/utils/fsNamespace';
+  let originalCurrentScript: PropertyDescriptor | undefined;
+
+  function stampDocumentCurrentScript(namespace: string | null) {
+    originalCurrentScript = Object.getOwnPropertyDescriptor(document, 'currentScript');
+    Object.defineProperty(document, 'currentScript', {
+      configurable: true,
+      value: namespace === null ? null : {
+        getAttribute: (name: string) => (name === 'data-fs-namespace' ? namespace : null),
+      },
+    });
+  }
+
+  function loadFresh(): { getFsNamespace: (win?: any) => string } {
+    delete require.cache[require.resolve(modulePath)];
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/no-dynamic-require
+    return require(modulePath);
+  }
+
+  afterEach(() => {
+    if (originalCurrentScript) {
+      Object.defineProperty(document, 'currentScript', originalCurrentScript);
+    } else {
+      delete (document as any).currentScript;
+    }
+    originalCurrentScript = undefined;
+    delete require.cache[require.resolve(modulePath)];
+  });
+
+  it('resolves the cached namespace when the live currentScript is null', () => {
+    stampDocumentCurrentScript('CachedNS');
+    const { getFsNamespace: fresh } = loadFresh();
+    expect(fresh(makeWin({}))).to.eq('CachedNS');
+  });
+
+  it('prefers the cached namespace over the _fs_namespace global', () => {
+    stampDocumentCurrentScript('CachedNS');
+    const { getFsNamespace: fresh } = loadFresh();
+    expect(fresh(makeWin({ fsNamespace: 'GlobalNS' }))).to.eq('CachedNS');
+  });
+});


### PR DESCRIPTION
## Summary
- `document.currentScript` is only non-null while a script runs synchronously and is reset to `null` once control returns to the event loop, so DLO's deferred callbacks (appender log, operator `handleData`, lifecycle hook) never see it. The attribute path never hit there, so DLO fell back to the `_fs_namespace` global.
- FullStory's loader now stamps the DLO library `<script>` tag with `data-fs-namespace`. At module-evaluation time (when this bundle first runs synchronously) `document.currentScript` is that stamped script, so we read the attribute once then, while it is live, and cache the resolved **string** (not the element, so it can still be garbage collected after DOM removal).
- Deferred callbacks now resolve a custom namespace without relying on the `_fs_namespace` global. Backward-safe: when the script tag isn't stamped the cache is empty and resolution falls back to the global, same as today.

## Resolution order (`getFsNamespace`)
1. `data-fs-namespace` on the live `document.currentScript`.
2. The same attribute captured at module-evaluation time (`cachedScriptNamespace`).
3. The `_fs_namespace` global.
4. Default `'FS'`.

## Changes
- `src/utils/fsNamespace.ts`: module-load cache of the namespace from `document.currentScript`.
- `test/fs-namespace.spec.ts`: added cases for the cached namespace (resolves when live `currentScript` is null; prefers cache over the global).
- Version bump `4.1.6` -> `4.1.7` + CHANGELOG entry.

## Test plan
- [x] `npx eslint` on changed files (clean)
- [x] `mocha` `test/fs-namespace.spec.ts` (10/10 passing)
- [ ] CI

## Follow-up
After merge, manually cut the `v4.1.7` release tag so it can be synced into the FullStory monorepo via `tools/opensource.go sync fullstory-data-layer-observer v4.1.7`.

Made with [Cursor](https://cursor.com)