### PR TITLE
Add release-dlo skill

### DIFF
--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -133,9 +133,18 @@ echo "DLO $DLO_VER vs target $TGT_VER => DLO is $CMP"
        summarizing the changes (match the existing terse, bullet style). Save this summary text — you'll
        reuse it as the GitHub release notes in Step 4.
     4. Update the `version` field in `package.json` to `latest-version`.
-    5. Update the version reference in `README.md` (the `Deployment` section links a versioned URL like
+    5. **Also bump `package-lock.json`** — it carries its own `version` (top-level and `packages[""]`)
+       that must match, or the release ships a stale lockfile version. Regenerate it from the bumped
+       `package.json` without touching `node_modules`:
+       ```bash
+       ( cd "$DLO_REPO" && npm install --package-lock-only )
+       ```
+       Confirm the only lockfile change is the two `version` fields → `latest-version` (if it also churns
+       dependencies, review that separately — the bump itself should be version-only).
+    6. Update the version reference in `README.md` (the `Deployment` section links a versioned URL like
        `https://edge.fullstory.com/datalayer/v4/v<version>.js` — update it to `latest-version`).
-    6. **⛔ HUMAN GATE**: Show the user the diff of these three files and the proposed changelog entry.
+    7. **⛔ HUMAN GATE**: Show the user the diff of these **four** files (`package.json`,
+       `package-lock.json`, `README.md`, `CHANGELOG.md`) and the proposed changelog entry.
        These changes must land on DLO `main` (with a `v<latest-version>` tag) before the release. `main`
        is PR-protected (recent history is all squashed PRs), so open a PR for the bump, and **wait** for
        the user to merge it. After merge, `git pull` main so HEAD includes the bump, then continue.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -45,8 +45,12 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
   Go script, run from `projects/fullstory`). It downloads the **GitHub release tag** into the monorepo,
   so the GitHub release/tag MUST exist before you sync.
 
-Throughout, call the resolved version **`latest-version`** (bare semver, no `v`). Derive the **major**
-as `v<N>` from it (e.g. `4.1.8` → `v4`); the test URLs and CDN paths use this major.
+Throughout, call the resolved version **`latest-version`** (bare semver, no `v`). Once it's known
+(Step 3), derive the **major** into a shell var and use that in the test URLs — do NOT hardcode a literal
+like `v4` (it looks runnable but silently breaks on a new major):
+```bash
+MAJOR="v$(printf '%s' "<latest-version>" | cut -d. -f1)"   # e.g. 4.1.8 -> v4
+```
 
 Set up shell vars once, at the start:
 ```bash
@@ -256,10 +260,10 @@ TEST_DIR="$TARGET"   # = $FS_HOME/opensource/fullstory-data-layer-observer, on t
    ```bash
    ( cd "$TEST_DIR" && npm install && npm run test:browser:bootstrap )
    ```
-2. Run the browser tests against both staging edges. **Replace `v4` with the major of `latest-version`.**
+2. Run the browser tests against both staging edges (uses `$MAJOR` from Orientation — never a hardcoded `v4`):
    ```bash
-   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
-   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
+   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
    ```
 3. Display both results to the user.
 
@@ -285,8 +289,8 @@ Repeat Step 8's tests from the **same `$TEST_DIR`** (still on the sync branch), 
 the hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`, `edge.eu1.staging.fullstory.com` →
 `edge.eu1.fullstory.com`). Keep the same major:
 ```bash
-( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/v4/latest.js npm run test:browser )
-( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
+( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
 ```
 Display the results to the user.
 

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -178,7 +178,7 @@ checkout itself** on a fresh `green`-based branch — no worktree.
    > `gh pr edit --body`). When creating the PR fresh, just include it from the start as above.
 4. Show the user the PR link and prompt them to get it reviewed and merged.
 
-## Step 6 — ⛔ HUMAN GATE: wait for the sync PR to merge, then find the squash commit
+## Step 6 — ⛔ HUMAN GATE: wait for the sync PR to merge, then poll `green` for the deploy commit
 
 STOP. Ask the user to confirm once the PR from Step 5 is merged. Do not proceed until they confirm.
 
@@ -192,15 +192,28 @@ guarantees the deploy hash is build-passing.)
    SQUASH=$(cd "$FS_HOME" && gh pr view <pr-number> --json mergeCommit -q .mergeCommit.oid)
    echo "squash commit: $SQUASH"
    ```
-2. Find the commit immediately after it on `green` (first commit whose parent is the squash commit):
+2. **Poll `green` until the deploy commit lands — don't make the user watch.** Even after the merge,
+   `green` won't include the squash commit until CI builds `master` and advances `green` past it, AND a
+   further commit lands after the squash. This routinely takes **well over an hour**. Do NOT sit in the
+   foreground or ask the user to keep re-checking — run a background poll that re-fetches and exits once
+   the commit-after-squash appears on `green`, so you're re-invoked when it's ready:
    ```bash
-   git -C "$MN_ROOT" fetch origin -q
-   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/green | head -1)
-   echo "deploy hash (commit after squash): $DEPLOY_HASH"
+   # Run with the Bash tool's run_in_background=true. It re-fetches, checks, sleeps, and exits
+   # (printing the deploy hash) only once green has advanced past the squash commit.
+   until git -C "$MN_ROOT" fetch origin green -q && \
+         H=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/green | head -1) && \
+         [ -n "$H" ]; do
+     sleep 900   # 15 min between checks
+   done
+   echo "DEPLOY_HASH=$H"
    ```
-   If that comes back empty, `green` has **not yet advanced past the squash commit** — CI builds are
-   still pending or failing. Wait for `green` to move (re-fetch and retry), or ask the user how to
-   proceed. Never fall back to deploying the squash commit itself.
+   - Launch it in the background (`run_in_background: true`) — a foreground `sleep` is blocked, and the
+     background runner re-invokes you when the loop exits. Tell the user you're polling and will notify
+     them when the hash is ready (expected >1hr); they don't need to babysit it.
+   - Alternatively, self-pace with scheduled re-checks (~15–20 min apart) if a background process isn't
+     appropriate for the run context.
+   - When it resolves, set `DEPLOY_HASH="$H"`, **notify the user**, and continue.
+   - Never fall back to deploying the squash commit itself.
 
 Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it with the user before deploying.
 

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -32,7 +32,8 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
       `origin/green` for the sync.
     - `master` is the mainline you **PR into**. When a merged commit's build passes, CI **auto-advances
       `green`** to it. So: base the sync branch on `green`, but target the PR at **`master`**.
-    - The squash-merge lands on `master`; the post-merge deploy commit is found on `origin/master`.
+    - The squash-merge lands on `master`; once its build passes CI advances `green` past it. The deploy
+      commit (commit-after-squash) is taken from `origin/green` — so it's inherently build-passing.
 - **conan cog name** for DLO: `fullstory-data-layer-observer`.
 - **conancli** (see the `conan-skill`): run from `projects/fullstory`:
   `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs=fullstory-data-layer-observer`
@@ -181,23 +182,25 @@ checkout itself** on a fresh `green`-based branch — no worktree.
 
 STOP. Ask the user to confirm once the PR from Step 5 is merged. Do not proceed until they confirm.
 
-Once merged, the PR is squash-merged into **`master`**. You must deploy the commit **immediately after**
-the squash commit — NOT the squash commit itself. (Builds tend to fail *on* the squash commit; the
-mechanics aren't important here, just always take the next one.)
+Once merged, the PR is squash-merged into **`master`**, and when its build passes CI advances **`green`**
+past it. You deploy the commit **immediately after** the squash commit, taken from **`green`** — NOT the
+squash commit itself. (Builds tend to fail *on* the squash commit; taking the next commit on `green` also
+guarantees the deploy hash is build-passing.)
 
 1. Get the squash-merge commit from the PR (run from `$FS_HOME` so `gh` targets the monorepo):
    ```bash
    SQUASH=$(cd "$FS_HOME" && gh pr view <pr-number> --json mergeCommit -q .mergeCommit.oid)
    echo "squash commit: $SQUASH"
    ```
-2. Find the commit immediately after it on `master` (first commit whose parent is the squash commit):
+2. Find the commit immediately after it on `green` (first commit whose parent is the squash commit):
    ```bash
    git -C "$MN_ROOT" fetch origin -q
