### PR TITLE
Bump package-lock.json to 4.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fullstory/data-layer-observer",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fullstory/data-layer-observer",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
Follow-up to #255: the v4.1.8 version bump updated `package.json`, `README.md`, and `CHANGELOG.md` but missed `package-lock.json`, whose `version` fields (top-level and `packages[""]`) still read `4.1.7`. This aligns the lockfile to `4.1.8`.

Version-only change (regenerated via `npm install --package-lock-only`); no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only lockfile edit with no runtime or dependency changes.
> 
> **Overview**
> Updates **`package-lock.json`** so its root and `packages[""]` **`version`** fields read **`4.1.8`**, matching **`package.json`** and the rest of the v4.1.8 release metadata after #255.
> 
> No dependency graph or lockfile content changes beyond the version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c86181eea58e98832bc230add8daec3727e405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->