### PR TITLE
Irv fs/cookie starts with

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,15 @@ window['_dlo_rules'] = [
 
 In place of `source` you can use `cookieSource` with an array of strings representing cookie names that will be looked up on the current page, and then send that through the operators if they exist.  Rules with a `cookieSource` will ignore the `monitor` flag on the rule, and will force `readOnLoad` to be `true`, This will attempt to read the cookies after `DOMContentLoaded` has fired.  If none of the cookie names specified are found the rule will not fire.
 
+You can use the `^` character to do a `startsWith` matching for cookie names.  For example a cookieSource of `^test` would match cookies of `test`, `tester`, and `test-cookie`
+
 Here is an example of a cookieSelector:
 
 ```javascript
 window['_dlo_rules'] = [
   {
     id: 'fs-uservars-user-all',
-    cookieSource: ['someCookie', 'anotherCookie'],
+    cookieSource: ['someCookie', 'anotherCookie', '^test'],
     operators: [
       { name: 'query', select: '$[(type,id)]' },
     ],

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -565,9 +565,7 @@ export class DataLayerObserver {
               const cookieList : string[] = Array.from(cookieMap.keys());
               const actualData:any = {};
               cookieSource.forEach((cookieName) => {
-                if (cookieMap.has(cookieName)) {
-                  actualData[cookieName] = cookieMap.get(cookieName);
-                } else if (cookieName && cookieName.startsWith('^')) {
+                if (cookieName && cookieName.startsWith('^') && cookieName.length > 1) {
                   const cookieNameWithoutPrefix = cookieName.substring(1);
                   const cookieMatches = cookieList.filter(
                     (cookie) => cookie && cookie.startsWith(cookieNameWithoutPrefix),
@@ -577,6 +575,8 @@ export class DataLayerObserver {
                       actualData[cookie] = cookieMap.get(cookie);
                     });
                   }
+                } else if (cookieMap.has(cookieName)) {
+                  actualData[cookieName] = cookieMap.get(cookieName);
                 }
               });
               const simpleValue = new SimpleDataLayerValue(cookieSource[0], actualData);

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -562,10 +562,21 @@ export class DataLayerObserver {
                 );
               }
               const cookieMap = getAvailableCookies();
+              const cookieList : string[] = Array.from(cookieMap.keys());
               const actualData:any = {};
               cookieSource.forEach((cookieName) => {
                 if (cookieMap.has(cookieName)) {
                   actualData[cookieName] = cookieMap.get(cookieName);
+                } else if (cookieName && cookieName.startsWith('^')) {
+                  const cookieNameWithoutPrefix = cookieName.substring(1);
+                  const cookieMatches = cookieList.filter(
+                    (cookie) => cookie && cookie.startsWith(cookieNameWithoutPrefix),
+                  );
+                  if (cookieMatches && cookieMatches.length > 0) {
+                    cookieMatches.forEach((cookie) => {
+                      actualData[cookie] = cookieMap.get(cookie);
+                    });
+                  }
                 }
               });
               const simpleValue = new SimpleDataLayerValue(cookieSource[0], actualData);

--- a/test/operator-cookieSource.spec.ts
+++ b/test/operator-cookieSource.spec.ts
@@ -229,4 +229,92 @@ describe('cookieSource unit tests', () => {
       },
     );
   });
+
+  it('it should work with starts with operator', () => {
+    (globalThis as any).document = {
+      cookie: ' foo=; one=two; four=five',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^foo', '^one', '^four'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    const [log] = expectParams(mockConsole, 'log');
+    expect(log).to.be.deep.eq(
+      {
+        foo: '',
+        one: 'two',
+        four: 'five',
+      },
+    );
+  });
+
+  it('it should work with starts with multiple match', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; footie=two; foosball=five',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^foo'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    const [log] = expectParams(mockConsole, 'log');
+    expect(log).to.be.deep.eq(
+      {
+        foo: 'one',
+        footie: 'two',
+        foosball: 'five',
+      },
+    );
+  });
+
+  it('it should work with starts with and exact match', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; footie=two; foosball=five; test=test',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^foo', 'test'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    const [log] = expectParams(mockConsole, 'log');
+    expect(log).to.be.deep.eq(
+      {
+        foo: 'one',
+        footie: 'two',
+        foosball: 'five',
+        test: 'test',
+      },
+    );
+  });
+
+  it('it should work with starts with and no match', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; footie=two; foosball=five; test=test',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^foob'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    expectNoCalls(mockConsole, 'log');
+  });
+
+  it('it should not break with starts with and special characters in test', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; footie=two; foosball=five; test=test',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^^foo'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    expectNoCalls(mockConsole, 'log');
+  });
+
+  it('it should not break with starts with and special characters in cookie', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; ^footie=two; foosball=five; test=test',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^foo'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    const [log] = expectParams(mockConsole, 'log');
+    expect(log).to.be.deep.eq(
+      {
+        foo: 'one',
+        foosball: 'five',
+      },
+    );
+  });
 });

--- a/test/operator-cookieSource.spec.ts
+++ b/test/operator-cookieSource.spec.ts
@@ -12,7 +12,7 @@ import { expectNoCalls, expectParams } from './utils/mocha';
 const originalConsole = globalThis.console;
 const mockConsole = new Console();
 
-describe.only('cookieSource unit tests', () => {
+describe('cookieSource unit tests', () => {
   beforeEach(() => {
     Logger.getInstance().appender = new ConsoleAppender();
     (globalThis as any).console = mockConsole;

--- a/test/operator-cookieSource.spec.ts
+++ b/test/operator-cookieSource.spec.ts
@@ -12,7 +12,7 @@ import { expectNoCalls, expectParams } from './utils/mocha';
 const originalConsole = globalThis.console;
 const mockConsole = new Console();
 
-describe('cookieSource unit tests', () => {
+describe.only('cookieSource unit tests', () => {
   beforeEach(() => {
     Logger.getInstance().appender = new ConsoleAppender();
     (globalThis as any).console = mockConsole;
@@ -316,5 +316,15 @@ describe('cookieSource unit tests', () => {
         foosball: 'five',
       },
     );
+  });
+
+  it('it should not work with starts with and wildcard/empty match', () => {
+    (globalThis as any).document = {
+      cookie: 'foo=one; footie=two; foosball=five; test=test',
+    };
+    const observer = new DataLayerObserver();
+    observer.registerRule({ cookieSource: ['^'], operators: [], destination: 'console.log' });
+    expectNoCalls(mockConsole, 'error');
+    expectNoCalls(mockConsole, 'log');
   });
 });


### PR DESCRIPTION
This adds a starts with option for cookie names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to cookie rule registration with backward-compatible exact matching and solid test coverage; no auth or data-pipeline redesign.
> 
> **Overview**
> **`cookieSource` rules can now match cookies by name prefix** using a leading `^` (e.g. `^test` matches `test`, `tester`, `test-cookie`). Exact names still work unchanged, and both can be mixed in one rule.
> 
> In **`observer.ts`**, cookie registration scans available cookie names: prefixed entries collect every name that `startsWith` the text after `^` (requires more than just `^`); others still use exact map lookup. Matched cookies are merged into the same key/value payload sent to operators.
> 
> **README** documents the `^` syntax with an updated example. **Tests** cover multi-match, prefix + exact mix, no match, lone `^`, and `^^` / odd cookie names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b16fea70bc2d6919677dc93f67a0231ea18674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->