-   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/master | head -1)
+   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/green | head -1)
    echo "deploy hash (commit after squash): $DEPLOY_HASH"
    ```
-   If that comes back empty, the squash commit is currently the tip of `master` — wait for the next commit
-   to land (or ask the user how to proceed) rather than deploying the squash commit.
+   If that comes back empty, `green` has **not yet advanced past the squash commit** — CI builds are
+   still pending or failing. Wait for `green` to move (re-fetch and retry), or ask the user how to
+   proceed. Never fall back to deploying the squash commit itself.
 
 Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it with the user before deploying.
 

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -54,9 +54,17 @@ If the working tree is dirty, stop and ask the user how to proceed.
 
 Read `version` from the DLO repo `package.json`.
 
-## Step 3 — Compare against the target folder
+## Step 3 — Compare against the released version
 
-Read `version` from `$TARGET/package.json` and compare (semver) to the DLO version.
+Read the currently-released target version from the monorepo trunk (`origin/green`) directly — NOT from
+the `$TARGET` working copy. The `$FS_HOME` checkout is usually parked on some other branch, so its
+`opensource/.../package.json` can be stale; reading `origin/green` needs no checkout and is authoritative:
+```bash
+git -C "$MN_ROOT" fetch origin -q
+git -C "$MN_ROOT" show origin/green:opensource/fullstory-data-layer-observer/package.json \
+  | node -p "JSON.parse(require('fs').readFileSync(0)).version"
+```
+Compare that (semver) to the DLO version from Step 2.
 
 - **DLO version is OLDER than target** → this is an error state. Report it and **exit**.
 - **DLO version is NEWER than target** (e.g. `4.1.8` vs `4.1.7`) → `latest-version` = the DLO version.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -81,15 +81,24 @@ the `$TARGET` working copy. The `$FS_HOME` checkout is usually parked on some ot
 `opensource/.../package.json` can be stale; reading `origin/green` needs no checkout and is authoritative:
 ```bash
 git -C "$MN_ROOT" fetch origin -q
-git -C "$MN_ROOT" show origin/green:opensource/fullstory-data-layer-observer/package.json \
-  | node -p "JSON.parse(require('fs').readFileSync(0)).version"
+TGT_VER=$(git -C "$MN_ROOT" show origin/green:opensource/fullstory-data-layer-observer/package.json \
+  | node -p "JSON.parse(require('fs').readFileSync(0)).version")
+DLO_VER=$(node -p "require('$DLO_REPO/package.json').version")   # from Step 2
 ```
-Compare that (semver) to the DLO version from Step 2.
+Compare them with a **proper numeric semver comparison — NOT a string/lexicographic compare** (else
+`4.1.10` would sort *before* `4.1.9`, which is wrong; also don't rely on `sort -V`, unavailable on
+macOS/BSD `sort`). Compare each dotted component numerically, e.g.:
+```bash
+CMP=$(node -e 'const a=process.argv[1].split(".").map(Number),b=process.argv[2].split(".").map(Number);
+for(let i=0;i<Math.max(a.length,b.length);i++){const x=a[i]||0,y=b[i]||0;if(x!==y){console.log(x>y?"newer":"older");process.exit()}}
+console.log("equal")' "$DLO_VER" "$TGT_VER")
+echo "DLO $DLO_VER vs target $TGT_VER => DLO is $CMP"
+```
 
-- **DLO version is OLDER than target** → this is an error state. Report it and **exit**.
-- **DLO version is NEWER than target** (e.g. `4.1.8` vs `4.1.7`) → `latest-version` = the DLO version.
+- **`older`** → DLO version is behind the released target — an error state. Report it and **exit**.
+- **`newer`** (e.g. `4.1.8` vs `4.1.7`) → `latest-version` = the DLO version.
   Skip to Step 4. (Normal case: whoever made changes already bumped the version + changelog.)
-- **Versions are EQUAL** → the target folder was synced from the released tag `v<version>`, so the real
+- **`equal`** → the target folder was synced from the released tag `v<version>`, so the real
   question is whether anything shippable has landed on DLO `main` since that release. Ask git directly —
   this is **authoritative and catches every file** (`src/`, `package.json`, `README.md`,
   `rollup.config.js`, `tsconfig.json`, tests, anything) rather than diffing a hand-picked list of paths

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -24,11 +24,15 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
   (`fsio.ProjectPath` reads `$FS_HOME`). So `opensource.go sync` always writes into the `$FS_HOME`
   checkout regardless of where you `cd` — a worktree elsewhere would be ignored. That's why this skill
   switches the `$FS_HOME` checkout itself onto a `green`-based branch (Step 5) and works there.
-- **Trunk branches differ per repo — do not conflate them:**
+- **Trunk / branch model differs per repo — do not conflate them:**
   - DLO source repo (`fullstory-data-layer-observer`) → trunk is **`main`**. All Step 1–4 branch/tag/pull
     operations use `main`.
-  - Monorepo (`$MN_ROOT` / `$FS_HOME`) → trunk is **`green`** (NOT `main`). The sync PR branches from,
-    targets, and merges into `origin/green`; the post-merge deploy commit is found on `origin/green`.
+  - Monorepo (`$MN_ROOT` / `$FS_HOME`) → two branches matter, **`green`** and **`master`** (NOT `main`):
+    - `green` is the known **build-passing** branch. You cannot PR into it directly. Branch **off**
+      `origin/green` for the sync.
+    - `master` is the mainline you **PR into**. When a merged commit's build passes, CI **auto-advances
+      `green`** to it. So: base the sync branch on `green`, but target the PR at **`master`**.
+    - The squash-merge lands on `master`; the post-merge deploy commit is found on `origin/master`.
 - **conan cog name** for DLO: `fullstory-data-layer-observer`.
 - **conancli** (see the `conan-skill`): run from `projects/fullstory`:
   `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs=fullstory-data-layer-observer`
@@ -149,7 +153,7 @@ checkout itself** on a fresh `green`-based branch — no worktree.
    This updates `opensource/repos.yaml`, re-downloads source into `opensource/fullstory-data-layer-observer`,
    and updates `etc/cfg/deploy/actions/fullstory-data-layer-observer/action.yaml` (`RELEASE_TAG`).
 3. Stage **only the sync's paths** (don't `git add -A` — avoid sweeping in any unrelated untracked files),
-   commit, push, and open a PR **against `green`** (the monorepo trunk, not `main`):
+   commit, push, and open a PR **against `master`** (you branch off `green` but PR into `master`):
    ```bash
    git -C "$MN_ROOT" add \
      projects/fullstory/opensource/repos.yaml \
@@ -158,30 +162,41 @@ checkout itself** on a fresh `green`-based branch — no worktree.
    git -C "$MN_ROOT" status --short   # sanity-check: only the DLO sync files are staged
    git -C "$MN_ROOT" commit -m "sync fullstory-data-layer-observer to v<latest-version>"
    git -C "$MN_ROOT" push -u origin "$(whoami)/sync-dlo-v<latest-version>"
-   ( cd "$FS_HOME" && gh pr create --base green --fill )
    ```
+   Then open the PR **against `master`** (NOT `green` — you can't PR into `green`) with a body that states
+   it's a sync and includes the changelog. Pull the changelog section for this version straight out of the
+   synced `CHANGELOG.md`:
+   ```bash
+   NOTES=$(awk '/^### <latest-version>$/{f=1;next} /^### /{f=0} f' "$TARGET/CHANGELOG.md")
+   ( cd "$FS_HOME" && gh pr create --base master \
+       --title "sync fullstory-data-layer-observer to v<latest-version>" \
+       --body "$(printf 'Syncs the open-source [\`fullstory-data-layer-observer\`](https://github.com/fullstorydev/fullstory-data-layer-observer) release **v<latest-version>** into the monorepo — updates \`opensource/repos.yaml\`, the deploy \`action.yaml\` \`RELEASE_TAG\`, and the vendored source under \`opensource/fullstory-data-layer-observer\`.\n\n## Changelog (v<latest-version>)\n%s\n' "$NOTES")" )
+   ```
+   > If a bot (e.g. Cursor) has already populated the PR body by the time you'd set it, **prepend** this
+   > content above the existing text instead of overwriting it (fetch `gh pr view --json body`, then
+   > `gh pr edit --body`). When creating the PR fresh, just include it from the start as above.
 4. Show the user the PR link and prompt them to get it reviewed and merged.
 
 ## Step 6 — ⛔ HUMAN GATE: wait for the sync PR to merge, then find the squash commit
 
 STOP. Ask the user to confirm once the PR from Step 5 is merged. Do not proceed until they confirm.
 
-Once merged, the PR is squash-merged into the monorepo trunk, **`green`**. You must deploy the commit
-**immediately after** the squash commit — NOT the squash commit itself. (Builds tend to fail *on* the
-squash commit; the mechanics aren't important here, just always take the next one.)
+Once merged, the PR is squash-merged into **`master`**. You must deploy the commit **immediately after**
+the squash commit — NOT the squash commit itself. (Builds tend to fail *on* the squash commit; the
+mechanics aren't important here, just always take the next one.)
 
 1. Get the squash-merge commit from the PR (run from `$FS_HOME` so `gh` targets the monorepo):
    ```bash
    SQUASH=$(cd "$FS_HOME" && gh pr view <pr-number> --json mergeCommit -q .mergeCommit.oid)
    echo "squash commit: $SQUASH"
    ```
-2. Find the commit immediately after it on `green` (first commit whose parent is the squash commit):
+2. Find the commit immediately after it on `master` (first commit whose parent is the squash commit):
    ```bash
    git -C "$MN_ROOT" fetch origin -q
-   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/green | head -1)
+   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/master | head -1)
    echo "deploy hash (commit after squash): $DEPLOY_HASH"
    ```
-   If that comes back empty, the squash commit is currently the tip of `green` — wait for the next commit
+   If that comes back empty, the squash commit is currently the tip of `master` — wait for the next commit
    to land (or ask the user how to proceed) rather than deploying the squash commit.
 
 Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it with the user before deploying.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -15,10 +15,15 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
 - **DLO repo** (the "latest" source): this repository — `fullstory-data-layer-observer`. Detect its
   root with `git rev-parse --show-toplevel` from the current folder. Version lives in `package.json`.
 - **GitHub repo**: `fullstorydev/fullstory-data-layer-observer`. Release tags are `v<version>` (e.g. `v4.1.7`).
-- **Target folder** (inside the monorepo): `$FS_HOME/opensource/fullstory-data-layer-observer`.
-- **Monorepo**: `$FS_HOME` is `.../mn/projects/fullstory`, but the **git root is one level up** —
-  `git -C "$FS_HOME" rev-parse --show-toplevel` (e.g. `/Users/<you>/src/mn`). Worktrees are worktrees
-  of that root, so a worktree at `~/src/worktrees/<x>` contains `projects/fullstory/` inside it.
+- **Target folder** (inside the monorepo): `$FS_HOME/opensource/fullstory-data-layer-observer`. This is
+  where the sync writes and where the browser tests run — this skill operates in the `$FS_HOME` checkout
+  directly (no separate worktree; see the resolution note below).
+- **Monorepo**: `$FS_HOME` is `.../mn/projects/fullstory`; its **git root is one level up** —
+  `git -C "$FS_HOME" rev-parse --show-toplevel` (e.g. `/Users/<you>/src/mn`), referred to as `$MN_ROOT`.
+- **`opensource.go` and `conancli` resolve paths from the `$FS_HOME` env var, NOT the current directory**
+  (`fsio.ProjectPath` reads `$FS_HOME`). So `opensource.go sync` always writes into the `$FS_HOME`
+  checkout regardless of where you `cd` — a worktree elsewhere would be ignored. That's why this skill
+  switches the `$FS_HOME` checkout itself onto a `green`-based branch (Step 5) and works there.
 - **Trunk branches differ per repo — do not conflate them:**
   - DLO source repo (`fullstory-data-layer-observer`) → trunk is **`main`**. All Step 1–4 branch/tag/pull
     operations use `main`.
@@ -45,10 +50,20 @@ MN_ROOT="$(git -C "$FS_HOME" rev-parse --show-toplevel)"
 
 ---
 
-## Step 1 — Sync main
+## Step 1 — Preflight both repos
 
-From the DLO repo, switch to `main` if not already there, then `git pull` to get up to date.
-If the working tree is dirty, stop and ask the user how to proceed.
+**DLO repo:** switch to `main` if not already there, then `git pull` to get up to date. If the working
+tree is dirty, stop and ask the user how to proceed.
+
+**Monorepo (`$FS_HOME`):** this skill switches the `$FS_HOME` checkout onto a `green`-based sync branch
+in Step 5, so it must be clean first (otherwise the switch would carry or clobber the user's work).
+Capture the current branch to restore at the end, and require a clean tree:
+```bash
+ORIG_MN_BRANCH="$(git -C "$MN_ROOT" rev-parse --abbrev-ref HEAD)"   # remember to restore this at the end
+git -C "$MN_ROOT" status --porcelain
+```
+If `git status --porcelain` prints **anything** (uncommitted or untracked changes), do NOT proceed —
+show the user the list and ask how to handle it (stash / commit / abort). Continue only once it's clean.
 
 ## Step 2 — Read the current version
 
@@ -118,27 +133,32 @@ gh release view "v<latest-version>" -R "$GH_REPO"
 
 ## Step 5 — Create the monorepo sync branch + PR
 
-The sync pulls the just-released tag into the monorepo and updates the conan action config.
+The sync pulls the just-released tag into the monorepo and updates the conan action config. Because
+`opensource.go` writes to `$FS_HOME` regardless of cwd (see Orientation), do this **in the `$FS_HOME`
+checkout itself** on a fresh `green`-based branch — no worktree.
 
-1. Create a worktree of the monorepo from `origin/green`, named by version, branched as
-   `<whoami>/sync-dlo-v<latest-version>`:
+1. Switch `$FS_HOME` to a new branch off `origin/green` (the tree is clean, verified in Step 1):
    ```bash
