### PR TITLE
Releasing v4.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Data Layer Observer follows semantic versioning when releasing updates.
 
 ## History
 
+### 4.1.8
+- Adds `startsWith` matching for `cookieSource` cookie names using a `^` prefix (e.g. `^test` matches `test`, `tester`, and `test-cookie`).
+
 ### 4.1.7
 - Caches the FullStory namespace from the executing script tag at load so it resolves in deferred callbacks where document.currentScript is null, without relying on the _fs_namespace global.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sensitive, private, and confidential information should never be added to a data
 
 DLO is a JavaScript asset that is included on a web page.  FullStory hosts versions of DLO on our CDN.  Versioned releases have the naming convention `<version>.js`, and the most recent version is named `latest.js`:
 
-- https://edge.fullstory.com/datalayer/v4/v4.1.6.js
+- https://edge.fullstory.com/datalayer/v4/v4.1.8.js
 - https://edge.fullstory.com/datalayer/v4/latest.js
 
 If you would like the most up to date version of DLO on your site always, use `latest.js`.  If you'd rather use stable releases and perform manual upgrades, use `<version>.js`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Monitor, transform, and send data layer content to FullStory",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps the DLO version to **4.1.8** to release the `cookieSource` `^` startsWith matching feature added in #254 (which landed without a version bump).

- `CHANGELOG.md`: new `### 4.1.8` entry
- `package.json`: `4.1.7` → `4.1.8`
- `README.md`: versioned CDN link → `v4.1.8.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no behavioral changes in this PR.
> 
> **Overview**
> **Release-only PR** that tags **4.1.8** for the `cookieSource` `^` prefix / `startsWith` cookie-name matching that landed in a prior change (#254) without a version bump.
> 
> Updates **`package.json`** (`4.1.7` → `4.1.8`), adds a **`### 4.1.8`** entry in **`CHANGELOG.md`**, and points the versioned CDN example in **`README.md`** at `v4.1.8.js`. No runtime or library code changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb5abb57e60522349b1d52d8639b613cc5950d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->