-   git -C "$MN_ROOT" fetch origin
-   git -C "$MN_ROOT" worktree add "$HOME/src/worktrees/v<latest-version>" \
-     -b "$(whoami)/sync-dlo-v<latest-version>" origin/green
+   git -C "$MN_ROOT" fetch origin -q
+   git -C "$MN_ROOT" checkout -b "$(whoami)/sync-dlo-v<latest-version>" origin/green
    ```
-2. Run the sync from `projects/fullstory` inside the new worktree:
+2. Run the sync (writes into `$FS_HOME`):
    ```bash
-   WT="$HOME/src/worktrees/v<latest-version>/projects/fullstory"
-   ( cd "$WT" && tools/opensource.go sync fullstory-data-layer-observer v<latest-version> )
+   ( cd "$FS_HOME" && tools/opensource.go sync fullstory-data-layer-observer v<latest-version> )
    ```
    This updates `opensource/repos.yaml`, re-downloads source into `opensource/fullstory-data-layer-observer`,
    and updates `etc/cfg/deploy/actions/fullstory-data-layer-observer/action.yaml` (`RELEASE_TAG`).
-3. Commit all changes, push the branch, and open a PR **against `green`** (the monorepo trunk, not `main`):
+3. Stage **only the sync's paths** (don't `git add -A` — avoid sweeping in any unrelated untracked files),
+   commit, push, and open a PR **against `green`** (the monorepo trunk, not `main`):
    ```bash
-   ( cd "$WT" && git add -A && git commit -m "sync fullstory-data-layer-observer to v<latest-version>" )
-   git -C "$WT" push -u origin "$(whoami)/sync-dlo-v<latest-version>"
-   ( cd "$WT" && gh pr create --base green --fill )
+   git -C "$MN_ROOT" add \
+     projects/fullstory/opensource/repos.yaml \
+     projects/fullstory/opensource/fullstory-data-layer-observer \
+     projects/fullstory/etc/cfg/deploy/actions/fullstory-data-layer-observer
+   git -C "$MN_ROOT" status --short   # sanity-check: only the DLO sync files are staged
+   git -C "$MN_ROOT" commit -m "sync fullstory-data-layer-observer to v<latest-version>"
+   git -C "$MN_ROOT" push -u origin "$(whoami)/sync-dlo-v<latest-version>"
+   ( cd "$FS_HOME" && gh pr create --base green --fill )
    ```
 4. Show the user the PR link and prompt them to get it reviewed and merged.
 
@@ -150,9 +170,9 @@ Once merged, the PR is squash-merged into the monorepo trunk, **`green`**. You m
 **immediately after** the squash commit — NOT the squash commit itself. (Builds tend to fail *on* the
 squash commit; the mechanics aren't important here, just always take the next one.)
 
-1. Get the squash-merge commit from the PR:
+1. Get the squash-merge commit from the PR (run from `$FS_HOME` so `gh` targets the monorepo):
    ```bash
-   SQUASH=$(gh pr view <pr-number> -R <monorepo> --json mergeCommit -q .mergeCommit.oid)
+   SQUASH=$(cd "$FS_HOME" && gh pr view <pr-number> --json mergeCommit -q .mergeCommit.oid)
    echo "squash commit: $SQUASH"
    ```
 2. Find the commit immediately after it on `green` (first commit whose parent is the squash commit):
@@ -168,11 +188,11 @@ Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it wit
 
 ## Step 7 — Deploy to staging (conancli)
 
-Deploy `$DEPLOY_HASH` (from Step 6) to staging using the `conan-skill`. Run conancli from any checkout of
-the monorepo under `projects/fullstory` — the branch you're on doesn't matter, conancli just talks to
-Conan with the hash. First make sure the hash is fetched locally so Conan/git can resolve it:
+Deploy `$DEPLOY_HASH` (from Step 6) to staging using the `conan-skill`. Run conancli from `$FS_HOME` — the
+branch you're on doesn't matter, conancli just talks to Conan with the hash. First fetch so the hash
+resolves locally:
 ```bash
-( cd "$WT" && git fetch origin -q && go run ./tools/conancli/ -env=fs-staging create \
+( cd "$FS_HOME" && git fetch origin -q && go run ./tools/conancli/ -env=fs-staging create \
     -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
 ```
 This deploys both na1 and eu1 realms. Surface the returned Conan deployment URL. The action is `manual`,
@@ -181,16 +201,15 @@ so it may await approval — show the URL and wait until the deploy reports comp
 
 ## Step 8 — Browser tests against staging
 
-Run the tests from the **worktree's synced copy**, NOT `$FS_HOME/opensource/...`. This matters: the
-`$FS_HOME` checkout is often on some other branch and does **not** contain the sync PR's changes (those
-landed on `green` in Step 6), so its `test/*.spec.ts` can be stale — if the release changed the test suite,
-you'd run the wrong tests. The worktree's `opensource/fullstory-data-layer-observer` holds exactly the
-content synced from the release tag in Step 5, which is what's deployed.
+Run the tests from `$TARGET` (`$FS_HOME/opensource/fullstory-data-layer-observer`). Because Step 5 left
+the `$FS_HOME` checkout **on the sync branch**, this copy holds exactly the content synced from the
+release tag — including any new/changed `test/*.spec.ts` — so the tests match what's deployed. (Do NOT
+switch `$FS_HOME` back to another branch before testing, or the test suite would go stale.)
 ```bash
-TEST_DIR="$WT/opensource/fullstory-data-layer-observer"   # $WT from Step 5
+TEST_DIR="$TARGET"   # = $FS_HOME/opensource/fullstory-data-layer-observer, on the sync branch
 ```
 
-1. Install deps and browser binaries (the worktree copy has no `node_modules`):
+1. Install deps and browser binaries (this folder has no `node_modules`):
    ```bash
    ( cd "$TEST_DIR" && npm install && npm run test:browser:bootstrap )
    ```
@@ -211,7 +230,7 @@ If tests fail (for real, not the drift issue), stop and report to the user befor
 
 Once staging tests pass, deploy the **same `$DEPLOY_HASH`** (Step 6) to production:
 ```bash
-( cd "$WT" && go run ./tools/conancli/ -env=fullstoryapp create \
+( cd "$FS_HOME" && go run ./tools/conancli/ -env=fullstoryapp create \
     -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
 ```
 Surface the returned Conan **approval URL** to the user. STOP. Do **not** approve on their behalf. Wait
@@ -219,8 +238,8 @@ until the user confirms the deploy is live in production before continuing.
 
 ## Step 10 — Browser tests against production
 
-Repeat Step 8's tests from the **same `$TEST_DIR`** (the worktree copy), but drop `staging.` from the
-hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`, `edge.eu1.staging.fullstory.com` →
+Repeat Step 8's tests from the **same `$TEST_DIR`** (still on the sync branch), but drop `staging.` from
+the hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`, `edge.eu1.staging.fullstory.com` →
 `edge.eu1.fullstory.com`). Keep the same major:
 ```bash
 ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/v4/latest.js npm run test:browser )
@@ -241,5 +260,6 @@ https://fullstory.grafana.net/d/-nktqXEnz/data-layer-observer-dlo?orgId=1&from=n
 - The three human gates are **hard stops**: Step 3.1.2 (bump PR merge, only if reached), Step 6 (sync PR
   merge), and Step 9 (prod approval). Never proceed past them without explicit user confirmation.
 - Report test output faithfully — if something fails, show it and stop rather than continuing to prod.
-- Clean up the worktree when done (optional, after the user confirms success):
-  `git -C "$MN_ROOT" worktree remove "$HOME/src/worktrees/v<latest-version>"`.
+- The `$FS_HOME` checkout is left on the sync branch through the tests (Steps 8/10). Once the user
+  confirms the release is done, offer to restore their original branch:
+  `git -C "$MN_ROOT" checkout "$ORIG_MN_BRANCH"` (from Step 1). Don't switch back before the tests run.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -20,6 +20,9 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
   directly (no separate worktree; see the resolution note below).
 - **Monorepo**: `$FS_HOME` is `.../mn/projects/fullstory`; its **git root is one level up** —
   `git -C "$FS_HOME" rev-parse --show-toplevel` (e.g. `/Users/<you>/src/mn`), referred to as `$MN_ROOT`.
+  Consequence: any **repo-root-relative git path** (e.g. `git show origin/green:<path>`, `git add <path>`
+  run with `-C "$MN_ROOT"`) must be prefixed with **`projects/fullstory/`** — the `opensource/…` and
+  `etc/cfg/…` trees live under `$FS_HOME`, not at the repo root.
 - **`opensource.go` and `conancli` resolve paths from the `$FS_HOME` env var, NOT the current directory**
   (`fsio.ProjectPath` reads `$FS_HOME`). So `opensource.go sync` always writes into the `$FS_HOME`
   checkout regardless of where you `cd` — a worktree elsewhere would be ignored. That's why this skill
@@ -81,7 +84,7 @@ the `$TARGET` working copy. The `$FS_HOME` checkout is usually parked on some ot
 `opensource/.../package.json` can be stale; reading `origin/green` needs no checkout and is authoritative:
 ```bash
 git -C "$MN_ROOT" fetch origin -q
-TGT_VER=$(git -C "$MN_ROOT" show origin/green:opensource/fullstory-data-layer-observer/package.json \
+TGT_VER=$(git -C "$MN_ROOT" show origin/green:projects/fullstory/opensource/fullstory-data-layer-observer/package.json \
   | node -p "JSON.parse(require('fs').readFileSync(0)).version")
 DLO_VER=$(node -p "require('$DLO_REPO/package.json').version")   # from Step 2
 ```

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -267,20 +267,32 @@ switch `$FS_HOME` back to another branch before testing, or the test suite would
 TEST_DIR="$TARGET"   # = $FS_HOME/opensource/fullstory-data-layer-observer, on the sync branch
 ```
 
-1. Install deps and browser binaries (this folder has no `node_modules`):
+1. **Pin Node 20** (required). This repo fails under the machine's global Node when it's been upgraded
+   (e.g. Homebrew bumped it to v26) — the browser tests won't start. Install node@20 once, then pin it for
+   the test dir with direnv (the DLO source repo's own `.envrc` is the model):
+   ```bash
+   brew install node@20                                                    # once per machine
+   printf 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"\n' > "$TEST_DIR/.envrc"
+   ( cd "$TEST_DIR" && direnv allow && node --version )                     # expect v20.x, not v26
+   ```
+   > Put the `.envrc` in the `fullstory-data-layer-observer` dir, NOT at `$FS_HOME`. If `$TEST_DIR` is the
+   > synced `$TARGET`, note a later `opensource.go sync` overwrites that folder — recreate the `.envrc`
+   > (and re-run `direnv allow`) after syncing.
+2. Install deps and browser binaries. **`webkit` must be installed explicitly** for this repo's setup, in
+   addition to the general bootstrap (which otherwise may not fetch it):
    ```bash
    ( cd "$TEST_DIR" && npm install && npm run test:browser:bootstrap )
+   ( cd "$TEST_DIR" && PLAYWRIGHT_BROWSERS_PATH=0 npx playwright install webkit )
    ```
-2. Run the browser tests against both staging edges (uses `$MAJOR` from Orientation — never a hardcoded `v4`):
+3. Run the browser tests against both staging edges (uses `$MAJOR` from Orientation — never a hardcoded `v4`):
    ```bash
    ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
    ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
    ```
-3. Display both results to the user.
+4. Display both results to the user.
 
-> **Node version drift (Step 8.1):** The two repos run different Node versions and the tests may fail to
-> start. If so, add `--experimental-transform-types` to the `test:browser` npm script you're invoking
-> (edit the script command in the target `package.json`, or invoke node with the flag) and re-run.
+> **If tests still won't start after pinning Node 20:** try adding `--experimental-transform-types` to the
+> `test:browser` npm script (a transform-types drift between Node versions).
 
 If tests fail (for real, not the drift issue), stop and report to the user before any prod deploy.
 

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -259,25 +259,24 @@ This deploys both na1 and eu1 realms; surface the Conan URL and wait for it to c
 
 ## Step 8 — Browser tests against staging
 
-Run the tests from `$TARGET` (`$FS_HOME/opensource/fullstory-data-layer-observer`). Because Step 5 left
-the `$FS_HOME` checkout **on the sync branch**, this copy holds exactly the content synced from the
-release tag — including any new/changed `test/*.spec.ts` — so the tests match what's deployed. (Do NOT
-switch `$FS_HOME` back to another branch before testing, or the test suite would go stale.)
+Run the tests from the **standalone `fullstory-data-layer-observer` repo** (`$DLO_REPO`) — NOT the monorepo
+`$TARGET`. Make sure the checkout is on the released code: Step 1 left it on `main` (which is at
+`v<latest-version>` once the release is out); to be exact, `git -C "$DLO_REPO" checkout v<latest-version>`.
+The browser tests exercise the deployed CDN script, so the checkout just needs the released test suite.
 ```bash
-TEST_DIR="$TARGET"   # = $FS_HOME/opensource/fullstory-data-layer-observer, on the sync branch
+TEST_DIR="$DLO_REPO"   # the standalone fullstory-data-layer-observer repo, at the released version
 ```
 
 1. **Pin Node 20** (required). This repo fails under the machine's global Node when it's been upgraded
-   (e.g. Homebrew bumped it to v26) — the browser tests won't start. Install node@20 once, then pin it for
-   the test dir with direnv (the DLO source repo's own `.envrc` is the model):
+   (e.g. Homebrew bumped it to v26) — the browser tests won't start. Install node@20 once and pin it for
+   the repo with direnv (this `.envrc` lives permanently in the standalone repo):
    ```bash
    brew install node@20                                                    # once per machine
    printf 'export PATH="/opt/homebrew/opt/node@20/bin:$PATH"\n' > "$TEST_DIR/.envrc"
    ( cd "$TEST_DIR" && direnv allow && node --version )                     # expect v20.x, not v26
    ```
-   > Put the `.envrc` in the `fullstory-data-layer-observer` dir, NOT at `$FS_HOME`. If `$TEST_DIR` is the
-   > synced `$TARGET`, note a later `opensource.go sync` overwrites that folder — recreate the `.envrc`
-   > (and re-run `direnv allow`) after syncing.
+   > In a non-interactive shell direnv won't auto-load; prefix test commands with
+   > `direnv exec "$TEST_DIR" …` (or `export PATH="/opt/homebrew/opt/node@20/bin:$PATH"`) so they use node 20.
 2. Install deps and browser binaries. **`webkit` must be installed explicitly** for this repo's setup, in
    addition to the general bootstrap (which otherwise may not fetch it):
    ```bash
@@ -309,9 +308,9 @@ until the user confirms the deploy is live in production before continuing.
 
 ## Step 10 — Browser tests against production
 
-Repeat Step 8's tests from the **same `$TEST_DIR`** (still on the sync branch), but drop `staging.` from
-the hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`, `edge.eu1.staging.fullstory.com` →
-`edge.eu1.fullstory.com`). Keep the same major:
+Repeat Step 8's tests from the **same `$TEST_DIR`** (the standalone repo; node 20 + browsers already set
+up), but drop `staging.` from the hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`,
+`edge.eu1.staging.fullstory.com` → `edge.eu1.fullstory.com`). Keep the same major:
 ```bash
 ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )
 ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/${MAJOR}/latest.js npm run test:browser )

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: release-dlo
+description: Release and deploy the FullStory Data Layer Observer (DLO). Runs the full pipeline from this repo — version/changelog check, GitHub release, monorepo sync PR, conan deploy to staging, browser tests, prod deploy, and post-deploy monitoring. Has several mandatory human gates (PR merge, prod approval). Invoke from the DLO repo (fullstory-data-layer-observer).
+user-invocable: true
+---
+
+# Release DLO
+
+Deploy FullStory Data Layer Observer end-to-end. This skill drives a multi-step pipeline that
+alternates between automated work and **human gates** — points where you MUST stop and wait for the
+user before continuing. Never skip a gate. Never approve a prod deploy on the user's behalf.
+
+## Orientation / key facts
+
+- **DLO repo** (the "latest" source): this repository — `fullstory-data-layer-observer`. Detect its
+  root with `git rev-parse --show-toplevel` from the current folder. Version lives in `package.json`.
+- **GitHub repo**: `fullstorydev/fullstory-data-layer-observer`. Release tags are `v<version>` (e.g. `v4.1.7`).
+- **Target folder** (inside the monorepo): `$FS_HOME/opensource/fullstory-data-layer-observer`.
+- **Monorepo**: `$FS_HOME` is `.../mn/projects/fullstory`, but the **git root is one level up** —
+  `git -C "$FS_HOME" rev-parse --show-toplevel` (e.g. `/Users/<you>/src/mn`). Worktrees are worktrees
+  of that root, so a worktree at `~/src/worktrees/<x>` contains `projects/fullstory/` inside it.
+- **conan cog name** for DLO: `fullstory-data-layer-observer`.
+- **conancli** (see the `conan-skill`): run from `projects/fullstory`:
+  `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs=fullstory-data-layer-observer`
+  - staging env = `fs-staging`, production env = `fullstoryapp`. One `create` deploys **both** na1 and eu1 realms.
+- **sync tool**: `tools/opensource.go sync fullstory-data-layer-observer v<version>` (a self-executing
+  Go script, run from `projects/fullstory`). It downloads the **GitHub release tag** into the monorepo,
+  so the GitHub release/tag MUST exist before you sync.
+
+Throughout, call the resolved version **`latest-version`** (bare semver, no `v`). Derive the **major**
+as `v<N>` from it (e.g. `4.1.8` → `v4`); the test URLs and CDN paths use this major.
+
+Set up shell vars once, at the start:
+```bash
+DLO_REPO="$(git rev-parse --show-toplevel)"        # run from the DLO repo
+GH_REPO="fullstorydev/fullstory-data-layer-observer"
+TARGET="$FS_HOME/opensource/fullstory-data-layer-observer"
+MN_ROOT="$(git -C "$FS_HOME" rev-parse --show-toplevel)"
+```
+
+---
+
+## Step 1 — Sync main
+
+From the DLO repo, switch to `main` if not already there, then `git pull` to get up to date.
+If the working tree is dirty, stop and ask the user how to proceed.
+
+## Step 2 — Read the current version
+
+Read `version` from the DLO repo `package.json`.
+
+## Step 3 — Compare against the target folder
+
+Read `version` from `$TARGET/package.json` and compare (semver) to the DLO version.
+
+- **DLO version is OLDER than target** → this is an error state. Report it and **exit**.
+- **DLO version is NEWER than target** (e.g. `4.1.8` vs `4.1.7`) → `latest-version` = the DLO version.
+  Skip to Step 4. (Normal case: whoever made changes already bumped the version + changelog.)
+- **Versions are EQUAL** → compare the **contents** of the two folders to detect unpushed code changes.
+  Compare source that actually ships — at minimum `src/`, plus `package.json`, `README.md`,
+  `rollup.config.js`, `tsconfig.json`. Ignore build output, `node_modules`, `.git`, lockfiles noise,
+  and files the monorepo sync doesn't take. A reasonable check:
+  ```bash
+  diff -rq --exclude=node_modules --exclude=.git --exclude=dist --exclude=build \
+    "$DLO_REPO/src" "$TARGET/src"
+  ```
+  - **Identical** → nothing to release. Report "target is already up to date with DLO main; nothing to
+    do" and **exit**.
+  - **Different** → someone landed code without bumping the version. Do a **patch** version bump (semver):
+    1. Compute `latest-version` = current version with patch incremented
+       (e.g. `4.1.7` → `4.1.8`).
+    2. `git diff v<previous-version>..HEAD` (previous = the current package.json version's tag) to
+       understand what changed.
+    3. Write a new `### <latest-version>` entry at the top of the History section in `CHANGELOG.md`
+       summarizing the changes (match the existing terse, bullet style). Save this summary text — you'll
+       reuse it as the GitHub release notes in Step 4.
+    4. Update the `version` field in `package.json` to `latest-version`.
+    5. Update the version reference in `README.md` (the `Deployment` section links a versioned URL like
+       `https://edge.fullstory.com/datalayer/v4/v<version>.js` — update it to `latest-version`).
+    6. **⛔ HUMAN GATE**: Show the user the diff of these three files and the proposed changelog entry.
+       These changes must land on DLO `main` (with a `v<latest-version>` tag) before the release. `main`
+       is PR-protected (recent history is all squashed PRs), so open a PR for the bump, and **wait** for
+       the user to merge it. After merge, `git pull` main so HEAD includes the bump, then continue.
+       (If the user confirms direct pushes to main are allowed, you may commit + push directly instead.)
+
+## Step 4 — Ensure a GitHub release exists
+
+Check for an existing release for `latest-version`:
+```bash
+gh release view "v<latest-version>" -R "$GH_REPO"
+```
+- If it exists, continue.
+- If not, create it, targeting the `main` commit that carries this version:
+  ```bash
+  gh release create "v<latest-version>" -R "$GH_REPO" --target main \
+    --title "v<latest-version>" --notes "<notes>"
+  ```
+  - `<notes>`: if you authored the changelog entry in Step 3.1.2, use that summary. Otherwise use the
+    `### <latest-version>` section already in `CHANGELOG.md`.
+  - Creating the release also creates the `v<latest-version>` tag, which the sync tool downloads.
+
+## Step 5 — Create the monorepo sync branch + PR
+
+The sync pulls the just-released tag into the monorepo and updates the conan action config.
+
+1. Create a worktree of the monorepo from `origin/green`, named by version, branched as
+   `<whoami>/sync-dlo-v<latest-version>`:
+   ```bash
+   git -C "$MN_ROOT" fetch origin
+   git -C "$MN_ROOT" worktree add "$HOME/src/worktrees/v<latest-version>" \
+     -b "$(whoami)/sync-dlo-v<latest-version>" origin/green
+   ```
+2. Run the sync from `projects/fullstory` inside the new worktree:
+   ```bash
+   WT="$HOME/src/worktrees/v<latest-version>/projects/fullstory"
+   ( cd "$WT" && tools/opensource.go sync fullstory-data-layer-observer v<latest-version> )
+   ```
+   This updates `opensource/repos.yaml`, re-downloads source into `opensource/fullstory-data-layer-observer`,
+   and updates `etc/cfg/deploy/actions/fullstory-data-layer-observer/action.yaml` (`RELEASE_TAG`).
+3. Commit all changes, push the branch, and open a PR against the monorepo's default branch:
+   ```bash
+   ( cd "$WT" && git add -A && git commit -m "sync fullstory-data-layer-observer to v<latest-version>" )
+   git -C "$WT" push -u origin "$(whoami)/sync-dlo-v<latest-version>"
+   ( cd "$WT" && gh pr create --fill )
+   ```
+4. Show the user the PR link and prompt them to get it reviewed and merged.
+
+## Step 6 — ⛔ HUMAN GATE: wait for the sync PR to merge, then find the squash commit
+
+STOP. Ask the user to confirm once the PR from Step 5 is merged. Do not proceed until they confirm.
+
+Once merged, the PR is squash-merged into the monorepo's main branch. Find that squash commit, then take
+the commit **immediately after** it on main — use that commit hash for all deploys going forward
+(Steps 7 and 9). Determine it via the PR:
+```bash
+gh pr view <pr-number> -R <monorepo> --json mergeCommit,state
+```
+Confirm the resolved deploy hash with the user before deploying.
+
+## Step 7 — Deploy to staging (conancli)
+
+From `projects/fullstory` (in the worktree, still on the Step-5 branch), deploy the Step-6 commit to
+staging. Uses the `conan-skill`:
+```bash
+( cd "$WT" && go run ./tools/conancli/ -env=fs-staging create \
+    -githash=<step6-commit> -cogs=fullstory-data-layer-observer )
+```
+This deploys both na1 and eu1 realms. Surface the returned Conan deployment URL. The action is `manual`,
+so it may await approval — show the URL and wait until the deploy reports complete before testing.
+(You may pass `-auto-approve` for staging if the user wants it streamlined; never for prod.)
+
+## Step 8 — Browser tests against staging
+
+From the **target folder** `$FS_HOME/opensource/fullstory-data-layer-observer`:
+
+1. Install browser binaries:
+   ```bash
+   ( cd "$TARGET" && npm run test:browser:bootstrap )
+   ```
+2. Run the browser tests against both staging edges. **Replace `v4` with the major of `latest-version`.**
+   ```bash
+   ( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+   ( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+   ```
+3. Display both results to the user.
+
+> **Node version drift (Step 8.1):** The two repos run different Node versions and the tests may fail to
+> start. If so, add `--experimental-transform-types` to the `test:browser` npm script you're invoking
+> (edit the script command in the target `package.json`, or invoke node with the flag) and re-run.
+
+If tests fail (for real, not the drift issue), stop and report to the user before any prod deploy.
+
+## Step 9 — ⛔ HUMAN GATE: deploy to production
+
+Once staging tests pass, deploy the **same Step-6 commit** to production:
+```bash
+( cd "$WT" && go run ./tools/conancli/ -env=fullstoryapp create \
+    -githash=<step6-commit> -cogs=fullstory-data-layer-observer )
+```
+Surface the returned Conan **approval URL** to the user. STOP. Do **not** approve on their behalf. Wait
+until the user confirms the deploy is live in production before continuing.
+
+## Step 10 — Browser tests against production
+
+Repeat Step 8's tests, but drop `staging.` from the hosts (`edge.staging.fullstory.com` →
+`edge.fullstory.com`, `edge.eu1.staging.fullstory.com` → `edge.eu1.fullstory.com`). Keep the same major:
+```bash
+( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+```
+Display the results to the user.
+
+## Step 11 — Monitor
+
+Prompt the user to watch the DLO Grafana dashboard:
+https://fullstory.grafana.net/d/-nktqXEnz/data-layer-observer-dlo?orgId=1&from=now-1h&to=now
+
+---
+
+## Notes for the operator (you)
+
+- Use a TaskCreate/TaskUpdate checklist to track the 11 steps; it's a long pipeline with gates.
+- The three human gates are **hard stops**: Step 3.1.2 (bump PR merge, only if reached), Step 6 (sync PR
+  merge), and Step 9 (prod approval). Never proceed past them without explicit user confirmation.
+- Report test output faithfully — if something fails, show it and stop rather than continuing to prod.
+- Clean up the worktree when done (optional, after the user confirms success):
+  `git -C "$MN_ROOT" worktree remove "$HOME/src/worktrees/v<latest-version>"`.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -19,6 +19,11 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
 - **Monorepo**: `$FS_HOME` is `.../mn/projects/fullstory`, but the **git root is one level up** —
   `git -C "$FS_HOME" rev-parse --show-toplevel` (e.g. `/Users/<you>/src/mn`). Worktrees are worktrees
   of that root, so a worktree at `~/src/worktrees/<x>` contains `projects/fullstory/` inside it.
+- **Trunk branches differ per repo — do not conflate them:**
+  - DLO source repo (`fullstory-data-layer-observer`) → trunk is **`main`**. All Step 1–4 branch/tag/pull
+    operations use `main`.
+  - Monorepo (`$MN_ROOT` / `$FS_HOME`) → trunk is **`green`** (NOT `main`). The sync PR branches from,
+    targets, and merges into `origin/green`; the post-merge deploy commit is found on `origin/green`.
 - **conan cog name** for DLO: `fullstory-data-layer-observer`.
 - **conancli** (see the `conan-skill`): run from `projects/fullstory`:
   `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs=fullstory-data-layer-observer`
@@ -56,17 +61,21 @@ Read `version` from `$TARGET/package.json` and compare (semver) to the DLO versi
 - **DLO version is OLDER than target** → this is an error state. Report it and **exit**.
 - **DLO version is NEWER than target** (e.g. `4.1.8` vs `4.1.7`) → `latest-version` = the DLO version.
   Skip to Step 4. (Normal case: whoever made changes already bumped the version + changelog.)
-- **Versions are EQUAL** → compare the **contents** of the two folders to detect unpushed code changes.
-  Compare source that actually ships — at minimum `src/`, plus `package.json`, `README.md`,
-  `rollup.config.js`, `tsconfig.json`. Ignore build output, `node_modules`, `.git`, lockfiles noise,
-  and files the monorepo sync doesn't take. A reasonable check:
+- **Versions are EQUAL** → the target folder was synced from the released tag `v<version>`, so the real
+  question is whether anything shippable has landed on DLO `main` since that release. Ask git directly —
+  this is **authoritative and catches every file** (`src/`, `package.json`, `README.md`,
+  `rollup.config.js`, `tsconfig.json`, tests, anything) rather than diffing a hand-picked list of paths
+  that can silently miss non-`src/` changes:
   ```bash
-  diff -rq --exclude=node_modules --exclude=.git --exclude=dist --exclude=build \
-    "$DLO_REPO/src" "$TARGET/src"
+  git -C "$DLO_REPO" fetch --tags -q
+  git -C "$DLO_REPO" diff --stat "v<version>..HEAD"   # lists changed files; empty output = no changes
   ```
-  - **Identical** → nothing to release. Report "target is already up to date with DLO main; nothing to
-    do" and **exit**.
-  - **Different** → someone landed code without bumping the version. Do a **patch** version bump (semver):
+  > Optional cross-check only: `diff -rq "$DLO_REPO" "$TARGET"`. Treat it as advisory — the target holds
+  > only the subset the monorepo sync ships, so `Only in $DLO_REPO: …` lines are expected noise. Never
+  > gate the release decision on a partial, hand-listed folder diff; use the git-tag diff above.
+  - **No changes** (empty diff) → nothing to release. Report "DLO main is unchanged since `v<version>`;
+    nothing to do" and **exit**.
+  - **Changes present** → code landed without a version bump. Do a **patch** version bump (semver):
     1. Compute `latest-version` = current version with patch incremented
        (e.g. `4.1.7` → `4.1.8`).
     2. `git diff v<previous-version>..HEAD` (previous = the current package.json version's tag) to
@@ -117,11 +126,11 @@ The sync pulls the just-released tag into the monorepo and updates the conan act
    ```
    This updates `opensource/repos.yaml`, re-downloads source into `opensource/fullstory-data-layer-observer`,
    and updates `etc/cfg/deploy/actions/fullstory-data-layer-observer/action.yaml` (`RELEASE_TAG`).
-3. Commit all changes, push the branch, and open a PR against the monorepo's default branch:
+3. Commit all changes, push the branch, and open a PR **against `green`** (the monorepo trunk, not `main`):
    ```bash
    ( cd "$WT" && git add -A && git commit -m "sync fullstory-data-layer-observer to v<latest-version>" )
    git -C "$WT" push -u origin "$(whoami)/sync-dlo-v<latest-version>"
-   ( cd "$WT" && gh pr create --fill )
+   ( cd "$WT" && gh pr create --base green --fill )
    ```
 4. Show the user the PR link and prompt them to get it reviewed and merged.
 
@@ -129,21 +138,34 @@ The sync pulls the just-released tag into the monorepo and updates the conan act
 
 STOP. Ask the user to confirm once the PR from Step 5 is merged. Do not proceed until they confirm.
 
-Once merged, the PR is squash-merged into the monorepo's main branch. Find that squash commit, then take
-the commit **immediately after** it on main — use that commit hash for all deploys going forward
-(Steps 7 and 9). Determine it via the PR:
-```bash
-gh pr view <pr-number> -R <monorepo> --json mergeCommit,state
-```
-Confirm the resolved deploy hash with the user before deploying.
+Once merged, the PR is squash-merged into the monorepo trunk, **`green`**. You must deploy the commit
+**immediately after** the squash commit — NOT the squash commit itself. (Builds tend to fail *on* the
+squash commit; the mechanics aren't important here, just always take the next one.)
+
+1. Get the squash-merge commit from the PR:
+   ```bash
+   SQUASH=$(gh pr view <pr-number> -R <monorepo> --json mergeCommit -q .mergeCommit.oid)
+   echo "squash commit: $SQUASH"
+   ```
+2. Find the commit immediately after it on `green` (first commit whose parent is the squash commit):
+   ```bash
+   git -C "$MN_ROOT" fetch origin -q
+   DEPLOY_HASH=$(git -C "$MN_ROOT" log --reverse --ancestry-path --format=%H "$SQUASH"..origin/green | head -1)
+   echo "deploy hash (commit after squash): $DEPLOY_HASH"
+   ```
+   If that comes back empty, the squash commit is currently the tip of `green` — wait for the next commit
+   to land (or ask the user how to proceed) rather than deploying the squash commit.
+
+Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it with the user before deploying.
 
 ## Step 7 — Deploy to staging (conancli)
 
-From `projects/fullstory` (in the worktree, still on the Step-5 branch), deploy the Step-6 commit to
-staging. Uses the `conan-skill`:
+Deploy `$DEPLOY_HASH` (from Step 6) to staging using the `conan-skill`. Run conancli from any checkout of
+the monorepo under `projects/fullstory` — the branch you're on doesn't matter, conancli just talks to
+Conan with the hash. First make sure the hash is fetched locally so Conan/git can resolve it:
 ```bash
-( cd "$WT" && go run ./tools/conancli/ -env=fs-staging create \
-    -githash=<step6-commit> -cogs=fullstory-data-layer-observer )
+( cd "$WT" && git fetch origin -q && go run ./tools/conancli/ -env=fs-staging create \
+    -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
 ```
 This deploys both na1 and eu1 realms. Surface the returned Conan deployment URL. The action is `manual`,
 so it may await approval — show the URL and wait until the deploy reports complete before testing.
@@ -151,16 +173,23 @@ so it may await approval — show the URL and wait until the deploy reports comp
 
 ## Step 8 — Browser tests against staging
 
-From the **target folder** `$FS_HOME/opensource/fullstory-data-layer-observer`:
+Run the tests from the **worktree's synced copy**, NOT `$FS_HOME/opensource/...`. This matters: the
+`$FS_HOME` checkout is often on some other branch and does **not** contain the sync PR's changes (those
+landed on `green` in Step 6), so its `test/*.spec.ts` can be stale — if the release changed the test suite,
+you'd run the wrong tests. The worktree's `opensource/fullstory-data-layer-observer` holds exactly the
+content synced from the release tag in Step 5, which is what's deployed.
+```bash
+TEST_DIR="$WT/opensource/fullstory-data-layer-observer"   # $WT from Step 5
+```
 
-1. Install browser binaries:
+1. Install deps and browser binaries (the worktree copy has no `node_modules`):
    ```bash
-   ( cd "$TARGET" && npm run test:browser:bootstrap )
+   ( cd "$TEST_DIR" && npm install && npm run test:browser:bootstrap )
    ```
 2. Run the browser tests against both staging edges. **Replace `v4` with the major of `latest-version`.**
    ```bash
-   ( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
-   ( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+   ( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.staging.fullstory.com/datalayer/v4/latest.js npm run test:browser )
    ```
 3. Display both results to the user.
 
@@ -172,21 +201,22 @@ If tests fail (for real, not the drift issue), stop and report to the user befor
 
 ## Step 9 — ⛔ HUMAN GATE: deploy to production
 
-Once staging tests pass, deploy the **same Step-6 commit** to production:
+Once staging tests pass, deploy the **same `$DEPLOY_HASH`** (Step 6) to production:
 ```bash
 ( cd "$WT" && go run ./tools/conancli/ -env=fullstoryapp create \
-    -githash=<step6-commit> -cogs=fullstory-data-layer-observer )
+    -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
 ```
 Surface the returned Conan **approval URL** to the user. STOP. Do **not** approve on their behalf. Wait
 until the user confirms the deploy is live in production before continuing.
 
 ## Step 10 — Browser tests against production
 
-Repeat Step 8's tests, but drop `staging.` from the hosts (`edge.staging.fullstory.com` →
-`edge.fullstory.com`, `edge.eu1.staging.fullstory.com` → `edge.eu1.fullstory.com`). Keep the same major:
+Repeat Step 8's tests from the **same `$TEST_DIR`** (the worktree copy), but drop `staging.` from the
+hosts (`edge.staging.fullstory.com` → `edge.fullstory.com`, `edge.eu1.staging.fullstory.com` →
+`edge.eu1.fullstory.com`). Keep the same major:
 ```bash
-( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/v4/latest.js npm run test:browser )
-( cd "$TARGET" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.fullstory.com/datalayer/v4/latest.js npm run test:browser )
+( cd "$TEST_DIR" && PLAYWRIGHT_DLO_SCRIPT_SRC=https://edge.eu1.fullstory.com/datalayer/v4/latest.js npm run test:browser )
 ```
 Display the results to the user.
 

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -37,10 +37,15 @@ user before continuing. Never skip a gate. Never approve a prod deploy on the us
       `green`** to it. So: base the sync branch on `green`, but target the PR at **`master`**.
     - The squash-merge lands on `master`; once its build passes CI advances `green` past it. The deploy
       commit (commit-after-squash) is taken from `origin/green` — so it's inherently build-passing.
-- **conan cog name** for DLO: `fullstory-data-layer-observer`.
+- **conan cog name** for DLO is the action's **display name**, `deploy 'fullstory-data-layer-observer'`
+  (NOT the directory name `fullstory-data-layer-observer`). Using the directory name fails at deploy time
+  with `Unable to find selected cog … in expanded tarball`. Pass it quoted: `-cog="deploy 'fullstory-data-layer-observer'"`.
 - **conancli** (see the `conan-skill`): run from `projects/fullstory`:
-  `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs=fullstory-data-layer-observer`
+  `go run ./tools/conancli/ -env=<env> create -githash=<hash> -cogs="deploy 'fullstory-data-layer-observer'"`
   - staging env = `fs-staging`, production env = `fullstoryapp`. One `create` deploys **both** na1 and eu1 realms.
+- **Staging auto-deploys** this cog (deploys show creator `autodeploy` in `history`); once `green` has the
+  sync, staging gets it automatically — a manual staging deploy is usually unnecessary (verify instead).
+  **Prod is manual** (human deployers in `history`) — Step 9 is a real `conancli create` + approval.
 - **sync tool**: `tools/opensource.go sync fullstory-data-layer-observer v<version>` (a self-executing
   Go script, run from `projects/fullstory`). It downloads the **GitHub release tag** into the monorepo,
   so the GitHub release/tag MUST exist before you sync.
@@ -233,18 +238,24 @@ guarantees the deploy hash is build-passing.)
 
 Use `$DEPLOY_HASH` for all deploys going forward (Steps 7 and 9). Confirm it with the user before deploying.
 
-## Step 7 — Deploy to staging (conancli)
+## Step 7 — Staging (usually auto-deployed — verify, don't manually deploy)
 
-Deploy `$DEPLOY_HASH` (from Step 6) to staging using the `conan-skill`. Run conancli from `$FS_HOME` — the
-branch you're on doesn't matter, conancli just talks to Conan with the hash. First fetch so the hash
-resolves locally:
+Staging **auto-deploys** this cog, so once `green` has the sync it typically ships to staging on its own.
+**Verify first** rather than deploying manually:
+```bash
+# Recent staging deploys for the cog (look for a SUCCEEDED autodeploy whose hash includes the sync):
+( cd "$FS_HOME" && go run ./tools/conancli/ -env=fs-staging history -cog="deploy 'fullstory-data-layer-observer'" -limit=5 )
+# And confirm the CDN serves the new version on both edges (expect HTTP 200):
+curl -s -o /dev/null -w "na1 %{http_code}\n" "https://edge.staging.fullstory.com/datalayer/${MAJOR}/v<latest-version>.js"
+curl -s -o /dev/null -w "eu1 %{http_code}\n" "https://edge.eu1.staging.fullstory.com/datalayer/${MAJOR}/v<latest-version>.js"
+```
+If staging already serves `v<latest-version>` on both edges, staging is done — go to Step 8. Only if it
+hasn't autodeployed after a reasonable wait, deploy it manually (note the **display-name** cog):
 ```bash
 ( cd "$FS_HOME" && git fetch origin -q && go run ./tools/conancli/ -env=fs-staging create \
-    -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
+    -githash="$DEPLOY_HASH" -cogs="deploy 'fullstory-data-layer-observer'" )
 ```
-This deploys both na1 and eu1 realms. Surface the returned Conan deployment URL. The action is `manual`,
-so it may await approval — show the URL and wait until the deploy reports complete before testing.
-(You may pass `-auto-approve` for staging if the user wants it streamlined; never for prod.)
+This deploys both na1 and eu1 realms; surface the Conan URL and wait for it to complete before testing.
 
 ## Step 8 — Browser tests against staging
 
@@ -275,10 +286,11 @@ If tests fail (for real, not the drift issue), stop and report to the user befor
 
 ## Step 9 — ⛔ HUMAN GATE: deploy to production
 
-Once staging tests pass, deploy the **same `$DEPLOY_HASH`** (Step 6) to production:
+Prod is **manual** (no autodeploy), so this is a real deploy. Once staging tests pass, deploy the **same
+`$DEPLOY_HASH`** (Step 6) to production (note the **display-name** cog):
 ```bash
-( cd "$FS_HOME" && go run ./tools/conancli/ -env=fullstoryapp create \
-    -githash="$DEPLOY_HASH" -cogs=fullstory-data-layer-observer )
+( cd "$FS_HOME" && git fetch origin -q && go run ./tools/conancli/ -env=fullstoryapp create \
+    -githash="$DEPLOY_HASH" -cogs="deploy 'fullstory-data-layer-observer'" )
 ```
 Surface the returned Conan **approval URL** to the user. STOP. Do **not** approve on their behalf. Wait
 until the user confirms the deploy is live in production before continuing.

--- a/.claude/skills/release-dlo/SKILL.md
+++ b/.claude/skills/release-dlo/SKILL.md
@@ -297,14 +297,17 @@ If tests fail (for real, not the drift issue), stop and report to the user befor
 
 ## Step 9 — ⛔ HUMAN GATE: deploy to production
 
-Prod is **manual** (no autodeploy), so this is a real deploy. Once staging tests pass, deploy the **same
-`$DEPLOY_HASH`** (Step 6) to production (note the **display-name** cog):
+Prod is **manual** (no autodeploy), so this is a real deploy. **The human gate is here, BEFORE you run
+`create`** — get the user's explicit go-ahead first, because for this cog `create` starts deploying
+immediately (it goes straight to `DEPLOYMENT_STATE_IN_PROGRESS`; there is no separate approval click to
+withhold). Only once the user says go, deploy the **same `$DEPLOY_HASH`** (Step 6), noting the
+**display-name** cog:
 ```bash
 ( cd "$FS_HOME" && git fetch origin -q && go run ./tools/conancli/ -env=fullstoryapp create \
     -githash="$DEPLOY_HASH" -cogs="deploy 'fullstory-data-layer-observer'" )
 ```
-Surface the returned Conan **approval URL** to the user. STOP. Do **not** approve on their behalf. Wait
-until the user confirms the deploy is live in production before continuing.
+Surface the returned Conan status URL, then poll the deploy to a terminal state (background poll, like
+staging) — do NOT run the prod tests until it reports `SUCCEEDED`. If it `FAILED`, stop and show the error.
 
 ## Step 10 — Browser tests against production
 


### PR DESCRIPTION
Adds a Claude Code skill at `.claude/skills/release-dlo/SKILL.md` that drives the DLO release/deploy pipeline end-to-end, with mandatory **human gates** where it stops for the operator.

### What it does
1. **Preflight** — DLO repo: switch to `main` + pull, require clean tree. Monorepo (`$FS_HOME`): capture the current branch and require a clean tree (warn + ask otherwise), since the sync switches its branch later.
2. **Version check** — read the released version from `origin/green` (not the possibly-stale `$FS_HOME` working copy) and compare with a **numeric** semver comparison (so `4.1.10 > 4.1.9`; no lexicographic/`sort -V`). Newer → release it; older → error; equal → check whether code landed on `main` since the last tag and, if so, do a **patch** bump (CHANGELOG/`package.json`/README) via a PR to DLO `main`.
3. **GitHub release** — create the `v<version>` release/tag if missing (release notes from the CHANGELOG section).
4. **Monorepo sync** — run `opensource.go sync` **in the `$FS_HOME` checkout itself** on a branch based off `origin/green`, then open a PR **into `master`** (you can't PR into `green`; CI advances `green` from `master` on passing builds). PR body states it's a sync and embeds the changelog.
5. **Deploy commit** — after the sync PR merges, **background-poll** `origin/green` until the commit-after-squash appears (build-passing), so the operator isn't forced to keep checking during the (often >1hr) wait.
6. **Deploy + verify** — Conan deploy to staging → Playwright browser tests against the na1/eu1 **staging** edges → Conan deploy to **prod** → tests against the prod edges → Grafana monitoring prompt.

### Key repo-specific rules it encodes
- **No worktree.** `opensource.go`/`conancli` resolve paths from the `$FS_HOME` env var, not cwd, so a separate worktree would be ignored — the skill works directly in the `$FS_HOME` checkout on a `green`-based branch instead.
- **Two roots.** `$FS_HOME` (`.../mn/projects/fullstory`) vs the git root `$MN_ROOT` (`.../mn`); repo-root-relative git paths need the `projects/fullstory/` prefix.
- **Branch model.** DLO repo trunk = `main`; monorepo = branch off `green`, PR into `master`, deploy hash from `green`.
- **Hard human gates:** version-bump PR merge (if reached), sync PR merge, and prod approval — never auto-approve prod.

Initial version — expect to keep iterating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition for agent workflows; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds a new **user-invocable** Claude Code skill at `.claude/skills/release-dlo/SKILL.md` that documents how an agent should run the **FullStory Data Layer Observer** release from this repo through monorepo sync, Conan deploys, and Playwright checks.
> 
> The skill defines an **11-step pipeline** with **mandatory human gates** (version-bump PR merge when needed, monorepo sync PR merge, and explicit prod approval before `conancli create`). It encodes repo-specific rules that are easy to get wrong: read released version from `origin/green` with **numeric semver** (not string compare), branch off `green` but PR into `master`, deploy the **commit-after-squash** on `green` (not the squash commit), use the Conan cog **display name** `deploy 'fullstory-data-layer-observer'`, and run `opensource.go sync` in the **`$FS_HOME` checkout** (paths resolve from `$FS_HOME`, not cwd — no worktree).
> 
> Operational details include background polling for `green` after sync merge, staging **verify-first** (autodeploy) vs manual prod deploy, browser tests from the **standalone DLO repo** against na1/eu1 staging/prod CDN URLs with **`$MAJOR`** derived from version, Node 20 pinning, and a post-deploy Grafana prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b91f33b7d697015557342fff5c71c0baa9b6d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->